### PR TITLE
Refactor Agent interface

### DIFF
--- a/sim/common/lightning_capacitor.go
+++ b/sim/common/lightning_capacitor.go
@@ -76,6 +76,8 @@ func (lcc LightningCapacitorCast) GetCooldown() time.Duration {
 
 func (lcc LightningCapacitorCast) GetCastInput(sim *core.Simulation, cast core.DirectCastAction) core.DirectCastInput {
 	return core.DirectCastInput{
+		IgnoreCooldowns: true,
+		IgnoreManaCost: true,
 		CritMultiplier: 1.5,
 	}
 }

--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -24,12 +24,16 @@ type Agent interface {
 	// Returns this Agent to its initial state. Called before each Sim iteration.
 	Reset(newsim *Simulation)
 
-	// Returns the action this Agent would like to take next.
-	ChooseAction(*Simulation) AgentAction
+	// Allows the Agent to take whatever actions it wants to. This is called by
+	// the main event loop. The return value determines when the main event loop
+	// will call this again; it will call Act() at the time specified by the return
+	// value.
+	Act(*Simulation) time.Duration
 
-	// This will be invoked right before the chosen action is actually executed, so the Agent can update its state.
-	// Note that the action may be different from the action chosen by this agent.
-	OnActionAccepted(*Simulation, AgentAction)
+	// This will be called instead of Act() for the very first loop iteration after each
+	// Simulation reset. Like Act(), the return value is the time at which the Agent
+	// would like Act() to be called.
+	Start(*Simulation) time.Duration
 }
 
 type ActionID struct {
@@ -60,8 +64,9 @@ type AgentAction interface {
 	// Amount of mana required to perform the action.
 	GetManaCost() float64
 
-	// Do the action.
-	Act(sim *Simulation)
+	// Do the action. Returns whether the action was successful. An unsuccessful
+	// action indicates that the prerequisites, like resource cost, were not met.
+	Act(sim *Simulation) bool
 }
 
 type AgentFactory func(*Simulation, Character, *proto.PlayerOptions) Agent

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -59,13 +59,9 @@ func (at *AuraTracker) ResetAuras() {
 func (at *AuraTracker) Advance(sim *Simulation, newTime time.Duration) {
 	// Go in reverse order so we can safely delete while looping
 	for i := len(at.ActiveAuraIDs) - 1; i >= 0; i-- {
-		// Need to check again because its possible for multiple auras to be removed
-		// within a single OnExpire call.
-		if i < len(at.ActiveAuraIDs) {
-			id := at.ActiveAuraIDs[i]
-			if at.Auras[id].Expires != 0 && at.Auras[id].Expires <= newTime {
-				at.RemoveAura(sim, id)
-			}
+		id := at.ActiveAuraIDs[i]
+		if at.Auras[id].Expires != 0 && at.Auras[id].Expires <= newTime {
+			at.RemoveAura(sim, id)
 		}
 	}
 }

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -59,9 +59,13 @@ func (at *AuraTracker) ResetAuras() {
 func (at *AuraTracker) Advance(sim *Simulation, newTime time.Duration) {
 	// Go in reverse order so we can safely delete while looping
 	for i := len(at.ActiveAuraIDs) - 1; i >= 0; i-- {
-		id := at.ActiveAuraIDs[i]
-		if at.Auras[id].Expires != 0 && at.Auras[id].Expires <= newTime {
-			at.RemoveAura(sim, id)
+		// Need to check again because its possible for multiple auras to be removed
+		// within a single OnExpire call.
+		if i < len(at.ActiveAuraIDs) {
+			id := at.ActiveAuraIDs[i]
+			if at.Auras[id].Expires != 0 && at.Auras[id].Expires <= newTime {
+				at.RemoveAura(sim, id)
+			}
 		}
 	}
 }
@@ -295,6 +299,18 @@ func NewICD() InternalCD {
 // List of all magic effects and spells and items and stuff that can go on CD or have an aura.
 const (
 	MagicIDUnknown int32 = iota
+
+	// Basic CDs
+	MagicIDGCD
+	MagicIDMainHandSwing
+	MagicIDOffHandSwing
+	MagicIDRangedSwing
+
+	// Used for applying the effects of hardcast / channeled spells at a later time.
+	// By definition there can be only 1 hardcast spell being cast at any moment
+	// so no need to make separate IDs for every spell.
+	MagicIDHardcast
+
 	// Spells, used for tracking CDs
 	MagicIDChainLightning6
 	// MagicIDFlameShock

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -302,11 +302,6 @@ const (
 	MagicIDOffHandSwing
 	MagicIDRangedSwing
 
-	// Used for applying the effects of hardcast / channeled spells at a later time.
-	// By definition there can be only 1 hardcast spell being cast at any moment
-	// so no need to make separate IDs for every spell.
-	MagicIDHardcast
-
 	// Spells, used for tracking CDs
 	MagicIDChainLightning6
 	// MagicIDFlameShock

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -32,7 +32,8 @@ type Character struct {
 
 	// mutatable state
 
-	// Aura used to handle results of hardcast after the cast completes
+	// Used for applying the effects of hardcast / channeled spells at a later time.
+	// By definition there can be only 1 hardcast spell being cast at any moment.
 	HardcastAura Aura
 
 	potionsUsed int32 // Number of potions used

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -110,6 +110,16 @@ func (character *Character) manaRegenPerSecond() float64 {
 	return character.Stats[stats.MP5] / 5.0
 }
 
+// Returns the amount of time this Character would need to wait in order to reach
+// the desired amount of mana, via mana regen.
+//
+// Assumes that desiredMana > currentMana. Calculation assumes the Character
+// will not take any actions during this period that would reset the 5-second rule.
+func (character *Character) TimeUntilManaRegen(desiredMana float64) time.Duration {
+	// +1 at the end is to deal with floating point math rounding errors.
+	return DurationFromSeconds((desiredMana-character.Stats[stats.Mana])/character.manaRegenPerSecond()) + 1
+}
+
 // Advance moves time forward counting down auras, CDs, mana regen, etc
 func (character *Character) Advance(sim *Simulation, elapsedTime time.Duration, newTime time.Duration) {
 	// MP5 regen

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -31,6 +31,10 @@ type Character struct {
 	*AuraTracker
 
 	// mutatable state
+
+	// Aura used to handle results of hardcast after the cast completes
+	HardcastAura Aura
+
 	potionsUsed int32 // Number of potions used
 }
 
@@ -134,6 +138,11 @@ func (character *Character) Advance(sim *Simulation, elapsedTime time.Duration, 
 
 	// Advance CDs and Auras
 	character.AuraTracker.Advance(sim, newTime)
+
+	if character.HardcastAura.Expires != 0 && character.HardcastAura.Expires <= newTime {
+		character.HardcastAura.OnExpire(sim)
+		character.HardcastAura = Aura{}
+	}
 }
 
 // Pops any on-use trinkets / gear

--- a/sim/core/common_actions.go
+++ b/sim/core/common_actions.go
@@ -41,11 +41,12 @@ func (action WaitAction) GetManaCost() float64 {
 	return 0
 }
 
-func (action WaitAction) Act(sim *Simulation) {
+func (action WaitAction) Act(sim *Simulation) bool {
 	if sim.Log != nil {
 		sim.Log("Doing nothing for %0.1f seconds.\n", action.GetDuration())
 	}
-	//sim.metricsAggregator.addAction(action)
+	//sim.MetricsAggregator.AddAction(action)
+	return true
 }
 
 func NewWaitAction(sim *Simulation, agent Agent, duration time.Duration) WaitAction {

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -142,17 +142,17 @@ func (action DirectCastAction) Act(sim *Simulation) bool {
 				character.ID, action.GetName(), character.Stats[stats.Mana], action.castInput.ManaCost, action.castInput.CastTime)
 	}
 
-	// For instead-cast spells we can skip creating an aura.
+	// For instant-cast spells we can skip creating an aura.
 	if action.castInput.CastTime == 0 {
 		action.internalOnCastComplete(sim)
 	} else {
-		character.AddAura(sim, Aura{
+		character.HardcastAura = Aura{
 			ID:      MagicIDHardcast,
 			Expires: sim.CurrentTime + action.castInput.CastTime,
 			OnExpire: func(sim *Simulation) {
 				action.internalOnCastComplete(sim)
 			},
-		})
+		}
 	}
 
 	if !action.castInput.IgnoreCooldowns {

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -147,7 +147,6 @@ func (action DirectCastAction) Act(sim *Simulation) bool {
 		action.internalOnCastComplete(sim)
 	} else {
 		character.HardcastAura = Aura{
-			ID:      MagicIDHardcast,
 			Expires: sim.CurrentTime + action.castInput.CastTime,
 			OnExpire: func(sim *Simulation) {
 				action.internalOnCastComplete(sim)

--- a/sim/core/metrics_aggregator.go
+++ b/sim/core/metrics_aggregator.go
@@ -106,7 +106,7 @@ func NewMetricsAggregator(numAgents int, encounterDuration float64) *MetricsAggr
 }
 
 // Adds the results of an action to the aggregated metrics.
-func (aggregator *MetricsAggregator) addCastAction(cast DirectCastAction, castResults []DirectCastDamageResult) {
+func (aggregator *MetricsAggregator) AddCastAction(cast DirectCastAction, castResults []DirectCastDamageResult) {
 	actionID := cast.GetActionID()
 	tag := cast.GetTag()
 
@@ -115,7 +115,9 @@ func (aggregator *MetricsAggregator) addCastAction(cast DirectCastAction, castRe
 	agentID := cast.GetAgent().GetCharacter().ID
 
 	iterationMetrics := &aggregator.agentIterations[agentID]
-	iterationMetrics.ManaSpent += cast.castInput.ManaCost
+	if !cast.castInput.IgnoreManaCost {
+		iterationMetrics.ManaSpent += cast.castInput.ManaCost
+	}
 
 	aggregateMetrics := &aggregator.agentAggregates[agentID]
 	actionMetrics, ok := aggregateMetrics.Actions[actionKey]
@@ -144,7 +146,7 @@ func (aggregator *MetricsAggregator) addCastAction(cast DirectCastAction, castRe
 	aggregateMetrics.Actions[actionKey] = actionMetrics
 }
 
-func (aggregator *MetricsAggregator) markOOM(agent Agent, oomAtTime time.Duration) {
+func (aggregator *MetricsAggregator) MarkOOM(agent Agent, oomAtTime time.Duration) {
 	agentID := agent.GetCharacter().ID
 
 	if aggregator.agentIterations[agentID].OOMAt == 0 {

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -187,6 +187,17 @@ type pendingAgent struct {
 	NextActionAt time.Duration
 }
 
+func (sim *Simulation) playerConsumes(agent Agent) {
+	// Consumes before any casts
+	TryActivateDrums(sim, agent)
+	TryActivateRacial(sim, agent)
+	TryActivatePotion(sim, agent)
+	TryActivateDarkRune(sim, agent)
+
+	// Pop activatable items if we can.
+	agent.GetCharacter().TryActivateEquipment(sim, agent)
+}
+
 // Run runs the simulation for the configured number of iterations, and
 // collects all the metrics together.
 func (sim *Simulation) Run() SimResult {
@@ -226,6 +237,7 @@ func (sim *Simulation) RunOnce() {
 	// setup initial actions.
 	for _, party := range sim.Raid.Parties {
 		for _, agent := range party.Players {
+			sim.playerConsumes(agent)
 			nextActionAt := agent.Start(sim)
 
 			if nextActionAt == NeverExpires {
@@ -250,6 +262,7 @@ func (sim *Simulation) RunOnce() {
 			sim.Advance(pa.NextActionAt - sim.CurrentTime)
 		}
 
+		sim.playerConsumes(pa.Agent)
 		pa.NextActionAt = pa.Agent.Act(sim)
 
 		if len(pendingAgents) == 1 {

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -244,7 +244,6 @@ func (sim *Simulation) RunOnce() {
 	})
 
 	for sim.CurrentTime < sim.Duration {
-		//fmt.Printf("Sim action\n")
 		pa := pendingAgents[0]
 
 		if pa.NextActionAt > sim.CurrentTime {
@@ -271,7 +270,7 @@ func (sim *Simulation) RunOnce() {
 // Advance moves time forward counting down auras, CDs, mana regen, etc
 func (sim *Simulation) Advance(elapsedTime time.Duration) {
 	newTime := sim.CurrentTime + elapsedTime
-	//fmt.Printf("Cur time: %s\n", newTime)
+	sim.CurrentTime = newTime
 
 	for _, party := range sim.Raid.Parties {
 		for _, agent := range party.Players {
@@ -280,5 +279,4 @@ func (sim *Simulation) Advance(elapsedTime time.Duration) {
 		}
 	}
 	sim.AuraTracker.Advance(sim, elapsedTime)
-	sim.CurrentTime = newTime
 }

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -56,7 +56,7 @@ type Simulation struct {
 	// Auras which are automatically applied on sim reset.
 	InitialAuras []InitialAura
 
-	metricsAggregator *MetricsAggregator
+	MetricsAggregator *MetricsAggregator
 
 	Rando       *wrappedRandom
 	rseed       int64
@@ -134,7 +134,7 @@ func newSim(raid *Raid, options Options, numPlayers int) *Simulation {
 		InitialAuras: []InitialAura{},
 		Log: nil,
 		AuraTracker: NewAuraTracker(),
-		metricsAggregator: NewMetricsAggregator(numPlayers, options.Encounter.Duration),
+		MetricsAggregator: NewMetricsAggregator(numPlayers, options.Encounter.Duration),
 	}
 	sim.Rando = &wrappedRandom{sim: sim, Rand: rand.New(rand.NewSource(options.RSeed))}
 
@@ -143,7 +143,7 @@ func newSim(raid *Raid, options Options, numPlayers int) *Simulation {
 
 // Get the metrics for an invidual Agent, for the current iteration.
 func (sim *Simulation) GetIndividualMetrics(agentID int) AgentIterationMetrics {
-	return sim.metricsAggregator.agentIterations[agentID]
+	return sim.MetricsAggregator.agentIterations[agentID]
 }
 
 func (sim *Simulation) AddInitialAura(initialAura InitialAura) {
@@ -182,21 +182,9 @@ func (sim *Simulation) Reset() {
 	}
 }
 
-type pendingAction struct {
+type pendingAgent struct {
 	Agent Agent
-	AgentAction
-	ExecuteAt time.Duration
-}
-
-func (sim *Simulation) playerConsumes(agent Agent) {
-	// Consumes before any casts
-	TryActivateDrums(sim, agent)
-	TryActivateRacial(sim, agent)
-	TryActivatePotion(sim, agent)
-	TryActivateDarkRune(sim, agent)
-
-	// Pop activatable items if we can.
-	agent.GetCharacter().TryActivateEquipment(sim, agent)
+	NextActionAt time.Duration
 }
 
 // Run runs the simulation for the configured number of iterations, and
@@ -221,10 +209,10 @@ func (sim *Simulation) Run() SimResult {
 
 	for i := 0; i < sim.Options.Iterations; i++ {
 		sim.RunOnce()
-		sim.metricsAggregator.doneIteration()
+		sim.MetricsAggregator.doneIteration()
 	}
 
-	result := sim.metricsAggregator.getResult()
+	result := sim.MetricsAggregator.getResult()
 	result.Logs = logsBuffer.String()
 	return result
 }
@@ -234,86 +222,46 @@ func (sim *Simulation) Run() SimResult {
 func (sim *Simulation) RunOnce() {
 	sim.Reset()
 
-	pendingActions := make([]pendingAction, 0, 25)
+	pendingAgents := make([]pendingAgent, 0, 25)
 	// setup initial actions.
 	for _, party := range sim.Raid.Parties {
 		for _, agent := range party.Players {
-			sim.playerConsumes(agent)
+			nextActionAt := agent.Start(sim)
 
-			action := agent.ChooseAction(sim)
-
-			// sim.CurrentTime is 0, so dont need to add it
-			executeAt := action.GetDuration()
-
-			if executeAt == NeverExpires {
+			if nextActionAt == NeverExpires {
 				continue // This means agent will not perform any actions at all
 			}
 
-			pendingActions = append(pendingActions, pendingAction{
-				ExecuteAt:   executeAt,
-				Agent:       agent,
-				AgentAction: action,
+			pendingAgents = append(pendingAgents, pendingAgent{
+				NextActionAt: nextActionAt,
+				Agent:        agent,
 			})
 		}
 	}
 	// order pending by execution time.
-	sort.Slice(pendingActions, func(i, j int) bool {
-		return pendingActions[i].ExecuteAt < pendingActions[j].ExecuteAt
+	sort.Slice(pendingAgents, func(i, j int) bool {
+		return pendingAgents[i].NextActionAt < pendingAgents[j].NextActionAt
 	})
 
-simloop:
 	for sim.CurrentTime < sim.Duration {
-		action := pendingActions[0]
-		agent := action.Agent
-		agent.OnActionAccepted(sim, action.AgentAction)
-		if action.ExecuteAt > sim.CurrentTime {
-			sim.Advance(action.ExecuteAt - sim.CurrentTime)
+		//fmt.Printf("Sim action\n")
+		pa := pendingAgents[0]
+
+		if pa.NextActionAt > sim.CurrentTime {
+			sim.Advance(pa.NextActionAt - sim.CurrentTime)
 		}
 
-		action.Act(sim)
+		pa.NextActionAt = pa.Agent.Act(sim)
 
-		sim.playerConsumes(agent)
-		newAction := agent.ChooseAction(sim)
-		actionDuration := newAction.GetDuration()
-
-		castAction, isCastAction := newAction.(DirectCastAction)
-		if isCastAction {
-			// TODO: This delays the cast damage until GCD is ready, even if the cast time is less than GCD.
-			// How to handle this?
-			actionDuration = MaxDuration(actionDuration, GCDMin)
-
-			manaCost := castAction.GetManaCost()
-			if agent.GetCharacter().Stats[stats.Mana] < manaCost {
-				// Not enough mana, wait until there is enough mana to cast the desired spell
-				// TODO: Doesn't account for spirit-based mana
-				regenTime := DurationFromSeconds((manaCost-agent.GetCharacter().Stats[stats.Mana])/agent.GetCharacter().manaRegenPerSecond()) + 1
-				if sim.Log != nil {
-					sim.Log("Not enough mana to cast... regen for %0.1f seconds before casting.\n", regenTime.Seconds())
-				}
-				actionDuration = regenTime
-				if sim.Options.ExitOnOOM {
-					break simloop // named for clarity since this is pretty deep nested.
-				}
-
-				// Cancel cast for now.
-				newAction = NewWaitAction(sim, agent, actionDuration)
-				sim.metricsAggregator.markOOM(agent, sim.CurrentTime)
-			}
-		}
-		pa := pendingAction{
-			ExecuteAt:   sim.CurrentTime + actionDuration,
-			Agent:       agent,
-			AgentAction: newAction,
-		}
-		if len(pendingActions) == 1 {
+		if len(pendingAgents) == 1 {
 			// We know in a single user sim, just always make the next pending action ours.
-			pendingActions[0] = pa
+			pendingAgents[0] = pa
 		} else {
 			// Insert into the list the correct execution time.
-			for i, v := range pendingActions {
-				if v.ExecuteAt >= pa.ExecuteAt {
-					copy(pendingActions, pendingActions[:i])
-					pendingActions[i] = pa
+			for i, v := range pendingAgents {
+				if v.NextActionAt >= pa.NextActionAt {
+					copy(pendingAgents, pendingAgents[:i])
+					pendingAgents[i] = pa
 				}
 			}
 		}
@@ -323,6 +271,7 @@ simloop:
 // Advance moves time forward counting down auras, CDs, mana regen, etc
 func (sim *Simulation) Advance(elapsedTime time.Duration) {
 	newTime := sim.CurrentTime + elapsedTime
+	//fmt.Printf("Cur time: %s\n", newTime)
 
 	for _, party := range sim.Raid.Parties {
 		for _, agent := range party.Players {

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -1,6 +1,8 @@
 package druid
 
 import (
+	"time"
+
 	"github.com/wowsims/tbc/sim/core/proto"
 	"github.com/wowsims/tbc/sim/core"
 )
@@ -25,10 +27,11 @@ func (druid *Druid) AddPartyBuffs(buffs *proto.Buffs) {
 func (druid *Druid) BuffUp(sim *core.Simulation) {
 }
 
-func (druid *Druid) ChooseAction(sim *core.Simulation) core.AgentAction {
-	return core.NewWaitAction(sim, druid, core.NeverExpires) // makes the bot wait forever and do nothing.
+func (druid *Druid) Act(sim *core.Simulation) time.Duration {
+	return core.NeverExpires // makes the bot wait forever and do nothing.
 }
-func (druid *Druid) OnActionAccepted(sim *core.Simulation, action core.AgentAction) {
+func (druid *Druid) Start(sim *core.Simulation) time.Duration {
+	return druid.Act(sim)
 }
 func (druid *Druid) Reset(newsim *core.Simulation) {
 }

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -1,6 +1,8 @@
 package mage
 
 import (
+	"time"
+
 	"github.com/wowsims/tbc/sim/core"
 	"github.com/wowsims/tbc/sim/core/proto"
 )
@@ -22,10 +24,11 @@ func (mage *Mage) AddPartyBuffs(buffs *proto.Buffs) {
 func (mage *Mage) BuffUp(sim *core.Simulation) {
 }
 
-func (mage *Mage) ChooseAction(sim *core.Simulation) core.AgentAction {
-	return core.NewWaitAction(sim, mage, core.NeverExpires) // makes the bot wait forever and do nothing.
+func (mage *Mage) Act(sim *core.Simulation) time.Duration {
+	return core.NeverExpires // makes the bot wait forever and do nothing.
 }
-func (mage *Mage) OnActionAccepted(sim *core.Simulation, action core.AgentAction) {
+func (mage *Mage) Start(sim *core.Simulation) time.Duration {
+	return mage.Act(sim)
 }
 func (mage *Mage) Reset(newsim *core.Simulation) {
 }

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -1,6 +1,8 @@
 package paladin
 
 import (
+	"time"
+
 	"github.com/wowsims/tbc/sim/core/proto"
 	"github.com/wowsims/tbc/sim/core"
 )
@@ -22,11 +24,12 @@ func (paladin *Paladin) AddRaidBuffs(buffs *proto.Buffs) {
 func (paladin *Paladin) AddPartyBuffs(buffs *proto.Buffs) {
 }
 
-func (paladin *Paladin) ChooseAction(sim *core.Simulation) core.AgentAction {
-	return core.NewWaitAction(sim, paladin, core.NeverExpires) // makes the bot wait forever and do nothing.
+func (paladin *Paladin) Act(sim *core.Simulation) time.Duration {
+	return core.NeverExpires // makes the bot wait forever and do nothing.
 }
 
-func (paladin *Paladin) OnActionAccepted(*core.Simulation, core.AgentAction) {
+func (paladin *Paladin) Start(sim *core.Simulation) time.Duration {
+	return paladin.Act(sim)
 }
 
 func (paladin *Paladin) BuffUp(sim *core.Simulation) {

--- a/sim/priest/priest.go
+++ b/sim/priest/priest.go
@@ -1,6 +1,8 @@
 package priest
 
 import (
+	"time"
+
 	"github.com/wowsims/tbc/sim/core/proto"
 	"github.com/wowsims/tbc/sim/core"
 )
@@ -18,15 +20,14 @@ func (priest *Priest) AddRaidBuffs(buffs *proto.Buffs) {
 	buffs.DivineSpirit = proto.TristateEffect_TristateEffectRegular
 }
 func (priest *Priest) AddPartyBuffs(buffs *proto.Buffs) {
-	buffs.ShadowPriestDps += 0
 }
 
-func (priest *Priest) ChooseAction(sim *core.Simulation) core.AgentAction {
-	return core.NewWaitAction(sim, priest, core.NeverExpires) // makes the bot wait forever and do nothing.
+func (priest *Priest) Act(sim *core.Simulation) time.Duration {
+	return core.NeverExpires // makes the bot wait forever and do nothing.
 }
 
-func (priest *Priest) OnActionAccepted(*core.Simulation, core.AgentAction) {
-
+func (priest *Priest) Start(sim *core.Simulation) time.Duration {
+		return priest.Act(sim)
 }
 
 func (priest *Priest) BuffUp(sim *core.Simulation) {

--- a/sim/shaman/electric_spell.go
+++ b/sim/shaman/electric_spell.go
@@ -75,8 +75,10 @@ func (spell ElectricSpell) GetCastInput(sim *core.Simulation, cast core.DirectCa
 	}
 
 	if spell.IsLightningOverload {
-		input.ManaCost = 0
 		input.CastTime = 0
+		input.ManaCost = 0
+		input.IgnoreCooldowns = true
+		input.IgnoreManaCost = true
 	} else if spell.Shaman.Talents.LightningMastery > 0 {
 		// Convection applies against the base cost of the spell.
 		input.ManaCost -= spell.GetBaseManaCost() * spell.Shaman.convectionBonus
@@ -117,7 +119,7 @@ func (spell ElectricSpell) ApplyHitInputModifiers(hitInput *core.DirectCastDamag
 }
 
 func (spell ElectricSpell) OnCastComplete(sim *core.Simulation, cast core.DirectCastAction) {
-	if !spell.IsLightningOverload && spell.Shaman.ElementalFocusStacks > 0 {
+	if spell.Shaman.Talents.ElementalFocus && !spell.IsLightningOverload && spell.Shaman.ElementalFocusStacks > 0 {
 		spell.Shaman.ElementalFocusStacks--
 	}
 }

--- a/sim/shaman/electric_spell.go
+++ b/sim/shaman/electric_spell.go
@@ -119,12 +119,12 @@ func (spell ElectricSpell) ApplyHitInputModifiers(hitInput *core.DirectCastDamag
 }
 
 func (spell ElectricSpell) OnCastComplete(sim *core.Simulation, cast core.DirectCastAction) {
-	if spell.Shaman.Talents.ElementalFocus && !spell.IsLightningOverload && spell.Shaman.ElementalFocusStacks > 0 {
+	if !spell.IsLightningOverload && spell.Shaman.ElementalFocusStacks > 0 {
 		spell.Shaman.ElementalFocusStacks--
 	}
 }
 func (spell ElectricSpell) OnElectricSpellHit(sim *core.Simulation, cast core.DirectCastAction, result *core.DirectCastDamageResult) {
-	if result.Crit {
+	if spell.Shaman.Talents.ElementalFocus && result.Crit {
 		spell.Shaman.ElementalFocusStacks = 2
 	}
 }

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -127,6 +127,7 @@ func (shaman *Shaman) Act(sim *core.Simulation) time.Duration {
 
 	actionSuccessful := newAction.Act(sim)
 	if actionSuccessful {
+		shaman.rotation.OnActionAccepted(shaman, sim, newAction)
 		return sim.CurrentTime + core.MaxDuration(
 				shaman.GetRemainingCD(core.MagicIDGCD, sim.CurrentTime),
 				newAction.GetDuration())
@@ -136,6 +137,7 @@ func (shaman *Shaman) Act(sim *core.Simulation) time.Duration {
 		// TODO: This logic should be in ele shaman code, because enhance react differently to going oom.
 		regenTime := shaman.TimeUntilManaRegen(newAction.GetManaCost())
 		newAction = core.NewWaitAction(sim, shaman, regenTime)
+		shaman.rotation.OnActionAccepted(shaman, sim, newAction)
 		return sim.CurrentTime + regenTime
 	}
 }

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -108,15 +108,6 @@ func (shaman *Shaman) OnActionAccepted(sim *core.Simulation, action core.AgentAc
 }
 
 func (shaman *Shaman) Act(sim *core.Simulation) time.Duration {
-	// Consumes before any casts
-	core.TryActivateDrums(sim, shaman)
-	core.TryActivateRacial(sim, shaman)
-	core.TryActivatePotion(sim, shaman)
-	core.TryActivateDarkRune(sim, shaman)
-
-	// Pop activatable items if we can.
-	shaman.TryActivateEquipment(sim, shaman)
-
 	// Before casting, activate shaman powers!
 	TryActivateBloodlust(sim, shaman)
 	if shaman.Talents.ElementalMastery {

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -106,6 +106,44 @@ func (shaman *Shaman) ChooseAction(sim *core.Simulation) core.AgentAction {
 func (shaman *Shaman) OnActionAccepted(sim *core.Simulation, action core.AgentAction) {
 	shaman.rotation.OnActionAccepted(shaman, sim, action)
 }
+
+func (shaman *Shaman) Act(sim *core.Simulation) time.Duration {
+	// Consumes before any casts
+	core.TryActivateDrums(sim, shaman)
+	core.TryActivateRacial(sim, shaman)
+	core.TryActivatePotion(sim, shaman)
+	core.TryActivateDarkRune(sim, shaman)
+
+	// Pop activatable items if we can.
+	shaman.TryActivateEquipment(sim, shaman)
+
+	// Before casting, activate shaman powers!
+	TryActivateBloodlust(sim, shaman)
+	if shaman.Talents.ElementalMastery {
+		TryActivateEleMastery(sim, shaman)
+	}
+
+	newAction := shaman.rotation.ChooseAction(shaman, sim)
+
+	actionSuccessful := newAction.Act(sim)
+	if actionSuccessful {
+		return sim.CurrentTime + core.MaxDuration(
+				shaman.GetRemainingCD(core.MagicIDGCD, sim.CurrentTime),
+				newAction.GetDuration())
+	} else {
+		// Only way for a shaman spell to fail is due to mana cost.
+		// Wait until we have enough mana to cast.
+		// TODO: This logic should be in ele shaman code, because enhance react differently to going oom.
+		regenTime := shaman.TimeUntilManaRegen(newAction.GetManaCost())
+		newAction = core.NewWaitAction(sim, shaman, regenTime)
+		return sim.CurrentTime + regenTime
+	}
+}
+func (shaman *Shaman) Start(sim *core.Simulation) time.Duration {
+	return shaman.Act(sim)
+}
+
+
 func (shaman *Shaman) Reset(newsim *core.Simulation) {
 	shaman.rotation.Reset(shaman, newsim)
 }

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -1,6 +1,11 @@
 package warlock
 
-import "github.com/wowsims/tbc/sim/core"
+import (
+	"time"
+
+	"github.com/wowsims/tbc/sim/core"
+	"github.com/wowsims/tbc/sim/core/proto"
+)
 
 type Warlock struct {
 	core.Character
@@ -12,11 +17,17 @@ func (warlock *Warlock) GetCharacter() *core.Character {
 	return &warlock.Character
 }
 
-func (warlock *Warlock) ChooseAction(sim *core.Simulation) core.AgentAction {
-	return core.NewWaitAction(sim, warlock, core.NeverExpires) // makes the bot wait forever and do nothing.
+func (warlock *Warlock) AddRaidBuffs(buffs *proto.Buffs) {
+}
+func (warlock *Warlock) AddPartyBuffs(buffs *proto.Buffs) {
 }
 
-func (warlock *Warlock) OnActionAccepted(*core.Simulation, core.AgentAction) {
+func (warlock *Warlock) Act(sim *core.Simulation) time.Duration {
+	return core.NeverExpires // makes the bot wait forever and do nothing.
+}
+
+func (warlock *Warlock) Start(sim *core.Simulation) time.Duration {
+	return warlock.Act(sim)
 }
 
 func (warlock *Warlock) BuffUp(sim *core.Simulation) {


### PR DESCRIPTION
Agents now simply return the amount of time until the next action. This opens room for much broader logic in the Agents, including melee attacks / non-GCD actions.