### PR TITLE
Fix reuse of template spells and enable multi-target elemental shaman test

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -143,6 +143,10 @@ type auraTracker struct {
 }
 
 func newAuraTracker(useDebuffIDs bool) auraTracker {
+	numAura := numAuraIDs
+	if useDebuffIDs {
+		numAura = numDebuffIDs
+	}
 	return auraTracker{
 		permanentAuras:      []PermanentAura{},
 		activeAuraIDs:       make([]AuraID, 0, 16),
@@ -151,6 +155,8 @@ func newAuraTracker(useDebuffIDs bool) auraTracker {
 		onBeforeSpellHitIDs: make([]AuraID, 0, 16),
 		onSpellHitIDs:       make([]AuraID, 0, 16),
 		onSpellMissIDs:      make([]AuraID, 0, 16),
+		auras:               make([]Aura, numAura),
+		cooldowns:           make([]time.Duration, numCooldownIDs),
 		useDebuffIDs:        useDebuffIDs,
 	}
 }

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -132,7 +132,7 @@ func (cast *Cast) startCasting(sim *Simulation, onCastComplete OnCastComplete) b
 					cast.Character.ID, cast.Name, cast.Character.CurrentMana(), cast.ManaCost)
 			}
 			sim.MetricsAggregator.MarkOOM(cast.Character, sim.CurrentTime)
-
+			cast.objectInUse = false // cast failed and we aren't using it
 			return false
 		}
 	}

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -65,6 +65,10 @@ type Cast struct {
 
 	// Callbacks for providing additional custom behavior.
 	OnCastComplete OnCastComplete
+
+	// Internal field only, used to prevent cast pool objects from being used by
+	// multiple casts simultaneously.
+	objectInUse bool
 }
 
 // AgentAction functions for actions that embed a Cast.
@@ -93,8 +97,13 @@ func (cast *Cast) GetDuration() time.Duration {
 	return cast.CastTime
 }
 
+func (cast *Cast) IsInUse() bool {
+	return cast.objectInUse
+}
+
 // Should be called exactly once after creation.
 func (cast *Cast) init(sim *Simulation) {
+	cast.objectInUse = true
 	cast.CastTime = time.Duration(float64(cast.CastTime) / cast.Character.CastSpeed())
 
 	// Apply on-cast effects.

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -75,6 +75,7 @@ func (spell *SingleTargetDirectDamageSpell) Act(sim *Simulation) bool {
 	return spell.startCasting(sim, func(sim *Simulation, cast *Cast) {
 		spell.Effect.apply(sim, &spell.SpellCast)
 		sim.MetricsAggregator.AddSpellCast(&spell.SpellCast)
+		spell.objectInUse = false
 	})
 }
 

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -212,7 +212,11 @@ func (ddi DotDamageInput) TimeRemaining(sim *Simulation) time.Duration {
 }
 
 func (ddi DotDamageInput) IsTicking(sim *Simulation) bool {
-	return ddi.TimeRemaining(sim) != 0
+	// It is possible that both cast and tick are to happen at the same time.
+	//  In this case the dot "time remaining" will be 0 but there will be ticks left.
+	//  If a DOT misses then it will have NumberTicks set but never have been started.
+	//  So the case of 'has a final tick time but its now, but it has ticks remaining' looks like this.
+	return (ddi.FinalTickTime != 0 && ddi.TickIndex < ddi.NumberTicks)
 }
 
 func (spellEffect *SpellEffect) applyDot(sim *Simulation, spellCast *SpellCast, ddInput *DotDamageInput) {

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -83,6 +83,9 @@ type SingleTargetDirectDamageSpellTemplate struct {
 }
 
 func (template *SingleTargetDirectDamageSpellTemplate) Apply(newAction *SingleTargetDirectDamageSpell) {
+	if newAction.objectInUse {
+		panic("Single target spell already in use")
+	}
 	*newAction = template.template
 }
 
@@ -115,6 +118,7 @@ func (spell *MultiTargetDirectDamageSpell) Act(sim *Simulation) bool {
 		}
 
 		sim.MetricsAggregator.AddSpellCast(&spell.SpellCast)
+		spell.objectInUse = false
 	})
 }
 
