### PR TITLE
Raid Sim API call.

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -15,28 +15,27 @@ import "warlock.proto";
 import "warrior.proto";
 
 message PlayerOptions {
-    Race race = 1;
-    Class class = 2;
-
-    oneof spec {
-        BalanceDruid balance_druid = 3;
-        Hunter hunter = 4;
-        Mage mage = 5;
-        RetributionPaladin retribution_paladin = 6;
-        ShadowPriest shadow_priest = 7;
-        Rogue rogue = 8;
-        ElementalShaman elemental_shaman = 9;
-        Warlock warlock = 10;
-        Warrior warrior = 11;
-    }
-
-    Consumes consumes = 12; // What consumes this player is going to be using.
 }
 
 message Player {
-    PlayerOptions options = 1;
-    EquipmentSpec equipment = 2;
-    repeated double custom_stats = 3;
+    Race race = 1;
+    Class class = 2;
+
+    EquipmentSpec equipment = 3;
+    Consumes consumes = 4;
+    repeated double bonus_stats = 5;
+
+    oneof spec {
+        BalanceDruid balance_druid = 6;
+        Hunter hunter = 7;
+        Mage mage = 8;
+        RetributionPaladin retribution_paladin = 9;
+        ShadowPriest shadow_priest = 10;
+        Rogue rogue = 11;
+        ElementalShaman elemental_shaman = 12;
+        Warlock warlock = 13;
+        Warrior warrior = 14;
+    }
 }
 
 message Party {

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -25,6 +25,8 @@ message Player {
     Consumes consumes = 4;
     repeated double bonus_stats = 5;
 
+		IndividualBuffs buffs = 15;
+
     oneof spec {
         BalanceDruid balance_druid = 6;
         Hunter hunter = 7;
@@ -40,10 +42,14 @@ message Player {
 
 message Party {
     repeated Player players = 1;
+
+		PartyBuffs buffs = 2;
 }
 
 message Raid {
     repeated Party parties = 1; 
+
+		RaidBuffs buffs = 2;
 }
 
 message SimOptions {
@@ -156,7 +162,6 @@ message IndividualSimRequest {
 
     RaidBuffs raid_buffs = 2;
     PartyBuffs party_buffs = 3;
-    IndividualBuffs Individual_buffs = 4;
 
     Encounter encounter = 5;
 		SimOptions sim_options = 6;
@@ -184,7 +189,6 @@ message ComputeStatsRequest {
     Player player = 1;
     RaidBuffs raid_buffs = 2;
     PartyBuffs party_buffs = 3;
-    IndividualBuffs individual_buffs = 4;
 }
 message ComputeStatsResult {
     repeated double gear_only = 1;

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -14,9 +14,6 @@ import "shaman.proto";
 import "warlock.proto";
 import "warrior.proto";
 
-message PlayerOptions {
-}
-
 message Player {
     Race race = 1;
     Class class = 2;

--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -18,9 +18,6 @@ type Agent interface {
 	// Updates the input Buffs to include party-wide buffs provided by this Agent.
 	AddPartyBuffs(partyBuffs *proto.PartyBuffs)
 
-	// See PresimOptions for details. If a presim is not needed, should return nil instead.
-	GetPresimOptions() *PresimOptions
-
 	// Called once before the first iteration, after all Agents and Targets are finalized.
 	// Use this to do any precomputations that require access to Sim or Target fields.
 	Init(sim *Simulation)
@@ -92,21 +89,4 @@ func NewAgent(player proto.Player) Agent {
 
 	character := NewCharacter(player)
 	return factory(character, player)
-}
-
-// A presim is a full simulation run with multiple iterations, as a preparation
-// step for testing out settings before starting the recorded iterations.
-//
-// If you don't know what this is, you probably don't need it.
-type PresimOptions struct {
-	// Called once before each presim round.
-	//
-	// Modify the player parameter to use whatever player options are desired
-	// for the presim.
-	SetPresimPlayerOptions func(player *proto.Player)
-
-	// Called once after each presim round to provide the results.
-	//
-	// Should return true if this Agent is done running presims, and false otherwise.
-	OnPresimResult func(presimResult proto.PlayerMetrics, iterations int32) bool
 }

--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -64,7 +64,7 @@ func (actionID ActionID) ToProto() *proto.ActionID {
 	return protoID
 }
 
-type AgentFactory func(Character, proto.PlayerOptions, proto.IndividualSimRequest) Agent
+type AgentFactory func(Character, proto.Player, proto.IndividualSimRequest) Agent
 
 var agentFactories map[string]AgentFactory = make(map[string]AgentFactory)
 
@@ -80,11 +80,7 @@ func RegisterAgentFactory(emptyOptions interface{}, factory AgentFactory) {
 
 // Constructs a new Agent. isr is only used for presims.
 func NewAgent(player proto.Player, isr proto.IndividualSimRequest) Agent {
-	if player.Options == nil {
-		panic("No player options provided!")
-	}
-
-	typeName := reflect.TypeOf(player.Options.GetSpec()).Elem().Name()
+	typeName := reflect.TypeOf(player.GetSpec()).Elem().Name()
 
 	factory, ok := agentFactories[typeName]
 	if !ok {
@@ -92,5 +88,5 @@ func NewAgent(player proto.Player, isr proto.IndividualSimRequest) Agent {
 	}
 
 	character := NewCharacter(player)
-	return factory(character, *player.Options, isr)
+	return factory(character, player, isr)
 }

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -110,7 +110,6 @@ func (character *Character) applyAllEffects(agent Agent) {
 	applyRaceEffects(agent)
 	character.applyItemEffects(agent)
 	character.applyItemSetBonusEffects(agent)
-	applyConsumeEffects(agent)
 }
 
 // Apply effects from all equipped items.

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -61,8 +61,8 @@ type Character struct {
 
 func NewCharacter(player proto.Player) Character {
 	character := Character{
-		Race:  player.Options.Race,
-		Class: player.Options.Class,
+		Race:  player.Race,
+		Class: player.Class,
 		Equip: items.ProtoToEquipment(*player.Equipment),
 		PseudoStats: stats.PseudoStats{
 			CastSpeedMultiplier:   1,
@@ -72,17 +72,17 @@ func NewCharacter(player proto.Player) Character {
 		Metrics:     NewCharacterMetrics(),
 	}
 
-	if player.Options.Consumes != nil {
-		character.consumes = *player.Options.Consumes
+	if player.Consumes != nil {
+		character.consumes = *player.Consumes
 	}
 
 	character.AddStats(BaseStats[BaseStatsKey{Race: character.Race, Class: character.Class}])
 	character.AddStats(character.Equip.Stats())
 
-	if player.CustomStats != nil {
-		customStats := stats.Stats{}
-		copy(customStats[:], player.CustomStats[:])
-		character.AddStats(customStats)
+	if player.BonusStats != nil {
+		bonusStats := stats.Stats{}
+		copy(bonusStats[:], player.BonusStats[:])
+		character.AddStats(bonusStats)
 	}
 
 	// Universal stat dependencies

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Registers all consume-related effects to the Agent.
-func applyConsumeEffects(agent Agent) {
+func applyConsumeEffects(agent Agent, partyBuffs proto.PartyBuffs) {
 	consumes := agent.GetCharacter().consumes
 
 	agent.GetCharacter().AddStats(consumesStats(consumes))
 
-	registerDrumsCD(agent, consumes)
+	registerDrumsCD(agent, partyBuffs, consumes)
 	registerPotionCD(agent, consumes)
 	registerDarkRuneCD(agent, consumes)
 }
@@ -90,8 +90,8 @@ func consumesStats(c proto.Consumes) stats.Stats {
 var DrumsAuraID = NewAuraID()
 var DrumsCooldownID = NewCooldownID()
 
-func registerDrumsCD(agent Agent, consumes proto.Consumes) {
-	character := agent.GetCharacter()
+func registerDrumsCD(agent Agent, partyBuffs proto.PartyBuffs, consumes proto.Consumes) {
+	//character := agent.GetCharacter()
 	drumsType := proto.Drums_DrumsUnknown
 
 	// Whether this agent is the one casting the drums.
@@ -100,8 +100,8 @@ func registerDrumsCD(agent Agent, consumes proto.Consumes) {
 	if consumes.Drums != proto.Drums_DrumsUnknown {
 		drumsType = consumes.Drums
 		//drumsSelfCast = true
-	} else if character.Party.buffs.Drums != proto.Drums_DrumsUnknown {
-		drumsType = character.Party.buffs.Drums
+	} else if partyBuffs.Drums != proto.Drums_DrumsUnknown {
+		drumsType = partyBuffs.Drums
 	}
 
 	// TODO: If drumsSelfCast == true, then do a cast time

--- a/sim/core/presim.go
+++ b/sim/core/presim.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"github.com/wowsims/tbc/sim/core/proto"
+	googleProto "google.golang.org/protobuf/proto"
+)
+
+// A presim is a full simulation run with multiple iterations, as a preparation
+// step for testing out settings before starting the recorded iterations.
+//
+// To use this, just implement this interface on your Agent.
+//
+// If you don't know what this is, you probably don't need it.
+type Presimmer interface {
+	GetPresimOptions() *PresimOptions
+}
+
+// Controls the presim behavior for 1 Agent.
+type PresimOptions struct {
+	// Called once before each presim round.
+	//
+	// Modify the player parameter to use whatever player options are desired
+	// for the presim.
+	SetPresimPlayerOptions func(player *proto.Player)
+
+	// Called once after each presim round to provide the results.
+	//
+	// Should return true if this Agent is done running presims, and false otherwise.
+	OnPresimResult func(presimResult proto.PlayerMetrics, iterations int32) bool
+}
+
+func (sim *Simulation) runPresims(request proto.RaidSimRequest) {
+	const numPresimIterations = 100
+
+	// Run presims if requested.
+	raidPresimOptions := make([]*PresimOptions, sim.Raid.Size())
+	remainingAgents := 0
+	for _, party := range sim.Raid.Parties {
+		for _, player := range party.Players {
+			presimmer, ok := player.(Presimmer)
+			if !ok {
+				continue
+			}
+
+			presimOptions := presimmer.GetPresimOptions()
+			if presimOptions == nil {
+				continue
+			}
+
+			raidPresimOptions[player.GetCharacter().ID] = presimOptions
+			remainingAgents++
+		}
+	}
+
+	// Base presim request.
+	// Define this outside the loop so that, as Agents iteratively update their
+	// settings, we keep the most recent settings even after that Agent is
+	// done with presims.
+	presimRequest := googleProto.Clone(&request).(*proto.RaidSimRequest)
+	presimRequest.SimOptions.RandomSeed = 1
+	presimRequest.SimOptions.Debug = false
+	presimRequest.SimOptions.Iterations = numPresimIterations
+
+	for remainingAgents > 0 {
+		// ** Run a presim round. **
+
+		// Let each Agent modify their own settings.
+		for partyIdx, party := range sim.Raid.Parties {
+			partyConfig := presimRequest.Raid.Parties[partyIdx]
+			for playerIdx, player := range party.Players {
+				playerConfig := partyConfig.Players[playerIdx]
+
+				presimOptions := raidPresimOptions[player.GetCharacter().ID]
+				if presimOptions == nil {
+					continue
+				}
+
+				presimOptions.SetPresimPlayerOptions(playerConfig)
+			}
+		}
+
+		// Run the presim.
+		presimResult := RunSim(*presimRequest)
+
+		// Provide each Agent with their own results.
+		for partyIdx, party := range sim.Raid.Parties {
+			partyMetrics := presimResult.RaidMetrics.Parties[partyIdx]
+			for playerIdx, player := range party.Players {
+				playerMetrics := partyMetrics.Players[playerIdx]
+				presimOptions := raidPresimOptions[player.GetCharacter().ID]
+				if presimOptions != nil {
+					done := presimOptions.OnPresimResult(*playerMetrics, numPresimIterations)
+					if done {
+						raidPresimOptions[player.GetCharacter().ID] = nil
+						remainingAgents--
+					}
+				}
+			}
+		}
+	}
+}

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/wowsims/tbc/sim/core/proto"
-	googleProto "google.golang.org/protobuf/proto"
 )
 
 func debugFunc(sim *Simulation) func(string, ...interface{}) {
@@ -95,67 +94,6 @@ func (sim *Simulation) RandomFloat(label string) float64 {
 		sim.testRands[labelHash] = labelRand
 	}
 	return labelRand.Float64()
-}
-
-func (sim *Simulation) runPresims(request proto.RaidSimRequest) {
-	const numPresimIterations = 100
-
-	// Run presims if requested.
-	raidPresimOptions := make([]*PresimOptions, sim.Raid.Size())
-	remainingAgents := 0
-	for _, party := range sim.Raid.Parties {
-		for _, player := range party.Players {
-			presimOptions := player.GetPresimOptions()
-			if presimOptions != nil {
-				raidPresimOptions[player.GetCharacter().ID] = presimOptions
-				remainingAgents++
-			}
-		}
-	}
-
-	// Base presim request.
-	// Define this outside the loop so that, as Agents iteratively update their
-	// settings, we keep the most recent settings even after that Agent is
-	// done with presims.
-	presimRequest := googleProto.Clone(&request).(*proto.RaidSimRequest)
-	presimRequest.SimOptions.RandomSeed = 1
-	presimRequest.SimOptions.Debug = false
-	presimRequest.SimOptions.Iterations = numPresimIterations
-
-	for remainingAgents > 0 {
-		// ** Run a presim round. **
-
-		// Let each Agent modify their own settings.
-		for partyIdx, party := range sim.Raid.Parties {
-			partyConfig := presimRequest.Raid.Parties[partyIdx]
-			for playerIdx, player := range party.Players {
-				playerConfig := partyConfig.Players[playerIdx]
-				presimOptions := raidPresimOptions[player.GetCharacter().ID]
-				if presimOptions != nil {
-					presimOptions.SetPresimPlayerOptions(playerConfig)
-				}
-			}
-		}
-
-		// Run the presim.
-		presimResult := RunSim(*presimRequest)
-
-		// Provide each Agent with their own results.
-		for partyIdx, party := range sim.Raid.Parties {
-			partyMetrics := presimResult.RaidMetrics.Parties[partyIdx]
-			for playerIdx, player := range party.Players {
-				playerMetrics := partyMetrics.Players[playerIdx]
-				presimOptions := raidPresimOptions[player.GetCharacter().ID]
-				if presimOptions != nil {
-					done := presimOptions.OnPresimResult(*playerMetrics, numPresimIterations)
-					if done {
-						raidPresimOptions[player.GetCharacter().ID] = nil
-						remainingAgents--
-					}
-				}
-			}
-		}
-	}
 }
 
 // Reset will set sim back and erase all current state.

--- a/sim/core/statweight.go
+++ b/sim/core/statweight.go
@@ -22,9 +22,14 @@ func CalcStatWeight(isr proto.IndividualSimRequest, statsToWeigh []stats.Stat, r
 		isr.Player.BonusStats = make([]float64, stats.Len)
 	}
 
-	baseSim := NewIndividualSim(isr)
-	baseStats := baseSim.Raid.Parties[0].Players[0].GetCharacter().GetStats()
-	baselineResult := baseSim.RunIndividual()
+	baseStatsResult := ComputeStats(&proto.ComputeStatsRequest{
+		Player:     isr.Player,
+		RaidBuffs:  isr.RaidBuffs,
+		PartyBuffs: isr.PartyBuffs,
+	})
+	baseStats := baseStatsResult.FinalStats
+
+	baselineResult := RunIndividualSim(&isr)
 
 	var waitGroup sync.WaitGroup
 	result := StatWeightsResult{}

--- a/sim/core/statweight.go
+++ b/sim/core/statweight.go
@@ -18,8 +18,8 @@ type StatWeightsResult struct {
 }
 
 func CalcStatWeight(isr proto.IndividualSimRequest, statsToWeigh []stats.Stat, referenceStat stats.Stat) StatWeightsResult {
-	if isr.Player.CustomStats == nil {
-		isr.Player.CustomStats = make([]float64, stats.Len)
+	if isr.Player.BonusStats == nil {
+		isr.Player.BonusStats = make([]float64, stats.Len)
 	}
 
 	baseSim := NewIndividualSim(isr)
@@ -34,7 +34,7 @@ func CalcStatWeight(isr proto.IndividualSimRequest, statsToWeigh []stats.Stat, r
 		defer waitGroup.Done()
 
 		simRequest := googleProto.Clone(&isr).(*proto.IndividualSimRequest)
-		simRequest.Player.CustomStats[stat] += value
+		simRequest.Player.BonusStats[stat] += value
 
 		simResult := RunIndividualSim(simRequest)
 

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -23,12 +23,14 @@ func NewEncounter(options proto.Encounter) Encounter {
 		encounter.Targets = append(encounter.Targets, target)
 	}
 
+	encounter.finalize()
+
 	return encounter
 }
 
-func (encounter *Encounter) Finalize() {
+func (encounter *Encounter) finalize() {
 	for _, target := range encounter.Targets {
-		target.Finalize()
+		target.finalize()
 	}
 }
 
@@ -67,7 +69,7 @@ type Target struct {
 	// Provides aura tracking behavior. Targets need auras to handle debuffs.
 	auraTracker
 
-	// Whether Finalize() has been called yet for this Character.
+	// Whether finalize() has been called yet for this Character.
 	// All fields above this may not be altered once finalized is set.
 	finalized bool
 }
@@ -196,7 +198,7 @@ func curseOfElementsAura(coe proto.TristateEffect) Aura {
 	}
 }
 
-func (target *Target) Finalize() {
+func (target *Target) finalize() {
 	if target.finalized {
 		return
 	}

--- a/sim/core/test_utils.go
+++ b/sim/core/test_utils.go
@@ -12,31 +12,22 @@ const ShortDuration = 60
 const LongDuration = 300
 
 type IndividualSimInputs struct {
-	SimOptions      *proto.SimOptions
-	Gear            *proto.EquipmentSpec
+	Player          *proto.Player
 	RaidBuffs       *proto.RaidBuffs
 	PartyBuffs      *proto.PartyBuffs
 	IndividualBuffs *proto.IndividualBuffs
-	Consumes        *proto.Consumes
-	Race            proto.Race
-	Class           proto.Class
+	SimOptions      *proto.SimOptions
 
 	Duration int
 
 	// Convenience field if only 1 target is desired
 	Target  *proto.Target
 	Targets []*proto.Target
-
-	PlayerOptions *proto.PlayerOptions
 }
 
 func NewIndividualSimRequest(inputs IndividualSimInputs) *proto.IndividualSimRequest {
 	isr := &proto.IndividualSimRequest{
-		Player: &proto.Player{
-			Equipment: inputs.Gear,
-			Options:   inputs.PlayerOptions,
-		},
-
+		Player:          inputs.Player,
 		RaidBuffs:       inputs.RaidBuffs,
 		PartyBuffs:      inputs.PartyBuffs,
 		IndividualBuffs: inputs.IndividualBuffs,
@@ -44,13 +35,6 @@ func NewIndividualSimRequest(inputs IndividualSimInputs) *proto.IndividualSimReq
 		Encounter:  &proto.Encounter{},
 		SimOptions: inputs.SimOptions,
 	}
-
-	if isr.Player.Options == nil {
-		isr.Player.Options = &proto.PlayerOptions{}
-	}
-	isr.Player.Options.Race = inputs.Race
-	isr.Player.Options.Class = inputs.Class
-	isr.Player.Options.Consumes = inputs.Consumes
 
 	isr.Encounter.Duration = float64(inputs.Duration)
 	if inputs.Target != nil {

--- a/sim/core/test_utils.go
+++ b/sim/core/test_utils.go
@@ -27,14 +27,15 @@ type IndividualSimInputs struct {
 
 func NewIndividualSimRequest(inputs IndividualSimInputs) *proto.IndividualSimRequest {
 	isr := &proto.IndividualSimRequest{
-		Player:          inputs.Player,
-		RaidBuffs:       inputs.RaidBuffs,
-		PartyBuffs:      inputs.PartyBuffs,
-		IndividualBuffs: inputs.IndividualBuffs,
+		Player:     inputs.Player,
+		RaidBuffs:  inputs.RaidBuffs,
+		PartyBuffs: inputs.PartyBuffs,
 
 		Encounter:  &proto.Encounter{},
 		SimOptions: inputs.SimOptions,
 	}
+
+	isr.Player.Buffs = inputs.IndividualBuffs
 
 	isr.Encounter.Duration = float64(inputs.Duration)
 	if inputs.Target != nil {
@@ -55,10 +56,9 @@ func NewIndividualSimRequest(inputs IndividualSimInputs) *proto.IndividualSimReq
 
 func CharacterStatsTest(label string, t *testing.T, isr *proto.IndividualSimRequest, expectedStats stats.Stats) {
 	csr := &proto.ComputeStatsRequest{
-		Player:          isr.Player,
-		RaidBuffs:       isr.RaidBuffs,
-		PartyBuffs:      isr.PartyBuffs,
-		IndividualBuffs: isr.IndividualBuffs,
+		Player:     isr.Player,
+		RaidBuffs:  isr.RaidBuffs,
+		PartyBuffs: isr.PartyBuffs,
 	}
 
 	result := ComputeStats(csr)
@@ -158,7 +158,6 @@ func IndividualBenchmark(b *testing.B, isr *proto.IndividualSimRequest) {
 	isr.SimOptions.IsTest = false
 
 	for i := 0; i < b.N; i++ {
-		sim := NewIndividualSim(*isr)
-		sim.Run()
+		RunIndividualSim(isr)
 	}
 }

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -11,12 +11,12 @@ import (
 )
 
 func RegisterBalanceDruid() {
-	core.RegisterAgentFactory(proto.PlayerOptions_BalanceDruid{}, func(character core.Character, options proto.PlayerOptions, isr proto.IndividualSimRequest) core.Agent {
+	core.RegisterAgentFactory(proto.Player_BalanceDruid{}, func(character core.Character, options proto.Player, isr proto.IndividualSimRequest) core.Agent {
 		return NewBalanceDruid(character, options, isr)
 	})
 }
 
-func NewBalanceDruid(character core.Character, options proto.PlayerOptions, isr proto.IndividualSimRequest) *BalanceDruid {
+func NewBalanceDruid(character core.Character, options proto.Player, isr proto.IndividualSimRequest) *BalanceDruid {
 	balanceOptions := options.GetBalanceDruid()
 
 	selfBuffs := druid.SelfBuffs{}
@@ -171,7 +171,7 @@ func (moonkin *BalanceDruid) PickRotations(baseRotation proto.BalanceDruid_Rotat
 		presimRequest.SimOptions.RandomSeed = 1
 		presimRequest.SimOptions.Debug = false
 		presimRequest.SimOptions.Iterations = 100
-		*presimRequest.Player.Options.Spec.(*proto.PlayerOptions_BalanceDruid).BalanceDruid.Rotation = rotation
+		*presimRequest.Player.Spec.(*proto.Player_BalanceDruid).BalanceDruid.Rotation = rotation
 
 		presimResult := core.RunIndividualSim(presimRequest)
 

--- a/sim/druid/balance/balance_test.go
+++ b/sim/druid/balance/balance_test.go
@@ -18,17 +18,19 @@ func TestNordBonus(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceTauren,
+				Class:     proto.Class_ClassDruid,
+				Equipment: P2Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsStarfire,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceTauren,
-			Class:    proto.Class_ClassDruid,
-
-			PlayerOptions: PlayerOptionsStarfire,
-			Gear:          P2Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 1538.2,
@@ -42,17 +44,19 @@ func TestSimulateP1Starfire(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceTauren,
+				Class:     proto.Class_ClassDruid,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsStarfire,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceTauren,
-			Class:    proto.Class_ClassDruid,
-
-			PlayerOptions: PlayerOptionsStarfire,
-			Gear:          P1Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 1413.4,
@@ -66,17 +70,19 @@ func TestSimulateP1Wrath(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceTauren,
+				Class:     proto.Class_ClassDruid,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsWrath,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceTauren,
-			Class:    proto.Class_ClassDruid,
-
-			PlayerOptions: PlayerOptionsWrath,
-			Gear:          P1Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 1141.3,
@@ -90,17 +96,19 @@ func TestAdaptive(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceTauren,
+				Class:     proto.Class_ClassDruid,
+				Equipment: P2Gear,
+				Consumes:  BasicConsumes,
+				Spec:      PlayerOptionsAdaptive,
+			},
+
 			RaidBuffs:       BasicRaidBuffs,
 			PartyBuffs:      BasicPartyBuffs,
 			IndividualBuffs: BasicIndividualBuffs,
 
-			Consumes: BasicConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceTauren,
-			Class:    proto.Class_ClassDruid,
-
-			PlayerOptions: PlayerOptionsAdaptive,
-			Gear:          P2Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 1569.7,
@@ -110,17 +118,19 @@ func TestAdaptive(t *testing.T) {
 
 func TestAverageDPS(t *testing.T) {
 	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
-		Gear:     P1Gear,
-		Race:     proto.Race_RaceNightElf,
-		Class:    proto.Class_ClassDruid,
-		Consumes: FullConsumes,
+		Player: &proto.Player{
+			Race:      proto.Race_RaceNightElf,
+			Class:     proto.Class_ClassDruid,
+			Equipment: P1Gear,
+			Consumes:  FullConsumes,
+			Spec:      PlayerOptionsStarfire,
+		},
 
 		RaidBuffs:       FullRaidBuffs,
 		PartyBuffs:      FullPartyBuffs,
 		IndividualBuffs: FullIndividualBuffs,
 
-		Target:        FullDebuffTarget,
-		PlayerOptions: PlayerOptionsStarfire,
+		Target: FullDebuffTarget,
 	})
 
 	core.IndividualSimAverageTest("P1Average", t, isr, 1258.1)

--- a/sim/druid/balance/presets.go
+++ b/sim/druid/balance/presets.go
@@ -43,7 +43,7 @@ var FullIndividualBuffs = &proto.IndividualBuffs{
 }
 
 var BasicConsumes = &proto.Consumes{
-	DefaultPotion:        proto.Potions_SuperManaPotion,
+	DefaultPotion: proto.Potions_SuperManaPotion,
 }
 var FullConsumes = &proto.Consumes{
 	FlaskOfBlindingLight: true,
@@ -68,48 +68,42 @@ var FullDebuffTarget = &proto.Target{
 	},
 }
 
-var PlayerOptionsAdaptive = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_BalanceDruid{
-		BalanceDruid: &proto.BalanceDruid{
-			Talents: StandardTalents,
-			Options: &proto.BalanceDruid_Options{
-				InnervateTarget: &proto.RaidTarget{TargetIndex: 0}, // self innervate
-			},
-			Rotation: &proto.BalanceDruid_Rotation{
-				PrimarySpell: proto.BalanceDruid_Rotation_Adaptive,
-				FaerieFire: true,
-			},
+var PlayerOptionsAdaptive = &proto.Player_BalanceDruid{
+	BalanceDruid: &proto.BalanceDruid{
+		Talents: StandardTalents,
+		Options: &proto.BalanceDruid_Options{
+			InnervateTarget: &proto.RaidTarget{TargetIndex: 0}, // self innervate
+		},
+		Rotation: &proto.BalanceDruid_Rotation{
+			PrimarySpell: proto.BalanceDruid_Rotation_Adaptive,
+			FaerieFire:   true,
 		},
 	},
 }
 
-var PlayerOptionsStarfire = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_BalanceDruid{
-		BalanceDruid: &proto.BalanceDruid{
-			Talents: StandardTalents,
-			Options: &proto.BalanceDruid_Options{
-				InnervateTarget: &proto.RaidTarget{TargetIndex: 0}, // self innervate
-			},
-			Rotation: &proto.BalanceDruid_Rotation{
-				PrimarySpell: proto.BalanceDruid_Rotation_Starfire,
-				Moonfire:     true,
-				FaerieFire:   true,
-			},
+var PlayerOptionsStarfire = &proto.Player_BalanceDruid{
+	BalanceDruid: &proto.BalanceDruid{
+		Talents: StandardTalents,
+		Options: &proto.BalanceDruid_Options{
+			InnervateTarget: &proto.RaidTarget{TargetIndex: 0}, // self innervate
+		},
+		Rotation: &proto.BalanceDruid_Rotation{
+			PrimarySpell: proto.BalanceDruid_Rotation_Starfire,
+			Moonfire:     true,
+			FaerieFire:   true,
 		},
 	},
 }
 
-var PlayerOptionsWrath = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_BalanceDruid{
-		BalanceDruid: &proto.BalanceDruid{
-			Talents: StandardTalents,
-			Options: &proto.BalanceDruid_Options{
-				InnervateTarget: &proto.RaidTarget{TargetIndex: 0}, // self innervate
-			},
-			Rotation: &proto.BalanceDruid_Rotation{
-				PrimarySpell: proto.BalanceDruid_Rotation_Wrath,
-				Moonfire:     true,
-			},
+var PlayerOptionsWrath = &proto.Player_BalanceDruid{
+	BalanceDruid: &proto.BalanceDruid{
+		Talents: StandardTalents,
+		Options: &proto.BalanceDruid_Options{
+			InnervateTarget: &proto.RaidTarget{TargetIndex: 0}, // self innervate
+		},
+		Rotation: &proto.BalanceDruid_Rotation{
+			PrimarySpell: proto.BalanceDruid_Rotation_Wrath,
+			Moonfire:     true,
 		},
 	},
 }

--- a/sim/priest/shadow/presets.go
+++ b/sim/priest/shadow/presets.go
@@ -64,15 +64,13 @@ var FullDebuffTarget = &proto.Target{
 	},
 }
 
-var PlayerOptionsBasic = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_ShadowPriest{
-		ShadowPriest: &proto.ShadowPriest{
-			Talents: StandardTalents,
-			Options: &proto.ShadowPriest_Options{},
-			Rotation: &proto.ShadowPriest_Rotation{
-				RotationType: proto.ShadowPriest_Rotation_Basic,
-				// UseDevPlague: true,
-			},
+var PlayerOptionsBasic = &proto.Player_ShadowPriest{
+	ShadowPriest: &proto.ShadowPriest{
+		Talents: StandardTalents,
+		Options: &proto.ShadowPriest_Options{},
+		Rotation: &proto.ShadowPriest_Rotation{
+			RotationType: proto.ShadowPriest_Rotation_Basic,
+			// UseDevPlague: true,
 		},
 	},
 }

--- a/sim/priest/shadow/spriest.go
+++ b/sim/priest/shadow/spriest.go
@@ -10,15 +10,15 @@ import (
 )
 
 func RegisterShadowPriest() {
-	core.RegisterAgentFactory(proto.Player_ShadowPriest{}, func(character core.Character, options proto.Player, isr proto.IndividualSimRequest) core.Agent {
-		return NewShadowPriest(character, options, isr)
+	core.RegisterAgentFactory(proto.Player_ShadowPriest{}, func(character core.Character, options proto.Player) core.Agent {
+		return NewShadowPriest(character, options)
 	})
 }
 
 var ShadowWeavingDebuffID = core.NewDebuffID()
 var ShadowWeaverAuraID = core.NewAuraID()
 
-func NewShadowPriest(character core.Character, options proto.Player, isr proto.IndividualSimRequest) *ShadowPriest {
+func NewShadowPriest(character core.Character, options proto.Player) *ShadowPriest {
 	shadowOptions := options.GetShadowPriest()
 
 	// Only undead can do Dev Plague
@@ -123,6 +123,10 @@ type ShadowPriest struct {
 
 func (spriest *ShadowPriest) GetPriest() *priest.Priest {
 	return &spriest.Priest
+}
+
+func (spriest *ShadowPriest) GetPresimOptions() *core.PresimOptions {
+	return nil
 }
 
 func (spriest *ShadowPriest) Reset(sim *core.Simulation) {

--- a/sim/priest/shadow/spriest.go
+++ b/sim/priest/shadow/spriest.go
@@ -10,7 +10,7 @@ import (
 )
 
 func RegisterShadowPriest() {
-	core.RegisterAgentFactory(proto.PlayerOptions_ShadowPriest{}, func(character core.Character, options proto.PlayerOptions, isr proto.IndividualSimRequest) core.Agent {
+	core.RegisterAgentFactory(proto.Player_ShadowPriest{}, func(character core.Character, options proto.Player, isr proto.IndividualSimRequest) core.Agent {
 		return NewShadowPriest(character, options, isr)
 	})
 }
@@ -18,7 +18,7 @@ func RegisterShadowPriest() {
 var ShadowWeavingDebuffID = core.NewDebuffID()
 var ShadowWeaverAuraID = core.NewAuraID()
 
-func NewShadowPriest(character core.Character, options proto.PlayerOptions, isr proto.IndividualSimRequest) *ShadowPriest {
+func NewShadowPriest(character core.Character, options proto.Player, isr proto.IndividualSimRequest) *ShadowPriest {
 	shadowOptions := options.GetShadowPriest()
 
 	// Only undead can do Dev Plague

--- a/sim/priest/shadow/spriest.go
+++ b/sim/priest/shadow/spriest.go
@@ -125,10 +125,6 @@ func (spriest *ShadowPriest) GetPriest() *priest.Priest {
 	return &spriest.Priest
 }
 
-func (spriest *ShadowPriest) GetPresimOptions() *core.PresimOptions {
-	return nil
-}
-
 func (spriest *ShadowPriest) Reset(sim *core.Simulation) {
 	spriest.Priest.Reset(sim)
 	spriest.swStacks = 0

--- a/sim/priest/shadow/spriest_test.go
+++ b/sim/priest/shadow/spriest_test.go
@@ -17,17 +17,19 @@ func TestSimulateP1Basic(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceUndead,
+				Class:     proto.Class_ClassPriest,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsBasic,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceUndead,
-			Class:    proto.Class_ClassPriest,
-
-			PlayerOptions: PlayerOptionsBasic,
-			Gear:          P1Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 1184.4,
@@ -37,17 +39,19 @@ func TestSimulateP1Basic(t *testing.T) {
 
 func TestAverageDPS(t *testing.T) {
 	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
+		Player: &proto.Player{
+			Race:      proto.Race_RaceUndead,
+			Class:     proto.Class_ClassPriest,
+			Equipment: P1Gear,
+			Consumes:  FullConsumes,
+			Spec:      PlayerOptionsBasic,
+		},
+
 		RaidBuffs:       FullRaidBuffs,
 		PartyBuffs:      FullPartyBuffs,
 		IndividualBuffs: FullIndividualBuffs,
 
-		Consumes: FullConsumes,
-		Target:   FullDebuffTarget,
-		Race:     proto.Race_RaceUndead,
-		Class:    proto.Class_ClassPriest,
-
-		PlayerOptions: PlayerOptionsBasic,
-		Gear:          P1Gear,
+		Target: FullDebuffTarget,
 	})
 
 	core.IndividualSimAverageTest("P1Average", t, isr, 1189.5)

--- a/sim/shaman/elemental/elemental.go
+++ b/sim/shaman/elemental/elemental.go
@@ -11,12 +11,12 @@ import (
 )
 
 func RegisterElementalShaman() {
-	core.RegisterAgentFactory(proto.PlayerOptions_ElementalShaman{}, func(character core.Character, options proto.PlayerOptions, isr proto.IndividualSimRequest) core.Agent {
+	core.RegisterAgentFactory(proto.Player_ElementalShaman{}, func(character core.Character, options proto.Player, isr proto.IndividualSimRequest) core.Agent {
 		return NewElementalShaman(character, options, isr)
 	})
 }
 
-func NewElementalShaman(character core.Character, options proto.PlayerOptions, isr proto.IndividualSimRequest) *ElementalShaman {
+func NewElementalShaman(character core.Character, options proto.Player, isr proto.IndividualSimRequest) *ElementalShaman {
 	eleShamOptions := options.GetElementalShaman()
 
 	selfBuffs := SelfBuffs{
@@ -261,7 +261,7 @@ func NewAdaptiveRotation(isr proto.IndividualSimRequest) *AdaptiveRotation {
 	presimRequest := googleProto.Clone(&isr).(*proto.IndividualSimRequest)
 	presimRequest.SimOptions.Debug = false
 	presimRequest.SimOptions.Iterations = 100
-	presimRequest.Player.Options.Spec.(*proto.PlayerOptions_ElementalShaman).ElementalShaman.Rotation.Type = proto.ElementalShaman_Rotation_CLOnClearcast
+	presimRequest.Player.Spec.(*proto.Player_ElementalShaman).ElementalShaman.Rotation.Type = proto.ElementalShaman_Rotation_CLOnClearcast
 
 	presimResult := core.RunIndividualSim(presimRequest)
 

--- a/sim/shaman/elemental/elemental.go
+++ b/sim/shaman/elemental/elemental.go
@@ -7,16 +7,15 @@ import (
 	"github.com/wowsims/tbc/sim/core"
 	"github.com/wowsims/tbc/sim/core/proto"
 	. "github.com/wowsims/tbc/sim/shaman"
-	googleProto "google.golang.org/protobuf/proto"
 )
 
 func RegisterElementalShaman() {
-	core.RegisterAgentFactory(proto.Player_ElementalShaman{}, func(character core.Character, options proto.Player, isr proto.IndividualSimRequest) core.Agent {
-		return NewElementalShaman(character, options, isr)
+	core.RegisterAgentFactory(proto.Player_ElementalShaman{}, func(character core.Character, options proto.Player) core.Agent {
+		return NewElementalShaman(character, options)
 	})
 }
 
-func NewElementalShaman(character core.Character, options proto.Player, isr proto.IndividualSimRequest) *ElementalShaman {
+func NewElementalShaman(character core.Character, options proto.Player) *ElementalShaman {
 	eleShamOptions := options.GetElementalShaman()
 
 	selfBuffs := SelfBuffs{
@@ -31,7 +30,7 @@ func NewElementalShaman(character core.Character, options proto.Player, isr prot
 
 	switch eleShamOptions.Rotation.Type {
 	case proto.ElementalShaman_Rotation_Adaptive:
-		rotation = NewAdaptiveRotation(isr)
+		rotation = NewAdaptiveRotation()
 	case proto.ElementalShaman_Rotation_CLOnClearcast:
 		rotation = NewCLOnClearcastRotation()
 	case proto.ElementalShaman_Rotation_CLOnCD:
@@ -56,6 +55,10 @@ type ElementalShaman struct {
 
 func (eleShaman *ElementalShaman) GetShaman() *Shaman {
 	return &eleShaman.Shaman
+}
+
+func (eleShaman *ElementalShaman) GetPresimOptions() *core.PresimOptions {
+	return eleShaman.rotation.GetPresimOptions()
 }
 
 func (eleShaman *ElementalShaman) Reset(sim *core.Simulation) {
@@ -88,6 +91,8 @@ func (eleShaman *ElementalShaman) Act(sim *core.Simulation) time.Duration {
 
 // Picks which attacks / abilities the Shaman does.
 type Rotation interface {
+	GetPresimOptions() *core.PresimOptions
+
 	// Returns the action this rotation would like to take next.
 	ChooseAction(*ElementalShaman, *core.Simulation) AgentAction
 
@@ -112,6 +117,7 @@ func (rotation *LBOnlyRotation) ChooseAction(eleShaman *ElementalShaman, sim *co
 func (rotation *LBOnlyRotation) OnActionAccepted(eleShaman *ElementalShaman, sim *core.Simulation, action AgentAction) {
 }
 func (rotation *LBOnlyRotation) Reset(eleShaman *ElementalShaman, sim *core.Simulation) {}
+func (rotation *LBOnlyRotation) GetPresimOptions() *core.PresimOptions                  { return nil }
 
 func NewLBOnlyRotation() *LBOnlyRotation {
 	return &LBOnlyRotation{}
@@ -134,6 +140,7 @@ func (rotation *CLOnCDRotation) ChooseAction(eleShaman *ElementalShaman, sim *co
 func (rotation *CLOnCDRotation) OnActionAccepted(eleShaman *ElementalShaman, sim *core.Simulation, action AgentAction) {
 }
 func (rotation *CLOnCDRotation) Reset(eleShaman *ElementalShaman, sim *core.Simulation) {}
+func (rotation *CLOnCDRotation) GetPresimOptions() *core.PresimOptions                  { return nil }
 
 func NewCLOnCDRotation() *CLOnCDRotation {
 	return &CLOnCDRotation{}
@@ -177,6 +184,8 @@ func (rotation *FixedRotation) Reset(eleShaman *ElementalShaman, sim *core.Simul
 	rotation.numLBsSinceLastCL = rotation.numLBsPerCL // This lets us cast CL first
 }
 
+func (rotation *FixedRotation) GetPresimOptions() *core.PresimOptions { return nil }
+
 func NewFixedRotation(numLBsPerCL int32) *FixedRotation {
 	return &FixedRotation{
 		numLBsPerCL: numLBsPerCL,
@@ -206,6 +215,8 @@ func (rotation *CLOnClearcastRotation) OnActionAccepted(eleShaman *ElementalSham
 func (rotation *CLOnClearcastRotation) Reset(eleShaman *ElementalShaman, sim *core.Simulation) {
 	rotation.prevPrevCastProccedCC = true // Lets us cast CL first
 }
+
+func (rotation *CLOnClearcastRotation) GetPresimOptions() *core.PresimOptions { return nil }
 
 func NewCLOnClearcastRotation() *CLOnClearcastRotation {
 	return &CLOnClearcastRotation{}
@@ -243,37 +254,29 @@ func (rotation *AdaptiveRotation) Reset(eleShaman *ElementalShaman, sim *core.Si
 	rotation.surplusRotation.Reset(eleShaman, sim)
 }
 
-func NewAdaptiveRotation(isr proto.IndividualSimRequest) *AdaptiveRotation {
-	rotation := &AdaptiveRotation{
+func (rotation *AdaptiveRotation) GetPresimOptions() *core.PresimOptions {
+	return &core.PresimOptions{
+		SetPresimPlayerOptions: func(player *proto.Player) {
+			player.Spec.(*proto.Player_ElementalShaman).ElementalShaman.Rotation.Type = proto.ElementalShaman_Rotation_CLOnClearcast
+		},
+
+		OnPresimResult: func(presimResult proto.PlayerMetrics, iterations int32) bool {
+			if float64(presimResult.NumOom) >= float64(iterations)*0.05 {
+				rotation.baseRotation = NewLBOnlyRotation()
+				rotation.surplusRotation = NewCLOnClearcastRotation()
+			} else {
+				rotation.baseRotation = NewCLOnClearcastRotation()
+				rotation.surplusRotation = NewCLOnCDRotation()
+			}
+			return true
+		},
+	}
+}
+
+func NewAdaptiveRotation() *AdaptiveRotation {
+	return &AdaptiveRotation{
 		manaTracker: common.NewManaSpendingRateTracker(),
 	}
-
-	// If no encounter is set, it means we aren't going to run a sim at all.
-	// So just return something valid.
-	// TODO: Probably need some organized way of doing presims so we dont have
-	// to check these types of things.
-	if isr.Encounter == nil || len(isr.Encounter.Targets) == 0 {
-		rotation.baseRotation = NewLBOnlyRotation()
-		rotation.surplusRotation = NewCLOnClearcastRotation()
-		return rotation
-	}
-
-	presimRequest := googleProto.Clone(&isr).(*proto.IndividualSimRequest)
-	presimRequest.SimOptions.Debug = false
-	presimRequest.SimOptions.Iterations = 100
-	presimRequest.Player.Spec.(*proto.Player_ElementalShaman).ElementalShaman.Rotation.Type = proto.ElementalShaman_Rotation_CLOnClearcast
-
-	presimResult := core.RunIndividualSim(presimRequest)
-
-	if presimResult.PlayerMetrics.NumOom >= 5 {
-		rotation.baseRotation = NewLBOnlyRotation()
-		rotation.surplusRotation = NewCLOnClearcastRotation()
-	} else {
-		rotation.baseRotation = NewCLOnClearcastRotation()
-		rotation.surplusRotation = NewCLOnCDRotation()
-	}
-
-	return rotation
 }
 
 // A single action that an Agent can take.

--- a/sim/shaman/elemental/elemental_test.go
+++ b/sim/shaman/elemental/elemental_test.go
@@ -15,16 +15,17 @@ func init() {
 
 func TestP1FullCharacterStats(t *testing.T) {
 	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
-		Gear:     P1Gear,
-		Race:     proto.Race_RaceTroll10,
-		Class:    proto.Class_ClassShaman,
-		Consumes: FullConsumes,
+		Player: &proto.Player{
+			Race:      proto.Race_RaceTroll10,
+			Class:     proto.Class_ClassShaman,
+			Equipment: P1Gear,
+			Consumes:  FullConsumes,
+			Spec:      PlayerOptionsAdaptive,
+		},
 
 		RaidBuffs:       FullRaidBuffs,
 		PartyBuffs:      FullPartyBuffs,
 		IndividualBuffs: FullIndividualBuffs,
-
-		PlayerOptions: PlayerOptionsAdaptive,
 	})
 
 	core.CharacterStatsTest("p1Full", t, isr, stats.Stats{
@@ -63,17 +64,19 @@ var ReferenceStat = proto.Stat_StatSpellPower
 
 func TestCalcStatWeight(t *testing.T) {
 	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
-		Gear:     P1Gear,
-		Race:     proto.Race_RaceTroll10,
-		Class:    proto.Class_ClassShaman,
-		Consumes: FullConsumes,
+		Player: &proto.Player{
+			Race:      proto.Race_RaceTroll10,
+			Class:     proto.Class_ClassShaman,
+			Equipment: P1Gear,
+			Consumes:  FullConsumes,
+			Spec:      PlayerOptionsAdaptive,
+		},
 
 		RaidBuffs:       FullRaidBuffs,
 		PartyBuffs:      FullPartyBuffs,
 		IndividualBuffs: FullIndividualBuffs,
 
-		Target:        FullDebuffTarget,
-		PlayerOptions: PlayerOptionsAdaptive,
+		Target: FullDebuffTarget,
 	})
 
 	core.StatWeightsTest("p1Full", t, isr, StatsToTest, ReferenceStat, stats.Stats{
@@ -90,18 +93,19 @@ func TestSimulatePreRaidNoBuffs(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
-			// no consumes
+			Player: &proto.Player{
+				Race:      proto.Race_RaceTroll10,
+				Class:     proto.Class_ClassShaman,
+				Equipment: PreRaidGear,
+				// no consumes
+				Spec: PlayerOptionsAdaptiveNoBuffs,
+			},
+
 			RaidBuffs:       BasicRaidBuffs,
 			PartyBuffs:      BasicPartyBuffs,
 			IndividualBuffs: BasicIndividualBuffs,
 
 			Target: NoDebuffTarget,
-
-			Race:  proto.Race_RaceTroll10,
-			Class: proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsAdaptiveNoBuffs,
-			Gear:          PreRaidGear,
 		},
 
 		ExpectedDpsShort: 994.9,
@@ -115,17 +119,19 @@ func TestSimulatePreRaid(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceOrc,
+				Class:     proto.Class_ClassShaman,
+				Equipment: PreRaidGear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsAdaptive,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceOrc,
-			Class:    proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsAdaptive,
-			Gear:          PreRaidGear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 1557.8,
@@ -139,17 +145,19 @@ func TestSimulateP1(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceOrc,
+				Class:     proto.Class_ClassShaman,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsAdaptive,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceOrc,
-			Class:    proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsAdaptive,
-			Gear:          P1Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 2166.0,
@@ -162,22 +170,24 @@ func TestMultiTarget(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceOrc,
+				Class:     proto.Class_ClassShaman,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsAdaptive,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
 			Targets: []*proto.Target{
 				FullDebuffTarget,
 				NoDebuffTarget,
 				NoDebuffTarget,
 				NoDebuffTarget,
 			},
-			Race:  proto.Race_RaceOrc,
-			Class: proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsAdaptive,
-			Gear:          P1Gear,
 		},
 
 		ExpectedDpsShort: 2684.5,
@@ -189,22 +199,24 @@ func TestMultiTarget(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceOrc,
+				Class:     proto.Class_ClassShaman,
+				Equipment: P1Tidefury,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsAdaptive,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
 			Targets: []*proto.Target{
 				FullDebuffTarget,
 				NoDebuffTarget,
 				NoDebuffTarget,
 				NoDebuffTarget,
 			},
-			Race:  proto.Race_RaceOrc,
-			Class: proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsAdaptive,
-			Gear:          P1Tidefury,
 		},
 
 		ExpectedDpsShort: 2731.0,
@@ -218,17 +230,19 @@ func TestLBOnlyAgent(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceOrc,
+				Class:     proto.Class_ClassShaman,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsLBOnly,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceOrc,
-			Class:    proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsLBOnly,
-			Gear:          P1Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 2041.9,
@@ -256,17 +270,19 @@ func TestClearcastAgent(t *testing.T) {
 		T:     t,
 
 		Inputs: core.IndividualSimInputs{
+			Player: &proto.Player{
+				Race:      proto.Race_RaceOrc,
+				Class:     proto.Class_ClassShaman,
+				Equipment: P1Gear,
+				Consumes:  FullConsumes,
+				Spec:      PlayerOptionsCLOnClearcast,
+			},
+
 			RaidBuffs:       FullRaidBuffs,
 			PartyBuffs:      FullPartyBuffs,
 			IndividualBuffs: FullIndividualBuffs,
 
-			Consumes: FullConsumes,
-			Target:   FullDebuffTarget,
-			Race:     proto.Race_RaceOrc,
-			Class:    proto.Class_ClassShaman,
-
-			PlayerOptions: PlayerOptionsCLOnClearcast,
-			Gear:          P1Gear,
+			Target: FullDebuffTarget,
 		},
 
 		ExpectedDpsShort: 2135.3,
@@ -276,17 +292,19 @@ func TestClearcastAgent(t *testing.T) {
 
 func TestAverageDPS(t *testing.T) {
 	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
-		Gear:     P1Gear,
-		Race:     proto.Race_RaceOrc,
-		Class:    proto.Class_ClassShaman,
-		Consumes: FullConsumes,
+		Player: &proto.Player{
+			Race:      proto.Race_RaceOrc,
+			Class:     proto.Class_ClassShaman,
+			Equipment: P1Gear,
+			Consumes:  FullConsumes,
+			Spec:      PlayerOptionsAdaptive,
+		},
 
 		RaidBuffs:       FullRaidBuffs,
 		PartyBuffs:      FullPartyBuffs,
 		IndividualBuffs: FullIndividualBuffs,
 
-		Target:        FullDebuffTarget,
-		PlayerOptions: PlayerOptionsAdaptive,
+		Target: FullDebuffTarget,
 	})
 
 	core.IndividualSimAverageTest("P1Average", t, isr, 1581.5)
@@ -294,18 +312,19 @@ func TestAverageDPS(t *testing.T) {
 
 func BenchmarkSimulate(b *testing.B) {
 	isr := core.NewIndividualSimRequest(core.IndividualSimInputs{
-		Gear:     P1Gear,
-		Race:     proto.Race_RaceOrc,
-		Class:    proto.Class_ClassShaman,
-		Consumes: FullConsumes,
+		Player: &proto.Player{
+			Race:      proto.Race_RaceOrc,
+			Class:     proto.Class_ClassShaman,
+			Equipment: P1Gear,
+			Consumes:  FullConsumes,
+			Spec:      PlayerOptionsAdaptive,
+		},
 
 		RaidBuffs:       FullRaidBuffs,
 		PartyBuffs:      FullPartyBuffs,
 		IndividualBuffs: FullIndividualBuffs,
 
 		Target: FullDebuffTarget,
-
-		PlayerOptions: PlayerOptionsAdaptive,
 	})
 
 	core.IndividualBenchmark(b, isr)

--- a/sim/shaman/elemental/presets.go
+++ b/sim/shaman/elemental/presets.go
@@ -24,9 +24,9 @@ var StandardTalents = &proto.ShamanTalents{
 	LightningOverload:  5,
 	TotemOfWrath:       true,
 
-	TotemicFocus:       5,
-	NaturesGuidance:    3,
-	TidalMastery:       5,
+	TotemicFocus:    5,
+	NaturesGuidance: 3,
+	TidalMastery:    5,
 }
 
 var eleShamOptionsNoBuffs = &proto.ElementalShaman_Options{
@@ -36,14 +36,12 @@ var eleShamOptionsNoBuffs = &proto.ElementalShaman_Options{
 	// TotemOfWrath:    true,
 	// WrathOfAirTotem: true,
 }
-var PlayerOptionsAdaptiveNoBuffs = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_ElementalShaman{
-		ElementalShaman: &proto.ElementalShaman{
-			Talents: StandardTalents,
-			Options: eleShamOptionsNoBuffs,
-			Rotation: &proto.ElementalShaman_Rotation{
-				Type: proto.ElementalShaman_Rotation_Adaptive,
-			},
+var PlayerOptionsAdaptiveNoBuffs = &proto.Player_ElementalShaman{
+	ElementalShaman: &proto.ElementalShaman{
+		Talents: StandardTalents,
+		Options: eleShamOptionsNoBuffs,
+		Rotation: &proto.ElementalShaman_Rotation{
+			Type: proto.ElementalShaman_Rotation_Adaptive,
 		},
 	},
 }
@@ -55,38 +53,32 @@ var eleShamOptions = &proto.ElementalShaman_Options{
 	TotemOfWrath:    true,
 	WrathOfAirTotem: true,
 }
-var PlayerOptionsAdaptive = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_ElementalShaman{
-		ElementalShaman: &proto.ElementalShaman{
-			Talents: StandardTalents,
-			Options: eleShamOptions,
-			Rotation: &proto.ElementalShaman_Rotation{
-				Type: proto.ElementalShaman_Rotation_Adaptive,
-			},
+var PlayerOptionsAdaptive = &proto.Player_ElementalShaman{
+	ElementalShaman: &proto.ElementalShaman{
+		Talents: StandardTalents,
+		Options: eleShamOptions,
+		Rotation: &proto.ElementalShaman_Rotation{
+			Type: proto.ElementalShaman_Rotation_Adaptive,
 		},
 	},
 }
 
-var PlayerOptionsLBOnly = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_ElementalShaman{
-		ElementalShaman: &proto.ElementalShaman{
-			Talents: StandardTalents,
-			Options: eleShamOptions,
-			Rotation: &proto.ElementalShaman_Rotation{
-				Type: proto.ElementalShaman_Rotation_LBOnly,
-			},
+var PlayerOptionsLBOnly = &proto.Player_ElementalShaman{
+	ElementalShaman: &proto.ElementalShaman{
+		Talents: StandardTalents,
+		Options: eleShamOptions,
+		Rotation: &proto.ElementalShaman_Rotation{
+			Type: proto.ElementalShaman_Rotation_LBOnly,
 		},
 	},
 }
 
-var PlayerOptionsCLOnClearcast = &proto.PlayerOptions{
-	Spec: &proto.PlayerOptions_ElementalShaman{
-		ElementalShaman: &proto.ElementalShaman{
-			Talents: StandardTalents,
-			Options: eleShamOptions,
-			Rotation: &proto.ElementalShaman_Rotation{
-				Type: proto.ElementalShaman_Rotation_CLOnClearcast,
-			},
+var PlayerOptionsCLOnClearcast = &proto.Player_ElementalShaman{
+	ElementalShaman: &proto.ElementalShaman{
+		Talents: StandardTalents,
+		Options: eleShamOptions,
+		Rotation: &proto.ElementalShaman_Rotation{
+			Type: proto.ElementalShaman_Rotation_CLOnClearcast,
 		},
 	},
 }

--- a/sim/web/main_test.go
+++ b/sim/web/main_test.go
@@ -13,7 +13,7 @@ import (
 	googleProto "google.golang.org/protobuf/proto"
 )
 
-var basicSpec = &proto.PlayerOptions_ElementalShaman{
+var basicSpec = &proto.Player_ElementalShaman{
 	ElementalShaman: &proto.ElementalShaman{
 		Rotation: &proto.ElementalShaman_Rotation{
 			Type: proto.ElementalShaman_Rotation_Adaptive,
@@ -80,13 +80,11 @@ func init() {
 func TestIndividualSim(t *testing.T) {
 	req := &proto.IndividualSimRequest{
 		Player: &proto.Player{
-			Options: &proto.PlayerOptions{
-				Race:     proto.Race_RaceTroll10,
-				Class:    proto.Class_ClassShaman,
-				Spec:     basicSpec,
-				Consumes: basicConsumes,
-			},
+			Race:      proto.Race_RaceTroll10,
+			Class:     proto.Class_ClassShaman,
 			Equipment: p1Equip,
+			Consumes:  basicConsumes,
+			Spec:      basicSpec,
 		},
 		RaidBuffs:       &proto.RaidBuffs{},
 		PartyBuffs:      &proto.PartyBuffs{},
@@ -132,12 +130,10 @@ func TestIndividualSim(t *testing.T) {
 func TestCalcStatWeight(t *testing.T) {
 	req := &proto.IndividualSimRequest{
 		Player: &proto.Player{
-			Options: &proto.PlayerOptions{
-				Race:     proto.Race_RaceTroll10,
-				Spec:     basicSpec,
-				Consumes: basicConsumes,
-			},
+			Race:      proto.Race_RaceTroll10,
 			Equipment: p1Equip,
+			Consumes:  basicConsumes,
+			Spec:      basicSpec,
 		},
 		RaidBuffs:       &proto.RaidBuffs{},
 		PartyBuffs:      &proto.PartyBuffs{},

--- a/sim/web/main_test.go
+++ b/sim/web/main_test.go
@@ -86,9 +86,6 @@ func TestIndividualSim(t *testing.T) {
 			Consumes:  basicConsumes,
 			Spec:      basicSpec,
 		},
-		RaidBuffs:       &proto.RaidBuffs{},
-		PartyBuffs:      &proto.PartyBuffs{},
-		IndividualBuffs: &proto.IndividualBuffs{},
 		Encounter: &proto.Encounter{
 			Duration: 120,
 			Targets: []*proto.Target{
@@ -135,9 +132,6 @@ func TestCalcStatWeight(t *testing.T) {
 			Consumes:  basicConsumes,
 			Spec:      basicSpec,
 		},
-		RaidBuffs:       &proto.RaidBuffs{},
-		PartyBuffs:      &proto.PartyBuffs{},
-		IndividualBuffs: &proto.IndividualBuffs{},
 		Encounter: &proto.Encounter{
 			Duration: 120,
 			Targets: []*proto.Target{

--- a/ui/core/components/_bonus_stats_picker.scss
+++ b/ui/core/components/_bonus_stats_picker.scss
@@ -1,24 +1,24 @@
-.custom-stats-root {
+.bonus-stats-root {
   margin: 10px;
 }
 
-.custom-stats-label {
+.bonus-stats-label {
   font-size: 18px;
   font-weight: 700;
 }
 
-.custom-stats-root .number-picker-root {
+.bonus-stats-root .number-picker-root {
   display: flex;
   align-items: center;
 }
 
-.custom-stats-root .number-picker-root.positive .input-label {
+.bonus-stats-root .number-picker-root.positive .input-label {
 	color: lawngreen;
 	font-weight: bold;
 	text-shadow: 2px 2px 3px black;
 }
 
-.custom-stats-root .number-picker-root.negative .input-label {
+.bonus-stats-root .number-picker-root.negative .input-label {
 	color: red;
 	font-weight: bold;
 	text-shadow: 2px 2px 3px black;

--- a/ui/core/components/bonus_stats_picker.ts
+++ b/ui/core/components/bonus_stats_picker.ts
@@ -8,16 +8,16 @@ import { NumberPicker } from './number_picker.js';
 
 declare var tippy: any;
 
-export class CustomStatsPicker extends Component {
+export class BonusStatsPicker extends Component {
   readonly stats: Array<Stat>;
   readonly statPickers: Array<NumberPicker<Player<any>>>;
 
   constructor(parent: HTMLElement, player: Player<any>, stats: Array<Stat>) {
-    super(parent, 'custom-stats-root');
+    super(parent, 'bonus-stats-root');
     this.stats = stats;
 
     const label = document.createElement('span');
-    label.classList.add('custom-stats-label');
+    label.classList.add('bonus-stats-label');
     label.textContent = 'Bonus Stats';
 		tippy(label, {
 			'content': 'Extra stats to add on top of gear, buffs, etc.',
@@ -27,15 +27,15 @@ export class CustomStatsPicker extends Component {
 
     this.statPickers = this.stats.map(stat => new NumberPicker(this.rootElem, player, {
       label: statNames[stat],
-      changedEvent: (player: Player<any>) => player.customStatsChangeEmitter,
-      getValue: (player: Player<any>) => player.getCustomStats().getStat(stat),
+      changedEvent: (player: Player<any>) => player.bonusStatsChangeEmitter,
+      getValue: (player: Player<any>) => player.getBonusStats().getStat(stat),
       setValue: (player: Player<any>, newValue: number) => {
-        const customStats = player.getCustomStats().withStat(stat, newValue);
-        player.setCustomStats(customStats);
+        const bonusStats = player.getBonusStats().withStat(stat, newValue);
+        player.setBonusStats(bonusStats);
       },
     }));
 
-		player.customStatsChangeEmitter.on(() => {
+		player.bonusStatsChangeEmitter.on(() => {
 			this.statPickers.forEach(statPicker => {
 				if (statPicker.getInputValue() > 0) {
 					statPicker.rootElem.classList.remove('negative');

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -14,7 +14,6 @@ import { Race } from '/tbc/core/proto/common.js';
 import { Spec } from '/tbc/core/proto/common.js';
 import { Stat } from '/tbc/core/proto/common.js';
 import { Player as PlayerProto } from '/tbc/core/proto/api.js';
-import { PlayerOptions as PlayerOptionsProto } from '/tbc/core/proto/api.js';
 import { ComputeStatsRequest, ComputeStatsResult } from '/tbc/core/proto/api.js';
 import { StatWeightsRequest, StatWeightsResult } from '/tbc/core/proto/api.js';
 

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -152,7 +152,6 @@ export class Player<SpecType extends Spec> {
 			player: this.toProto(),
 			raidBuffs: this.sim.getRaidBuffs(),
 			partyBuffs: this.sim.getPartyBuffs(),
-			individualBuffs: this.sim.getIndividualBuffs(),
 		}));
 
 		this.currentStats = computeStatsResult;
@@ -343,6 +342,7 @@ export class Player<SpecType extends Spec> {
 					equipment: this.getGear().asSpec(),
 					consumes: this.getConsumes(),
 					bonusStats: this.getBonusStats().asArray(),
+					buffs: this.sim.getIndividualBuffs(),
 				}),
 				this.getRotation(),
 				this.getTalents(),

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -372,6 +372,11 @@ export class Player<SpecType extends Spec> {
 			console.warn('Failed to parse consumes: ' + e);
 		}
 
+		// For legacy format. Do not remove this until 2022/01/02 (1 month).
+		if (obj['customStats']) {
+			obj['bonusStats'] = obj['customStats'];
+		}
+
 		try {
 			this.setBonusStats(Stats.fromJson(obj['bonusStats']));
 		} catch (e) {

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -54,7 +54,7 @@ export class Player<SpecType extends Spec> {
 
   readonly spec: Spec;
   private consumes: Consumes = Consumes.create();
-  private customStats: Stats = new Stats();
+  private bonusStats: Stats = new Stats();
   private gear: Gear = new Gear({});
   private race: Race;
   private rotation: SpecRotation<SpecType>;
@@ -68,7 +68,7 @@ export class Player<SpecType extends Spec> {
 	private currentStats: ComputeStatsResult;
 
   readonly consumesChangeEmitter = new TypedEvent<void>();
-  readonly customStatsChangeEmitter = new TypedEvent<void>();
+  readonly bonusStatsChangeEmitter = new TypedEvent<void>();
   readonly gearChangeEmitter = new TypedEvent<void>();
   readonly raceChangeEmitter = new TypedEvent<void>();
   readonly rotationChangeEmitter = new TypedEvent<void>();
@@ -94,7 +94,7 @@ export class Player<SpecType extends Spec> {
 
     [
       this.consumesChangeEmitter,
-      this.customStatsChangeEmitter,
+      this.bonusStatsChangeEmitter,
       this.gearChangeEmitter,
       this.raceChangeEmitter,
       this.rotationChangeEmitter,
@@ -216,16 +216,16 @@ export class Player<SpecType extends Spec> {
     this.gearChangeEmitter.emit();
   }
 
-  getCustomStats(): Stats {
-    return this.customStats;
+  getBonusStats(): Stats {
+    return this.bonusStats;
   }
 
-  setCustomStats(newCustomStats: Stats) {
-    if (newCustomStats.equals(this.customStats))
+  setBonusStats(newBonusStats: Stats) {
+    if (newBonusStats.equals(this.bonusStats))
       return;
 
-    this.customStats = newCustomStats;
-    this.customStatsChangeEmitter.emit();
+    this.bonusStats = newBonusStats;
+    this.bonusStatsChangeEmitter.emit();
   }
 
   getRotation(): SpecRotation<SpecType> {
@@ -336,15 +336,17 @@ export class Player<SpecType extends Spec> {
   }
 
 	toProto(): PlayerProto {
-    return PlayerProto.create({
-      customStats: this.getCustomStats().asArray(),
-      equipment: this.getGear().asSpec(),
-      options: withSpecProto(PlayerOptionsProto.create({
-        race: this.getRace(),
-        class: specToClass[this.spec],
-        consumes: this.getConsumes(),
-      }), this.getRotation(), this.getTalents(), this.getSpecOptions()),
-    });
+    return withSpecProto(
+				PlayerProto.create({
+					race: this.getRace(),
+					class: specToClass[this.spec],
+					equipment: this.getGear().asSpec(),
+					consumes: this.getConsumes(),
+					bonusStats: this.getBonusStats().asArray(),
+				}),
+				this.getRotation(),
+				this.getTalents(),
+				this.getSpecOptions());
 	}
 
 	// TODO: Remove to/from json functions and use proto versions instead. This will require
@@ -353,7 +355,7 @@ export class Player<SpecType extends Spec> {
   toJson(): Object {
     return {
       'consumes': Consumes.toJson(this.consumes),
-      'customStats': this.customStats.toJson(),
+      'bonusStats': this.bonusStats.toJson(),
       'gear': EquipmentSpec.toJson(this.gear.asSpec()),
       'race': this.race,
       'rotation': this.specTypeFunctions.rotationToJson(this.rotation),
@@ -371,9 +373,9 @@ export class Player<SpecType extends Spec> {
 		}
 
 		try {
-			this.setCustomStats(Stats.fromJson(obj['customStats']));
+			this.setBonusStats(Stats.fromJson(obj['bonusStats']));
 		} catch (e) {
-			console.warn('Failed to parse custom stats: ' + e);
+			console.warn('Failed to parse bonus stats: ' + e);
 		}
 
 		try {

--- a/ui/core/proto_utils/utils.ts
+++ b/ui/core/proto_utils/utils.ts
@@ -1,7 +1,6 @@
 import { intersection } from '/tbc/core/utils.js';
 
 import { Player } from '/tbc/core/proto/api.js';
-import { PlayerOptions } from '/tbc/core/proto/api.js';
 import { ArmorType } from '/tbc/core/proto/common.js';
 import { Class } from '/tbc/core/proto/common.js';
 import { Enchant } from '/tbc/core/proto/common.js';
@@ -496,11 +495,11 @@ export const specToLocalStorageKey: Record<Spec, string> = {
 
 // Returns a copy of playerOptions, with the class field set.
 export function withSpecProto<SpecType extends Spec>(
-    playerOptions: PlayerOptions,
+    player: Player,
     rotation: SpecRotation<SpecType>,
     talents: SpecTalents<SpecType>,
-    specOptions: SpecOptions<SpecType>): PlayerOptions {
-  const copy = PlayerOptions.clone(playerOptions);
+    specOptions: SpecOptions<SpecType>): Player {
+  const copy = Player.clone(player);
   if (BalanceDruidRotation.is(rotation)) {
 		copy.class = Class.ClassDruid;
     copy.spec = {
@@ -592,7 +591,7 @@ export function withSpecProto<SpecType extends Spec>(
       }),
     };
   } else {
-    throw new Error('Unrecognized talents with options: ' + PlayerOptions.toJsonString(playerOptions));
+    throw new Error('Unrecognized talents with options: ' + Player.toJsonString(player));
   }
   return copy;
 }

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -17,7 +17,6 @@ import { Race } from '/tbc/core/proto/common.js';
 import { Spec } from '/tbc/core/proto/common.js';
 import { Stat } from '/tbc/core/proto/common.js';
 import { Player } from '/tbc/core/proto/api.js';
-import { PlayerOptions } from '/tbc/core/proto/api.js';
 import { GearListRequest, GearListResult } from '/tbc/core/proto/api.js';
 import { IndividualSimRequest, IndividualSimResult } from '/tbc/core/proto/api.js';
 import { StatWeightsRequest, StatWeightsResult } from '/tbc/core/proto/api.js';

--- a/ui/core/sim_ui.ts
+++ b/ui/core/sim_ui.ts
@@ -261,7 +261,6 @@ export abstract class SimUI<SpecType extends Spec> {
 			player: this.player.toProto(),
 			raidBuffs: this.sim.getRaidBuffs(),
 			partyBuffs: this.sim.getPartyBuffs(),
-			individualBuffs: this.sim.getIndividualBuffs(),
 			encounter: this.encounter.toProto(),
 			simOptions: SimOptions.create({
 				iterations: iterations,

--- a/ui/core/themes/_default.scss
+++ b/ui/core/themes/_default.scss
@@ -1,7 +1,7 @@
 @import "../components/actions";
 @import "../components/boolean_picker";
 @import "../components/character_stats";
-@import "../components/custom_stats_picker";
+@import "../components/bonus_stats_picker";
 @import "../components/detailed_results";
 @import "../components/encounter_picker";
 @import "../components/enum_picker";
@@ -177,13 +177,13 @@ td, th {
   position: relative;
 }
 
-.custom-stats-root {
+.bonus-stats-root {
   justify-content: end;
   text-align: right;
 	color: var(--main-text-color);
 }
 
-.custom-stats-root .number-picker-root {
+.bonus-stats-root .number-picker-root {
   justify-content: end;
 }
 

--- a/ui/core/themes/default.ts
+++ b/ui/core/themes/default.ts
@@ -5,7 +5,7 @@ import { Target } from '/tbc/core/target.js';
 import { Actions } from '/tbc/core/components/actions.js';
 import { BooleanPicker, BooleanPickerConfig } from '/tbc/core/components/boolean_picker.js';
 import { CharacterStats } from '/tbc/core/components/character_stats.js';
-import { CustomStatsPicker } from '/tbc/core/components/custom_stats_picker.js';
+import { BonusStatsPicker } from '/tbc/core/components/bonus_stats_picker.js';
 import { DetailedResults } from '/tbc/core/components/detailed_results.js';
 import { EncounterPicker, EncounterPickerConfig } from '/tbc/core/components/encounter_picker.js';
 import { EnumPicker, EnumPickerConfig } from '/tbc/core/components/enum_picker.js';
@@ -93,7 +93,7 @@ export interface DefaultThemeConfig<SpecType extends Spec> extends SimUIConfig<S
 
 export interface GearAndStats {
   gear: Gear,
-  customStats?: Stats,
+  bonusStats?: Stats,
 }
 
 export interface PresetGear {
@@ -135,7 +135,7 @@ export class DefaultTheme<SpecType extends Spec> extends SimUI<SpecType> {
     const characterStats = new CharacterStats(this.parentElem.getElementsByClassName('default-stats')[0] as HTMLElement, config.displayStats, this.player);
 
     const gearPicker = new GearPicker(this.parentElem.getElementsByClassName('gear-picker')[0] as HTMLElement, this.player);
-    const customStatsPicker = new CustomStatsPicker(this.parentElem.getElementsByClassName('custom-stats-picker')[0] as HTMLElement, this.player, config.epStats);
+    const bonusStatsPicker = new BonusStatsPicker(this.parentElem.getElementsByClassName('bonus-stats-picker')[0] as HTMLElement, this.player, config.epStats);
 
     const talentsPicker = newTalentsPicker(this.player.spec, this.parentElem.getElementsByClassName('talents-picker')[0] as HTMLElement, this.player);
 		// Add a url parameter to help people trapped in the wrong talents   ;)
@@ -236,27 +236,27 @@ export class DefaultTheme<SpecType extends Spec> extends SimUI<SpecType> {
       getData: (player: Player<any>) => {
         return {
           gear: player.getGear(),
-          customStats: player.getCustomStats(),
+          bonusStats: player.getBonusStats(),
         };
       },
       setData: (player: Player<any>, newGearAndStats: GearAndStats) => {
         player.setGear(newGearAndStats.gear);
-				if (newGearAndStats.customStats) {
-					player.setCustomStats(newGearAndStats.customStats);
+				if (newGearAndStats.bonusStats) {
+					player.setBonusStats(newGearAndStats.bonusStats);
 				}
       },
       changeEmitters: [this.player.changeEmitter],
-      equals: (a: GearAndStats, b: GearAndStats) => a.gear.equals(b.gear) && equalsOrBothNull(a.customStats, b.customStats, (a, b) => a.equals(b)),
+      equals: (a: GearAndStats, b: GearAndStats) => a.gear.equals(b.gear) && equalsOrBothNull(a.bonusStats, b.bonusStats, (a, b) => a.equals(b)),
       toJson: (a: GearAndStats) => {
         return {
           gear: EquipmentSpec.toJson(a.gear.asSpec()),
-          customStats: a.customStats?.toJson(),
+          bonusStats: a.bonusStats?.toJson(),
         };
       },
       fromJson: (obj: any) => {
         return {
           gear: this.sim.lookupEquipmentSpec(EquipmentSpec.fromJson(obj['gear'])),
-          customStats: Stats.fromJson(obj['customStats']),
+          bonusStats: Stats.fromJson(obj['bonusStats']),
         };
       },
     });
@@ -359,7 +359,7 @@ export class DefaultTheme<SpecType extends Spec> extends SimUI<SpecType> {
 				isPreset: true,
 				data: {
 					gear: this.sim.lookupEquipmentSpec(presetGear.gear),
-					customStats: new Stats(),
+					bonusStats: new Stats(),
 				},
 				enableWhen: presetGear.enableWhen,
 			});
@@ -409,7 +409,7 @@ const layoutHTML = `
             </div>
           </div>
           <div class="right-gear-panel">
-            <div class="custom-stats-picker">
+            <div class="bonus-stats-picker">
             </div>
             <div class="saved-gear-manager">
             </div>

--- a/ui/core/worker_pool.ts
+++ b/ui/core/worker_pool.ts
@@ -11,6 +11,7 @@ import { Stat } from './proto/common.js';
 import { ComputeStatsRequest, ComputeStatsResult } from './proto/api.js';
 import { GearListRequest, GearListResult } from './proto/api.js';
 import { IndividualSimRequest, IndividualSimResult } from './proto/api.js';
+import { RaidSimRequest, RaidSimResult } from './proto/api.js';
 import { StatWeightsRequest, StatWeightsResult } from './proto/api.js';
 
 import { repoName } from './resources.js';
@@ -57,6 +58,14 @@ export class WorkerPool {
 		const resultData = await this.makeApiCall('individualSim', IndividualSimRequest.toBinary(request));
 		const result = IndividualSimResult.fromBinary(resultData);
     console.log('Individual sim result: ' + IndividualSimResult.toJsonString(result));
+		return result;
+  }
+
+  async raidSim(request: RaidSimRequest): Promise<RaidSimResult> {
+    console.log('Raid sim request: ' + RaidSimRequest.toJsonString(request));
+		const resultData = await this.makeApiCall('raidSim', RaidSimRequest.toBinary(request));
+		const result = RaidSimResult.fromBinary(resultData);
+    console.log('Raid sim result: ' + RaidSimResult.toJsonString(result));
 		return result;
   }
 }

--- a/ui/worker/sim_worker.js
+++ b/ui/worker/sim_worker.js
@@ -618,6 +618,7 @@ addEventListener('message', async (e) => {
 		['computeStats', computeStats],
 		['gearList', gearList],
 		['individualSim', individualSim],
+		['raidSim', raidSim],
 		['statWeights', statWeights],
 	].forEach(funcData => {
 		const funcName = funcData[0];


### PR DESCRIPTION
To implement this I had to make a few design changes:

 - Moved raid/party/individual buffs to be on the raid/party/player protos.
 - Refactored presim logic entirely to be managed by the Sim.
 - Merged Player/PlayerOptions protos (this was not mandatory, just wanted to do it).

Also renamed custom_stats --> bonus_stats on the proto to be more consistent with its purpose.