### PR TITLE
Several small refactors

### DIFF
--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -14,18 +14,22 @@ type Agent interface {
 	GetCharacter() *Character
 
 	// Updates the input Buffs to include raid-wide buffs provided by this Agent.
-	AddRaidBuffs(*proto.Buffs)
+	AddRaidBuffs(buffs *proto.Buffs)
 	// Updates the input Buffs to include party-wide buffs provided by this Agent.
-	AddPartyBuffs(*proto.Buffs)
+	AddPartyBuffs(buffs *proto.Buffs)
 
 	// Returns this Agent to its initial state. Called before each Sim iteration.
-	Reset(newsim *Simulation)
+	Reset(sim *Simulation)
 
 	// Allows the Agent to take whatever actions it wants to. This is called by
 	// the main event loop. The return value determines when the main event loop
 	// will call this again; it will call Act() at the time specified by the return
 	// value.
-	Act(*Simulation) time.Duration
+	Act(sim *Simulation) time.Duration
+
+	// Called after sim.CurrentTime is changed. Use this function to calculate
+	// mana/energy regen, cooldown changes, etc.
+	Advance(sim *Simulation, elapsedTime time.Duration)
 }
 
 type ActionID struct {

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -96,7 +96,6 @@ func (sim *Simulation) reset() {
 	// Reset all players
 	for _, party := range sim.Raid.Parties {
 		for _, agent := range party.Players {
-			agent.GetCharacter().Reset(sim)
 			agent.Reset(sim)
 		}
 	}
@@ -186,13 +185,11 @@ func (sim *Simulation) RunOnce() {
 
 // Advance moves time forward counting down auras, CDs, mana regen, etc
 func (sim *Simulation) Advance(elapsedTime time.Duration) {
-	newTime := sim.CurrentTime + elapsedTime
-	sim.CurrentTime = newTime
+	sim.CurrentTime += elapsedTime
 
 	for _, party := range sim.Raid.Parties {
 		for _, agent := range party.Players {
-			// FUTURE: Do agents need to be notified or just advance the player state?
-			agent.GetCharacter().Advance(sim, elapsedTime, newTime)
+			agent.Advance(sim, elapsedTime)
 		}
 	}
 

--- a/sim/shaman/electric_spell.go
+++ b/sim/shaman/electric_spell.go
@@ -23,6 +23,7 @@ const (
 // Shared logic for Lightning Bolt and Chain Lightning
 type ElectricSpell struct {
 	Shaman *Shaman
+	Target *core.Target
 	IsLightningOverload bool
 
 	name         string

--- a/sim/shaman/elemental/elemental.go
+++ b/sim/shaman/elemental/elemental.go
@@ -58,8 +58,9 @@ func (eleShaman *ElementalShaman) GetShaman() *Shaman {
 	return &eleShaman.Shaman
 }
 
-func (eleShaman *ElementalShaman) Reset(newsim *core.Simulation) {
-	eleShaman.rotation.Reset(eleShaman, newsim)
+func (eleShaman *ElementalShaman) Reset(sim *core.Simulation) {
+	eleShaman.Shaman.Reset(sim)
+	eleShaman.rotation.Reset(eleShaman, sim)
 }
 
 func (eleShaman *ElementalShaman) Act(sim *core.Simulation) time.Duration {
@@ -101,7 +102,7 @@ type LBOnlyRotation struct {
 }
 
 func (rotation *LBOnlyRotation) ChooseAction(eleShaman *ElementalShaman, sim *core.Simulation) core.AgentAction {
-	return NewLightningBolt(sim, eleShaman.GetShaman(), false)
+	return NewLightningBolt(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 }
 
 func (rotation *LBOnlyRotation) OnActionAccepted(eleShaman *ElementalShaman, sim *core.Simulation, action core.AgentAction) {
@@ -120,9 +121,9 @@ type CLOnCDRotation struct {
 
 func (rotation *CLOnCDRotation) ChooseAction(eleShaman *ElementalShaman, sim *core.Simulation) core.AgentAction {
 	if eleShaman.IsOnCD(ChainLightningCooldownID, sim.CurrentTime) {
-		return NewLightningBolt(sim, eleShaman.GetShaman(), false)
+		return NewLightningBolt(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 	} else {
-		return NewChainLightning(sim, eleShaman.GetShaman(), false)
+		return NewChainLightning(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 	}
 }
 
@@ -152,17 +153,17 @@ func (rotation *FixedRotation) temporaryHasteActive(eleShaman *ElementalShaman) 
 
 func (rotation *FixedRotation) ChooseAction(eleShaman *ElementalShaman, sim *core.Simulation) core.AgentAction {
 	if rotation.numLBsSinceLastCL < rotation.numLBsPerCL {
-		return NewLightningBolt(sim, eleShaman.GetShaman(), false)
+		return NewLightningBolt(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 	}
 
 	if !eleShaman.IsOnCD(ChainLightningCooldownID, sim.CurrentTime) {
-		return NewChainLightning(sim, eleShaman.GetShaman(), false)
+		return NewChainLightning(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 	}
 
 	// If we have a temporary haste effect (like bloodlust or quags eye) then
 	// we should add LB casts instead of waiting
 	if rotation.temporaryHasteActive(eleShaman) {
-		return NewLightningBolt(sim, eleShaman.GetShaman(), false)
+		return NewLightningBolt(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 	}
 
 	return core.NewWaitAction(sim, eleShaman.GetCharacter(), eleShaman.GetRemainingCD(ChainLightningCooldownID, sim.CurrentTime))
@@ -201,10 +202,10 @@ type CLOnClearcastRotation struct {
 
 func (rotation *CLOnClearcastRotation) ChooseAction(eleShaman *ElementalShaman, sim *core.Simulation) core.AgentAction {
 	if eleShaman.IsOnCD(ChainLightningCooldownID, sim.CurrentTime) || !rotation.prevPrevCastProccedCC {
-		return NewLightningBolt(sim, eleShaman.GetShaman(), false)
+		return NewLightningBolt(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 	}
 
-	return NewChainLightning(sim, eleShaman.GetShaman(), false)
+	return NewChainLightning(sim, eleShaman.GetShaman(), sim.GetPrimaryTarget(), false)
 }
 
 func (rotation *CLOnClearcastRotation) OnActionAccepted(eleShaman *ElementalShaman, sim *core.Simulation, action core.AgentAction) {

--- a/sim/shaman/lightning_bolt.go
+++ b/sim/shaman/lightning_bolt.go
@@ -25,7 +25,7 @@ func (lb LightningBolt) GetCooldown() time.Duration {
 
 func (lb LightningBolt) GetHitInputs(sim *core.Simulation, cast core.DirectCastAction) []core.DirectCastDamageInput{
 	hitInput := core.DirectCastDamageInput{
-		Target: sim.GetPrimaryTarget(),
+		Target: lb.Target,
 		MinBaseDamage: 571,
 		MaxBaseDamage: 652,
 		SpellCoefficient: 0.794,
@@ -43,13 +43,13 @@ func (lb LightningBolt) OnSpellHit(sim *core.Simulation, cast core.DirectCastAct
 	if !lb.IsLightningOverload {
 		lightningOverloadChance := float64(lb.Shaman.Talents.LightningOverload) * 0.04
 		if sim.RandomFloat("LO") < lightningOverloadChance {
-			overloadAction := NewLightningBolt(sim, lb.Shaman, true)
+			overloadAction := NewLightningBolt(sim, lb.Shaman, lb.Target, true)
 			overloadAction.Act(sim)
 		}
 	}
 }
 
-func NewLightningBolt(sim *core.Simulation, shaman *Shaman, IsLightningOverload bool) core.DirectCastAction {
+func NewLightningBolt(sim *core.Simulation, shaman *Shaman, target *core.Target, IsLightningOverload bool) core.DirectCastAction {
 	baseManaCost := 300.0
 	if shaman.Equip[items.ItemSlotRanged].ID == TotemOfThePulsingEarth {
 		baseManaCost -= 27.0
@@ -59,6 +59,7 @@ func NewLightningBolt(sim *core.Simulation, shaman *Shaman, IsLightningOverload 
 		sim,
 		LightningBolt{ElectricSpell{
 			Shaman: shaman,
+			Target: target,
 			IsLightningOverload: IsLightningOverload,
 			name: "Lightning Bolt",
 			baseManaCost: baseManaCost,

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -106,6 +106,15 @@ func (shaman *Shaman) AddPartyBuffs(buffs *proto.Buffs) {
 	}
 }
 
+func (shaman *Shaman) Reset(sim *core.Simulation) {
+	shaman.Character.Reset(sim)
+}
+
+func (shaman *Shaman) Advance(sim *core.Simulation, elapsedTime time.Duration) {
+	shaman.Character.RegenManaMP5Only(sim, elapsedTime)
+	shaman.Character.Advance(sim, elapsedTime)
+}
+
 var ElementalMasteryAuraID = core.NewAuraID()
 var ElementalMasteryCooldownID = core.NewCooldownID()
 func (shaman *Shaman) registerElementalMasteryCD() {


### PR DESCRIPTION
 - Create a separate Aura counter for debuffs since Targets only use debuffs and Characters only use buffs.
 - Add a 'target' field to NewLightningBolt and NewChainLighting instead of automatically populating it in the spell code. Probably won't ever use this but feels more natural since they are targeted spells.
 - Call character.Reset() and character.Advance() from the agent, instead of from the sim. This is a tiny perf improvement and also will make it easy to use different resource regen functions for each Agent.
 - Create separate index arrays for each Aura OnXXX callback. This is a much smaller perf improvement than I was hoping for, but it is an improvement.