@@ -124,6 +128,9 @@ type MultiTargetDirectDamageSpellTemplate struct {
 }
 
 func (template *MultiTargetDirectDamageSpellTemplate) Apply(newAction *MultiTargetDirectDamageSpell) {
+	if newAction.objectInUse {
+		panic("Multi target spell already in use")
+	}
 	*newAction = template.template
 	newAction.Effects = template.effects
 	copy(newAction.Effects, template.template.Effects)
@@ -174,6 +181,7 @@ func (dotEffect *DamageOverTimeSpellEffect) apply(sim *Simulation, spellCast *Sp
 		// Handle a missed cast here.
 		dotEffect.SpellEffect.applyResultsToCast(spellCast)
 		sim.MetricsAggregator.AddSpellCast(spellCast)
+		spellCast.objectInUse = false
 	}
 
 	dotEffect.SpellEffect.afterCalculations(sim, spellCast)
@@ -242,6 +250,7 @@ func (spellEffect *SpellEffect) applyDot(sim *Simulation, spellCast *SpellCast, 
 			// Complete metrics and adding results etc
 			spellEffect.applyResultsToCast(spellCast)
 			sim.MetricsAggregator.AddSpellCast(spellCast)
+			spellCast.objectInUse = false
 
 			// Kills the pending action from the main run loop.
 			pa.NextActionAt = NeverExpires
@@ -256,6 +265,9 @@ type DamageOverTimeSpellTemplate struct {
 }
 
 func (template *DamageOverTimeSpellTemplate) Apply(newAction *DamageOverTimeSpell) {
+	if newAction.objectInUse {
+		panic("Damage over time spell already in use")
+	}
 	*newAction = template.template
 }
 

--- a/sim/core/item_sets.go
+++ b/sim/core/item_sets.go
@@ -64,7 +64,7 @@ type ActiveSetBonus struct {
 }
 
 // Returns a list describing all active set bonuses.
-func (character *Character) getActiveSetBonuses() []ActiveSetBonus {
+func (character *Character) GetActiveSetBonuses() []ActiveSetBonus {
 	activeBonuses := []ActiveSetBonus{}
 	setItemCount := map[string]int32{}
 
@@ -87,7 +87,7 @@ func (character *Character) getActiveSetBonuses() []ActiveSetBonus {
 
 // Apply effects from item set bonuses.
 func (character *Character) applyItemSetBonusEffects(agent Agent) {
-	activeSetBonuses := character.getActiveSetBonuses()
+	activeSetBonuses := character.GetActiveSetBonuses()
 
 	for _, activeSetBonus := range activeSetBonuses {
 		activeSetBonus.BonusEffect(agent)
@@ -96,7 +96,7 @@ func (character *Character) applyItemSetBonusEffects(agent Agent) {
 
 // Returns the names of all active set bonuses.
 func (character *Character) GetActiveSetBonusNames() []string {
-	activeSetBonuses := character.getActiveSetBonuses()
+	activeSetBonuses := character.GetActiveSetBonuses()
 	names := []string{}
 
 	for _, activeSetBonus := range activeSetBonuses {

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -45,7 +45,9 @@ func (moonkin *BalanceDruid) Reset(sim *core.Simulation) {
 
 func (moonkin *BalanceDruid) Act(sim *core.Simulation) time.Duration {
 	// Activate shared druid behaviors
-	moonkin.TryInnervate(sim)
+	if moonkin.TryInnervate(sim) {
+		return sim.CurrentTime + moonkin.GetRemainingCD(core.GCDCooldownID, sim.CurrentTime)
+	}
 
 	target := sim.GetPrimaryTarget()
 	if moonkin.rotationOptions.FaerieFire && !target.HasAura(druid.FaerieFireDebuffID) {

--- a/sim/druid/balance/balance_test.go
+++ b/sim/druid/balance/balance_test.go
@@ -6,52 +6,10 @@ import (
 	_ "github.com/wowsims/tbc/sim/common" // imported to get caster sets included. (we use spellfire here)
 	"github.com/wowsims/tbc/sim/core"
 	"github.com/wowsims/tbc/sim/core/proto"
-	"github.com/wowsims/tbc/sim/druid"
 )
 
 func init() {
 	RegisterBalanceDruid()
-}
-
-func TestMoonfireReset(t *testing.T) {
-	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
-		RaidBuffs:       FullRaidBuffs,
-		PartyBuffs:      FullPartyBuffs,
-		IndividualBuffs: FullIndividualBuffs,
-
-		Consumes: FullConsumes,
-		Target:   FullDebuffTarget,
-		Race:     proto.Race_RaceTauren,
-		Class:    proto.Class_ClassDruid,
-
-		PlayerOptions: PlayerOptionsStarfire,
-		Gear:          P1Gear,
-		SimOptions: &proto.SimOptions{
-			Iterations: 1,
-		},
-	})
-	isr.Encounter.Duration = 300
-	sim := core.NewIndividualSim(*isr)
-	result := sim.Run()
-
-	var mfCasts int32
-	for _, act := range result.Agents[0].Actions {
-		if act.ActionID.SpellID == druid.SpellIDMF {
-			mfCasts = act.Casts
-		}
-	}
-	isr.SimOptions.Iterations = 10
-	sim2 := core.NewIndividualSim(*isr)
-	result2 := sim2.Run()
-
-	for _, act := range result2.Agents[0].Actions {
-		if act.ActionID.SpellID == druid.SpellIDMF {
-			if mfCasts == act.Casts {
-				// TODO: This is really a failure of the framework to cleanup pending dots.
-				t.Fatalf("No new moonfire casts after first sim run. This means moonfire action is still ticking.")
-			}
-		}
-	}
 }
 
 func TestSimulateP1Starfire(t *testing.T) {
@@ -74,7 +32,7 @@ func TestSimulateP1Starfire(t *testing.T) {
 		},
 
 		ExpectedDpsShort: 1184.8,
-		ExpectedDpsLong:  1168.6,
+		ExpectedDpsLong:  1155.4,
 	})
 }
 
@@ -97,7 +55,7 @@ func TestSimulateP1Wrath(t *testing.T) {
 			Gear:          P1Gear,
 		},
 
-		ExpectedDpsShort: 1258.2,
-		ExpectedDpsLong:  1026.3,
+		ExpectedDpsShort: 1160.6,
+		ExpectedDpsLong:  1002.8,
 	})
 }

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -70,7 +70,12 @@ func (druid *Druid) Init(sim *core.Simulation) {
 }
 
 func (druid *Druid) Reset(newsim *core.Simulation) {
-	druid.moonfireCastTemplate.Apply(&druid.MoonfireSpell)
+	// Cleanup and pending dots and casts
+	druid.MoonfireSpell = core.DamageOverTimeSpell{}
+	druid.InsectSwarmSpell = core.DamageOverTimeSpell{}
+	druid.starfireSpell = core.SingleTargetDirectDamageSpell{}
+	druid.wrathSpell = core.SingleTargetDirectDamageSpell{}
+
 	druid.Character.Reset(newsim)
 }
 
@@ -86,7 +91,7 @@ var InnervateCD = core.NewCooldownID()
 //  would need to solve the same issue we had as dots (maybe ID per user)
 var InnervateAuraID = core.NewAuraID()
 
-func (druid *Druid) TryInnervate(sim *core.Simulation) {
+func (druid *Druid) TryInnervate(sim *core.Simulation) bool {
 	// Currently just activates innervate on self when own mana is <75%
 	// TODO: get a real recommendation when to use this.
 	if druid.SelfBuffs.Innervate && druid.GetRemainingCD(InnervateCD, sim.CurrentTime) == 0 {
@@ -110,8 +115,10 @@ func (druid *Druid) TryInnervate(sim *core.Simulation) {
 			druid.SetCD(InnervateCD, cd)
 			// triggers GCD
 			druid.SetCD(core.GCDCooldownID, core.CalculatedGCD(&druid.Character))
+			return true
 		}
 	}
+	return false
 }
 func (druid *Druid) Act(sim *core.Simulation) time.Duration {
 	return core.NeverExpires // does nothing

--- a/sim/shaman/chain_lightning.go
+++ b/sim/shaman/chain_lightning.go
@@ -1,7 +1,6 @@
 package shaman
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/wowsims/tbc/sim/core"
@@ -48,13 +47,20 @@ func (shaman *Shaman) newChainLightningTemplate(sim *core.Simulation, isLightnin
 		}
 	}
 
+	setBonuses := shaman.GetActiveSetBonuses()
+	hasTidefury := false
+	for _, bonus := range setBonuses {
+		if bonus.Name == "Tidefury Raiment" && bonus.NumPieces >= 2 {
+			hasTidefury = true
+			break
+		}
+	}
 	numHits := core.MinInt32(3, sim.GetNumTargets())
 	effects := make([]core.DirectDamageSpellEffect, 0, numHits)
 	effects = append(effects, effect)
 	for i := int32(1); i < numHits; i++ {
 		bounceEffect := effects[i-1] // Makes a copy
-
-		if shaman.HasAura(Tidefury2PcAuraID) {
+		if hasTidefury {
 			bounceEffect.DamageMultiplier *= 0.83
 		} else {
 			bounceEffect.DamageMultiplier *= 0.7
@@ -84,11 +90,9 @@ func (shaman *Shaman) NewChainLightning(sim *core.Simulation, target *core.Targe
 		objIndex := shaman.getFirstAvailableCLLOObjectIndex()
 		cl = &shaman.chainLightningSpellLOs[objIndex]
 		shaman.chainLightningLOCastTemplates[objIndex].Apply(cl)
-		fmt.Printf("Lo: %d\n", objIndex)
 	} else {
 		cl = &shaman.chainLightningSpell
 		shaman.chainLightningCastTemplate.Apply(cl)
-		fmt.Printf("not Lo\n")
 	}
 
 	// Set dynamic fields, i.e. the stuff we couldn't precompute.

--- a/sim/shaman/chain_lightning.go
+++ b/sim/shaman/chain_lightning.go
@@ -47,14 +47,7 @@ func (shaman *Shaman) newChainLightningTemplate(sim *core.Simulation, isLightnin
 		}
 	}
 
-	setBonuses := shaman.GetActiveSetBonuses()
-	hasTidefury := false
-	for _, bonus := range setBonuses {
-		if bonus.Name == "Tidefury Raiment" && bonus.NumPieces >= 2 {
-			hasTidefury = true
-			break
-		}
-	}
+	hasTidefury := ItemSetTidefury.CharacterHasSetBonus(&shaman.Character, 2)
 	numHits := core.MinInt32(3, sim.GetNumTargets())
 	effects := make([]core.DirectDamageSpellEffect, 0, numHits)
 	effects = append(effects, effect)

--- a/sim/shaman/chain_lightning.go
+++ b/sim/shaman/chain_lightning.go
@@ -1,6 +1,7 @@
 package shaman
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/wowsims/tbc/sim/core"
@@ -66,16 +67,28 @@ func (shaman *Shaman) newChainLightningTemplate(sim *core.Simulation, isLightnin
 	return core.NewMultiTargetDirectDamageSpellTemplate(spellTemplate)
 }
 
+func (shaman *Shaman) getFirstAvailableCLLOObjectIndex() int {
+	for i, _ := range shaman.chainLightningSpellLOs {
+		if !shaman.chainLightningSpellLOs[i].IsInUse() {
+			return i
+		}
+	}
+	panic("All chain lightning LO objects in use!")
+}
+
 func (shaman *Shaman) NewChainLightning(sim *core.Simulation, target *core.Target, isLightningOverload bool) *core.MultiTargetDirectDamageSpell {
 	var cl *core.MultiTargetDirectDamageSpell
 
 	// Initialize cast from precomputed template.
 	if isLightningOverload {
-		cl = &shaman.chainLightningSpellLO
-		shaman.chainLightningLOCastTemplate.Apply(cl)
+		objIndex := shaman.getFirstAvailableCLLOObjectIndex()
+		cl = &shaman.chainLightningSpellLOs[objIndex]
+		shaman.chainLightningLOCastTemplates[objIndex].Apply(cl)
+		fmt.Printf("Lo: %d\n", objIndex)
 	} else {
 		cl = &shaman.chainLightningSpell
 		shaman.chainLightningCastTemplate.Apply(cl)
+		fmt.Printf("not Lo\n")
 	}
 
 	// Set dynamic fields, i.e. the stuff we couldn't precompute.

--- a/sim/shaman/elemental/elemental_test.go
+++ b/sim/shaman/elemental/elemental_test.go
@@ -181,7 +181,7 @@ func TestMultiTarget(t *testing.T) {
 			Gear:          P1Gear,
 		},
 
-		ExpectedDpsShort: 2459.5,
+		ExpectedDpsShort: 2497.0,
 		ExpectedDpsLong:  1943.5,
 	})
 

--- a/sim/shaman/elemental/elemental_test.go
+++ b/sim/shaman/elemental/elemental_test.go
@@ -157,27 +157,6 @@ func TestSimulateP1(t *testing.T) {
 		ExpectedDpsLong:  1625.6,
 	})
 }
-
-//func TestMultiTarget(t *testing.T) {
-//	params := core.IndividualParams{
-//		Equip:         P1Gear,
-//		Race:          proto.Race_RaceOrc,
-//   Class:         proto.Class_ClassShaman,
-//		Consumes:      FullConsumes,
-//		Buffs:         FullBuffs,
-//   Options:       FullDebuffOptions,
-//		Options:       makeOptions(core.BasicOptions, LongEncounter),
-//		PlayerOptions: &PlayerOptionsAdaptive,
-//	}
-//	params.Options.Encounter.NumTargets = 3
-//
-//	doSimulateTest(
-//		"multiTarget",
-//		t,
-//		params,
-//		1533.5)
-//}
-
 func TestMultiTarget(t *testing.T) {
 	core.IndividualSimAllEncountersTest(core.AllEncountersTestOptions{
 		Label: "multiTarget",
@@ -193,16 +172,44 @@ func TestMultiTarget(t *testing.T) {
 				FullDebuffTarget,
 				NoDebuffTarget,
 				NoDebuffTarget,
+				NoDebuffTarget,
 			},
-			Race:     proto.Race_RaceOrc,
-			Class:    proto.Class_ClassShaman,
+			Race:  proto.Race_RaceOrc,
+			Class: proto.Class_ClassShaman,
 
 			PlayerOptions: PlayerOptionsAdaptive,
 			Gear:          P1Gear,
 		},
 
-		ExpectedDpsShort: 1880.7,
-		ExpectedDpsLong:  1601.9,
+		ExpectedDpsShort: 2459.5,
+		ExpectedDpsLong:  1943.5,
+	})
+
+	core.IndividualSimAllEncountersTest(core.AllEncountersTestOptions{
+		Label: "multiTarget-tidefury",
+		T:     t,
+
+		Inputs: core.IndividualSimInputs{
+			RaidBuffs:       FullRaidBuffs,
+			PartyBuffs:      FullPartyBuffs,
+			IndividualBuffs: FullIndividualBuffs,
+
+			Consumes: FullConsumes,
+			Targets: []*proto.Target{
+				FullDebuffTarget,
+				NoDebuffTarget,
+				NoDebuffTarget,
+				NoDebuffTarget,
+			},
+			Race:  proto.Race_RaceOrc,
+			Class: proto.Class_ClassShaman,
+
+			PlayerOptions: PlayerOptionsAdaptive,
+			Gear:          P1Tidefury,
+		},
+
+		ExpectedDpsShort: 2504.6,
+		ExpectedDpsLong:  1930.4,
 	})
 }
 

--- a/sim/shaman/elemental/elemental_test.go
+++ b/sim/shaman/elemental/elemental_test.go
@@ -129,8 +129,8 @@ func TestSimulatePreRaid(t *testing.T) {
 			Gear:          PreRaidGear,
 		},
 
-		ExpectedDpsShort: 1297.5,
-		ExpectedDpsLong:  1009.1,
+		ExpectedDpsShort: 1429.1,
+		ExpectedDpsLong:  1169.2,
 	})
 }
 
@@ -153,30 +153,58 @@ func TestSimulateP1(t *testing.T) {
 			Gear:          P1Gear,
 		},
 
-		ExpectedDpsShort: 1928.0,
-		ExpectedDpsLong:  1470.0,
+		ExpectedDpsShort: 1883.1,
+		ExpectedDpsLong:  1625.6,
 	})
 }
 
-// func TestMultiTarget(t *testing.T) {
-// 	params := core.IndividualParams{
-// 		Equip:         P1Gear,
-// 		Race:          proto.Race_RaceOrc,
-//    Class:         proto.Class_ClassShaman,
-// 		Consumes:      FullConsumes,
-// 		Buffs:         FullBuffs,
-//    Options:       FullDebuffOptions,
-// 		Options:       makeOptions(core.BasicOptions, LongEncounter),
-// 		PlayerOptions: &PlayerOptionsAdaptive,
-// 	}
-// 	params.Options.Encounter.NumTargets = 3
+//func TestMultiTarget(t *testing.T) {
+//	params := core.IndividualParams{
+//		Equip:         P1Gear,
+//		Race:          proto.Race_RaceOrc,
+//   Class:         proto.Class_ClassShaman,
+//		Consumes:      FullConsumes,
+//		Buffs:         FullBuffs,
+//   Options:       FullDebuffOptions,
+//		Options:       makeOptions(core.BasicOptions, LongEncounter),
+//		PlayerOptions: &PlayerOptionsAdaptive,
+//	}
+//	params.Options.Encounter.NumTargets = 3
+//
+//	doSimulateTest(
+//		"multiTarget",
+//		t,
+//		params,
+//		1533.5)
+//}
 
-// 	doSimulateTest(
-// 		"multiTarget",
-// 		t,
-// 		params,
-// 		1533.5)
-// }
+func TestMultiTarget(t *testing.T) {
+	core.IndividualSimAllEncountersTest(core.AllEncountersTestOptions{
+		Label: "multiTarget",
+		T:     t,
+
+		Inputs: core.IndividualSimInputs{
+			RaidBuffs:       FullRaidBuffs,
+			PartyBuffs:      FullPartyBuffs,
+			IndividualBuffs: FullIndividualBuffs,
+
+			Consumes: FullConsumes,
+			Targets: []*proto.Target{
+				FullDebuffTarget,
+				NoDebuffTarget,
+				NoDebuffTarget,
+			},
+			Race:     proto.Race_RaceOrc,
+			Class:    proto.Class_ClassShaman,
+
+			PlayerOptions: PlayerOptionsAdaptive,
+			Gear:          P1Gear,
+		},
+
+		ExpectedDpsShort: 1880.7,
+		ExpectedDpsLong:  1601.9,
+	})
+}
 
 func TestLBOnlyAgent(t *testing.T) {
 	core.IndividualSimAllEncountersTest(core.AllEncountersTestOptions{
@@ -197,8 +225,8 @@ func TestLBOnlyAgent(t *testing.T) {
 			Gear:          P1Gear,
 		},
 
-		ExpectedDpsShort: 1761.8,
-		ExpectedDpsLong:  1483.9,
+		ExpectedDpsShort: 1880.7,
+		ExpectedDpsLong:  1601.9,
 	})
 }
 
@@ -235,8 +263,8 @@ func TestClearcastAgent(t *testing.T) {
 			Gear:          P1Gear,
 		},
 
-		ExpectedDpsShort: 1715.9,
-		ExpectedDpsLong:  1526.6,
+		ExpectedDpsShort: 2023.1,
+		ExpectedDpsLong:  1677.5,
 	})
 }
 
@@ -255,7 +283,7 @@ func TestAverageDPS(t *testing.T) {
 		PlayerOptions: PlayerOptionsAdaptive,
 	})
 
-	core.IndividualSimAverageTest("P1Average", t, isr, 1508.04)
+	core.IndividualSimAverageTest("P1Average", t, isr, 1622.65)
 }
 
 func BenchmarkSimulate(b *testing.B) {

--- a/sim/shaman/elemental/presets.go
+++ b/sim/shaman/elemental/presets.go
@@ -121,7 +121,9 @@ var NoDebuffTarget = &proto.Target{
 
 var FullDebuffTarget = &proto.Target{
 	Debuffs: &proto.Debuffs{
+		ImprovedSealOfTheCrusader: true,
 		JudgementOfWisdom: true,
+		Misery: true,
 	},
 }
 

--- a/sim/shaman/elemental/presets.go
+++ b/sim/shaman/elemental/presets.go
@@ -5,13 +5,11 @@ import (
 	"github.com/wowsims/tbc/sim/core/proto"
 )
 
-var BasicRaidBuffs = &proto.RaidBuffs{
-}
+var BasicRaidBuffs = &proto.RaidBuffs{}
 var BasicPartyBuffs = &proto.PartyBuffs{
 	Bloodlust: 1,
 }
-var BasicIndividualBuffs = &proto.IndividualBuffs{
-}
+var BasicIndividualBuffs = &proto.IndividualBuffs{}
 
 var StandardTalents = &proto.ShamanTalents{
 	ElementalFocus:     true,
@@ -100,7 +98,7 @@ var FullPartyBuffs = &proto.PartyBuffs{
 var FullIndividualBuffs = &proto.IndividualBuffs{
 	BlessingOfKings:  true,
 	BlessingOfWisdom: proto.TristateEffect_TristateEffectImproved,
-	ShadowPriestDps: 500,
+	ShadowPriestDps:  500,
 }
 
 var FullConsumes = &proto.Consumes{
@@ -115,21 +113,20 @@ var FullConsumes = &proto.Consumes{
 }
 
 var NoDebuffTarget = &proto.Target{
-	Debuffs: &proto.Debuffs{
-	},
+	Debuffs: &proto.Debuffs{},
 }
 
 var FullDebuffTarget = &proto.Target{
 	Debuffs: &proto.Debuffs{
 		ImprovedSealOfTheCrusader: true,
-		JudgementOfWisdom: true,
-		Misery: true,
+		JudgementOfWisdom:         true,
+		Misery:                    true,
 	},
 }
 
 var PreRaidGear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 	items.ItemStringSpec{
-		Name: "Tidefury Helm",
+		Name:    "Tidefury Helm",
 		Enchant: "Glyph of Power",
 		Gems: []string{
 			"Runed Living Ruby",
@@ -137,7 +134,7 @@ var PreRaidGear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		},
 	},
 	items.ItemStringSpec{
-		Name: "Brooch of Heightened Potential",
+		Name:    "Brooch of Heightened Potential",
 		Enchant: "Zandalar Signet of Mojo",
 	},
 	items.ItemStringSpec{
@@ -159,7 +156,7 @@ var PreRaidGear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		Name: "Moonrage Girdle",
 	},
 	items.ItemStringSpec{
-		Name: "Tidefury Kilt",
+		Name:    "Tidefury Kilt",
 		Enchant: "Mystic Spellthread",
 	},
 	items.ItemStringSpec{
@@ -190,7 +187,7 @@ var PreRaidGear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 
 var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 	items.ItemStringSpec{
-		Name: "Cyclone Faceguard",
+		Name:    "Cyclone Faceguard",
 		Enchant: "Glyph of Power",
 		Gems: []string{
 			"Chaotic Skyfire Diamond",
@@ -201,7 +198,7 @@ var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		Name: "Adornment of Stolen Souls",
 	},
 	items.ItemStringSpec{
-		Name: "Cyclone Shoulderguards",
+		Name:    "Cyclone Shoulderguards",
 		Enchant: "Greater Inscription of Discipline",
 		Gems: []string{
 			"Potent Noble Topaz",
@@ -212,7 +209,7 @@ var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		Name: "Ruby Drape of the Mysticant",
 	},
 	items.ItemStringSpec{
-		Name: "Netherstrike Breastplate",
+		Name:    "Netherstrike Breastplate",
 		Enchant: "Chest - Exceptional Stats",
 		Gems: []string{
 			"Runed Living Ruby",
@@ -221,14 +218,14 @@ var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		},
 	},
 	items.ItemStringSpec{
-		Name: "Netherstrike Bracers",
+		Name:    "Netherstrike Bracers",
 		Enchant: "Bracer - Spellpower",
 		Gems: []string{
 			"Potent Noble Topaz",
 		},
 	},
 	items.ItemStringSpec{
-		Name: "Soul-Eater's Handwraps",
+		Name:    "Soul-Eater's Handwraps",
 		Enchant: "Gloves - Major Spellpower",
 		Gems: []string{
 			"Potent Noble Topaz",
@@ -243,7 +240,7 @@ var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		},
 	},
 	items.ItemStringSpec{
-		Name: "Stormsong Kilt",
+		Name:    "Stormsong Kilt",
 		Enchant: "Runic Spellthread",
 		Gems: []string{
 			"Potent Noble Topaz",
@@ -255,11 +252,11 @@ var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		Name: "Windshear Boots",
 	},
 	items.ItemStringSpec{
-		Name: "Ring of Unrelenting Storms",
+		Name:    "Ring of Unrelenting Storms",
 		Enchant: "Ring - Spellpower",
 	},
 	items.ItemStringSpec{
-		Name: "Ring of Recurrence",
+		Name:    "Ring of Recurrence",
 		Enchant: "Ring - Spellpower",
 	},
 	items.ItemStringSpec{
@@ -272,11 +269,104 @@ var P1Gear = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
 		Name: "Totem of the Void",
 	},
 	items.ItemStringSpec{
-		Name: "Nathrezim Mindblade",
+		Name:    "Nathrezim Mindblade",
 		Enchant: "Weapon - Major Spellpower",
 	},
 	items.ItemStringSpec{
-		Name: "Mazthoril Honor Shield",
+		Name:    "Mazthoril Honor Shield",
+		Enchant: "Shield - Intellect",
+	},
+})
+
+var P1Tidefury = items.EquipmentSpecFromStrings([]items.ItemStringSpec{
+	items.ItemStringSpec{
+		Name:    "Cyclone Faceguard",
+		Enchant: "Glyph of Power",
+		Gems: []string{
+			"Chaotic Skyfire Diamond",
+			"Potent Noble Topaz",
+		},
+	},
+	items.ItemStringSpec{
+		Name: "Adornment of Stolen Souls",
+	},
+	items.ItemStringSpec{
+		Name:    "Cyclone Shoulderguards",
+		Enchant: "Greater Inscription of Discipline",
+		Gems: []string{
+			"Potent Noble Topaz",
+			"Potent Noble Topaz",
+		},
+	},
+	items.ItemStringSpec{
+		Name: "Ruby Drape of the Mysticant",
+	},
+	items.ItemStringSpec{
+		Name:    "Netherstrike Breastplate",
+		Enchant: "Chest - Exceptional Stats",
+		Gems: []string{
+			"Runed Living Ruby",
+			"Runed Living Ruby",
+			"Runed Living Ruby",
+		},
+	},
+	items.ItemStringSpec{
+		Name:    "Netherstrike Bracers",
+		Enchant: "Bracer - Spellpower",
+		Gems: []string{
+			"Potent Noble Topaz",
+		},
+	},
+	items.ItemStringSpec{
+		Name:    "Tidefury Gauntlets",
+		Enchant: "Gloves - Major Spellpower",
+		// Gems: []string{
+		// 	"Potent Noble Topaz",
+		// 	"Glowing Nightseye",
+		// },
+	},
+	items.ItemStringSpec{
+		Name: "Netherstrike Belt",
+		Gems: []string{
+			"Glowing Nightseye",
+			"Potent Noble Topaz",
+		},
+	},
+	items.ItemStringSpec{
+		Name:    "Tidefury Kilt",
+		Enchant: "Runic Spellthread",
+		// Gems: []string{
+		// 	"Potent Noble Topaz",
+		// 	"Runed Living Ruby",
+		// 	"Glowing Nightseye",
+		// },
+	},
+	items.ItemStringSpec{
+		Name: "Windshear Boots",
+	},
+	items.ItemStringSpec{
+		Name:    "Ring of Unrelenting Storms",
+		Enchant: "Ring - Spellpower",
+	},
+	items.ItemStringSpec{
+		Name:    "Ring of Recurrence",
+		Enchant: "Ring - Spellpower",
+	},
+	items.ItemStringSpec{
+		Name: "The Lightning Capacitor",
+	},
+	items.ItemStringSpec{
+		Name: "Icon of the Silver Crescent",
+	},
+	items.ItemStringSpec{
+		Name: "Totem of the Void",
+	},
+	items.ItemStringSpec{
+		Name:    "Nathrezim Mindblade",
+		Enchant: "Weapon - Major Spellpower",
+	},
+	items.ItemStringSpec{
+		Name:    "Mazthoril Honor Shield",
 		Enchant: "Shield - Intellect",
 	},
 })

--- a/sim/shaman/items.go
+++ b/sim/shaman/items.go
@@ -25,13 +25,7 @@ var ItemSetTidefury = core.ItemSet{
 	Items: map[int32]struct{}{28231: {}, 27510: {}, 28349: {}, 27909: {}, 27802: {}},
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
-			character := agent.GetCharacter()
-			character.AddPermanentAura(func(sim *core.Simulation) core.Aura {
-				return core.Aura{
-					ID: Tidefury2PcAuraID,
-					Name: "Tidefury 2pc",
-				}
-			})
+			// Handled in chain_lightning.go
 		},
 		4: func(agent core.Agent) {
 			shamanAgent, ok := agent.(ShamanAgent)
@@ -60,12 +54,12 @@ var ItemSetCycloneRegalia = core.ItemSet{
 			character := agent.GetCharacter()
 			character.AddPermanentAura(func(sim *core.Simulation) core.Aura {
 				return core.Aura{
-					ID:      Cyclone4PcAuraID,
-					Name:    "Cyclone 4pc Bonus",
+					ID:   Cyclone4PcAuraID,
+					Name: "Cyclone 4pc Bonus",
 					OnSpellHit: func(sim *core.Simulation, spellCast *core.SpellCast, spellEffect *core.SpellEffect) {
 						if spellEffect.Crit && sim.RandomFloat("cycl4p") < 0.11 {
 							character.AddAura(sim, core.Aura{
-								ID: Cyclone4PcManaRegainAuraID,
+								ID:   Cyclone4PcManaRegainAuraID,
 								Name: "Cyclone Mana Cost Reduction",
 								OnCast: func(sim *core.Simulation, cast *core.Cast) {
 									// TODO: how to make sure this goes in before clearcasting?
@@ -85,15 +79,15 @@ var ItemSetCycloneRegalia = core.ItemSet{
 
 var Cataclysm4PcAuraID = core.NewAuraID()
 var ItemSetCataclysmRegalia = core.ItemSet{
-	Name:    "Cataclysm Regalia",
-	Items:   map[int32]struct{}{30169: {}, 30170: {}, 30171: {}, 30172: {}, 30173: {}},
+	Name:  "Cataclysm Regalia",
+	Items: map[int32]struct{}{30169: {}, 30170: {}, 30171: {}, 30172: {}, 30173: {}},
 	Bonuses: map[int32]core.ApplyEffect{
 		4: func(agent core.Agent) {
 			character := agent.GetCharacter()
 			character.AddPermanentAura(func(sim *core.Simulation) core.Aura {
 				return core.Aura{
-					ID:      Cataclysm4PcAuraID,
-					Name:    "Cataclysm 4pc Bonus",
+					ID:   Cataclysm4PcAuraID,
+					Name: "Cataclysm 4pc Bonus",
 					OnSpellHit: func(sim *core.Simulation, spellCast *core.SpellCast, spellEffect *core.SpellEffect) {
 						if spellEffect.Crit && sim.RandomFloat("cata4p") < 0.25 {
 							character.AddStat(stats.Mana, 120)
@@ -119,8 +113,8 @@ var ItemSetSkyshatterRegalia = core.ItemSet{
 			character := agent.GetCharacter()
 			character.AddPermanentAura(func(sim *core.Simulation) core.Aura {
 				return core.Aura{
-					ID:      Skyshatter4PcAuraID,
-					Name:    "Skyshatter 4pc Bonus",
+					ID:   Skyshatter4PcAuraID,
+					Name: "Skyshatter 4pc Bonus",
 					OnBeforeSpellHit: func(sim *core.Simulation, spellCast *core.SpellCast, spellEffect *core.SpellEffect) {
 						if spellCast.ActionID.SpellID == SpellIDLB12 {
 							spellEffect.DamageMultiplier *= 1.05
@@ -133,15 +127,16 @@ var ItemSetSkyshatterRegalia = core.ItemSet{
 }
 
 var NaturalAlignmentCrystalCooldownID = core.NewCooldownID()
+
 func ApplyNaturalAlignmentCrystal(agent core.Agent) {
 	const sp = 250
 	const dur = time.Second * 20
 
 	agent.GetCharacter().AddMajorCooldown(core.MajorCooldown{
-		CooldownID: NaturalAlignmentCrystalCooldownID,
-		Cooldown: time.Minute * 5,
+		CooldownID:       NaturalAlignmentCrystalCooldownID,
+		Cooldown:         time.Minute * 5,
 		SharedCooldownID: core.OffensiveTrinketSharedCooldownID,
-		SharedCooldown: dur,
+		SharedCooldown:   dur,
 		ActivationFactory: func(sim *core.Simulation) core.CooldownActivation {
 			return func(sim *core.Simulation, character *core.Character) bool {
 				character.AddStat(stats.SpellPower, sp)
@@ -167,6 +162,7 @@ func ApplyNaturalAlignmentCrystal(agent core.Agent) {
 // ActivateFathomBrooch adds an aura that has a chance on cast of nature spell
 //  to restore 335 mana. 40s ICD
 var FathomBroochOfTheTidewalkerAuraID = core.NewAuraID()
+
 func ApplyFathomBroochOfTheTidewalker(agent core.Agent) {
 	character := agent.GetCharacter()
 	character.AddPermanentAura(func(sim *core.Simulation) core.Aura {
@@ -174,8 +170,8 @@ func ApplyFathomBroochOfTheTidewalker(agent core.Agent) {
 		const icdDur = time.Second * 40
 
 		return core.Aura{
-			ID:      FathomBroochOfTheTidewalkerAuraID,
-			Name:    "Fathom-Brooch of the Tidewalker",
+			ID:   FathomBroochOfTheTidewalkerAuraID,
+			Name: "Fathom-Brooch of the Tidewalker",
 			OnCastComplete: func(sim *core.Simulation, cast *core.Cast) {
 				if icd.IsOnCD(sim) {
 					return
@@ -194,6 +190,7 @@ func ApplyFathomBroochOfTheTidewalker(agent core.Agent) {
 
 var SkycallTotemAuraID = core.NewAuraID()
 var EnergizedAuraID = core.NewAuraID()
+
 func ApplySkycallTotem(agent core.Agent) {
 	character := agent.GetCharacter()
 	character.AddPermanentAura(func(sim *core.Simulation) core.Aura {

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -138,7 +138,6 @@ func (shaman *Shaman) Reset(sim *core.Simulation) {
 
 	numHits := core.MinInt32(3, sim.GetNumTargets())
 	shaman.chainLightningSpellLOs = make([]core.MultiTargetDirectDamageSpell, numHits)
-
 }
 
 func (shaman *Shaman) Advance(sim *core.Simulation, elapsedTime time.Duration) {

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -130,6 +130,15 @@ func (shaman *Shaman) Init(sim *core.Simulation) {
 
 func (shaman *Shaman) Reset(sim *core.Simulation) {
 	shaman.Character.Reset(sim)
+
+	// Reset all spells so any pending casts are cleaned up
+	shaman.lightningBoltSpell = core.SingleTargetDirectDamageSpell{}
+	shaman.lightningBoltSpellLO = core.SingleTargetDirectDamageSpell{}
+	shaman.chainLightningSpell = core.MultiTargetDirectDamageSpell{}
+
+	numHits := core.MinInt32(3, sim.GetNumTargets())
+	shaman.chainLightningSpellLOs = make([]core.MultiTargetDirectDamageSpell, numHits)
+
 }
 
 func (shaman *Shaman) Advance(sim *core.Simulation, elapsedTime time.Duration) {

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -66,15 +66,15 @@ type Shaman struct {
 	lightningBoltSpell   core.SingleTargetDirectDamageSpell
 	lightningBoltSpellLO core.SingleTargetDirectDamageSpell
 
-	chainLightningSpell   core.MultiTargetDirectDamageSpell
-	chainLightningSpellLO core.MultiTargetDirectDamageSpell
+	chainLightningSpell    core.MultiTargetDirectDamageSpell
+	chainLightningSpellLOs []core.MultiTargetDirectDamageSpell
 
 	// Precomputed templated cast generator for quickly resetting cast fields.
 	lightningBoltCastTemplate   core.SingleTargetDirectDamageSpellTemplate
 	lightningBoltLOCastTemplate core.SingleTargetDirectDamageSpellTemplate
 
-	chainLightningCastTemplate   core.MultiTargetDirectDamageSpellTemplate
-	chainLightningLOCastTemplate core.MultiTargetDirectDamageSpellTemplate
+	chainLightningCastTemplate    core.MultiTargetDirectDamageSpellTemplate
+	chainLightningLOCastTemplates []core.MultiTargetDirectDamageSpellTemplate
 }
 
 // Implemented by each Shaman spec.
@@ -117,8 +117,15 @@ func (shaman *Shaman) Init(sim *core.Simulation) {
 	// Precompute all the spell templates.
 	shaman.lightningBoltCastTemplate = shaman.newLightningBoltTemplate(sim, false)
 	shaman.lightningBoltLOCastTemplate = shaman.newLightningBoltTemplate(sim, true)
+
 	shaman.chainLightningCastTemplate = shaman.newChainLightningTemplate(sim, false)
-	shaman.chainLightningLOCastTemplate = shaman.newChainLightningTemplate(sim, true)
+
+	numHits := core.MinInt32(3, sim.GetNumTargets())
+	shaman.chainLightningSpellLOs = make([]core.MultiTargetDirectDamageSpell, numHits)
+	shaman.chainLightningLOCastTemplates = []core.MultiTargetDirectDamageSpellTemplate{}
+	for i := int32(0); i < numHits; i++ {
+		shaman.chainLightningLOCastTemplates = append(shaman.chainLightningLOCastTemplates, shaman.newChainLightningTemplate(sim, true))
+	}
 }
 
 func (shaman *Shaman) Reset(sim *core.Simulation) {


### PR DESCRIPTION
On end of a sim any spell that is 'casting' but not done is now "in use". This adds a to reset the cleanup of those spells.
 A more generic way of handling this would be a 'cleanup' function to pendingActions because this is the same problem that dots had when rolling and the sim ended.

Fixes issue with tidefury not being used.

Enables the multi-target test again.