### PR TITLE
vigo/normalizedWeaponDamage

### DIFF
--- a/sim/common/melee_sets.go
+++ b/sim/common/melee_sets.go
@@ -92,8 +92,7 @@ var ItemSetFistsOfFury = core.ItemSet{
 			spellObj := core.SimpleSpell{}
 
 			character.AddPermanentAura(func(sim *core.Simulation) core.Aura {
-				// TODO: Get real numbers for this.
-				ppmm := character.AutoAttacks.NewPPMManager(1.0)
+				ppmm := character.AutoAttacks.NewPPMManager(2)
 
 				castTemplate := core.NewSimpleSpellTemplate(core.SimpleSpell{
 					SpellCast: core.SpellCast{

--- a/sim/core/attack_test.go
+++ b/sim/core/attack_test.go
@@ -24,7 +24,7 @@ func TestAutoSwing(t *testing.T) {
 			Targets: []*Target{{}},
 		},
 		isTest:            true,
-		testRands:         make(map[uint32]*rand.Rand),
+		testRands:         make(map[string]*rand.Rand),
 		emptyAuras:        make([]Aura, numAuraIDs),
 		pendingActionPool: newPAPool(),
 	}
@@ -67,7 +67,7 @@ func TestRangedAutoSwing(t *testing.T) {
 			Targets: []*Target{{}},
 		},
 		isTest:            true,
-		testRands:         make(map[uint32]*rand.Rand),
+		testRands:         make(map[string]*rand.Rand),
 		emptyAuras:        make([]Aura, numAuraIDs),
 		pendingActionPool: newPAPool(),
 	}

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -146,27 +146,28 @@ func (cast *Cast) init(sim *Simulation) {
 // Start casting the spell. Return value indicates whether the spell successfully
 // started casting.
 func (cast *Cast) startCasting(sim *Simulation, onCastComplete OnCastComplete) bool {
-
-	switch cast.Cost.Type {
-	case stats.Mana:
-		if cast.Character.CurrentMana() < cast.Cost.Value {
-			if sim.Log != nil {
-				cast.Character.Log(sim, "Failed casting %s, not enough mana. (Current Mana = %0.03f, Mana Cost = %0.03f)",
-					cast.ActionID, cast.Character.CurrentMana(), cast.Cost.Value)
+	if cast.Cost.Value > 0 {
+		switch cast.Cost.Type {
+		case stats.Mana:
+			if cast.Character.CurrentMana() < cast.Cost.Value {
+				if sim.Log != nil {
+					cast.Character.Log(sim, "Failed casting %s, not enough mana. (Current Mana = %0.03f, Mana Cost = %0.03f)",
+						cast.ActionID, cast.Character.CurrentMana(), cast.Cost.Value)
+				}
+				cast.objectInUse = false
+				return false
 			}
-			cast.objectInUse = false
-			return false
+		case stats.Rage:
+			if cast.Character.CurrentRage() < cast.Cost.Value {
+				return false
+			}
+			cast.Character.SpendRage(sim, cast.Cost.Value, cast.ActionID)
+		case stats.Energy:
+			if cast.Character.CurrentEnergy() < cast.Cost.Value {
+				return false
+			}
+			cast.Character.SpendEnergy(sim, cast.Cost.Value, cast.ActionID)
 		}
-	case stats.Rage:
-		if cast.Character.CurrentRage() < cast.Cost.Value {
-			return false
-		}
-		cast.Character.SpendRage(sim, cast.Cost.Value, cast.ActionID)
-	case stats.Energy:
-		if cast.Character.CurrentEnergy() < cast.Cost.Value {
-			return false
-		}
-		cast.Character.SpendEnergy(sim, cast.Cost.Value, cast.ActionID)
 	}
 
 	if sim.Log != nil {

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -146,28 +146,26 @@ func (cast *Cast) init(sim *Simulation) {
 // Start casting the spell. Return value indicates whether the spell successfully
 // started casting.
 func (cast *Cast) startCasting(sim *Simulation, onCastComplete OnCastComplete) bool {
-	if cast.Cost.Value > 0 {
-		switch cast.Cost.Type {
-		case stats.Mana:
-			if cast.Character.CurrentMana() < cast.Cost.Value {
-				if sim.Log != nil {
-					cast.Character.Log(sim, "Failed casting %s, not enough mana. (Current Mana = %0.03f, Mana Cost = %0.03f)",
-						cast.ActionID, cast.Character.CurrentMana(), cast.Cost.Value)
-				}
-				cast.objectInUse = false
-				return false
+	switch cast.Cost.Type {
+	case stats.Mana:
+		if cast.Character.CurrentMana() < cast.Cost.Value {
+			if sim.Log != nil {
+				cast.Character.Log(sim, "Failed casting %s, not enough mana. (Current Mana = %0.03f, Mana Cost = %0.03f)",
+					cast.ActionID, cast.Character.CurrentMana(), cast.Cost.Value)
 			}
-		case stats.Rage:
-			if cast.Character.CurrentRage() < cast.Cost.Value {
-				return false
-			}
-			cast.Character.SpendRage(sim, cast.Cost.Value, cast.ActionID)
-		case stats.Energy:
-			if cast.Character.CurrentEnergy() < cast.Cost.Value {
-				return false
-			}
-			cast.Character.SpendEnergy(sim, cast.Cost.Value, cast.ActionID)
+			cast.objectInUse = false
+			return false
 		}
+	case stats.Rage:
+		if cast.Character.CurrentRage() < cast.Cost.Value {
+			return false
+		}
+		cast.Character.SpendRage(sim, cast.Cost.Value, cast.ActionID)
+	case stats.Energy:
+		if cast.Character.CurrentEnergy() < cast.Cost.Value {
+			return false
+		}
+		cast.Character.SpendEnergy(sim, cast.Cost.Value, cast.ActionID)
 	}
 
 	if sim.Log != nil {

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -24,7 +24,7 @@ type Simulation struct {
 
 	// Used for testing only, see RandomFloat().
 	isTest    bool
-	testRands map[uint32]*rand.Rand
+	testRands map[string]*rand.Rand
 
 	// Current Simulation State
 	pendingActions    []*PendingAction
@@ -75,7 +75,7 @@ func NewSim(rsr proto.RaidSimRequest) *Simulation {
 		rand: rand.New(rand.NewSource(rseed)),
 
 		isTest:    simOptions.IsTest,
-		testRands: make(map[uint32]*rand.Rand),
+		testRands: make(map[string]*rand.Rand),
 
 		emptyAuras: make([]Aura, numAuraIDs),
 
@@ -94,11 +94,10 @@ func (sim *Simulation) RandomFloat(label string) float64 {
 		return sim.rand.Float64()
 	}
 
-	labelHash := hash(label)
-	labelRand, isPresent := sim.testRands[labelHash]
+	labelRand, isPresent := sim.testRands[label]
 	if !isPresent {
-		labelRand = rand.New(rand.NewSource(int64(labelHash)))
-		sim.testRands[labelHash] = labelRand
+		labelRand = rand.New(rand.NewSource(int64(hash(label))))
+		sim.testRands[label] = labelRand
 	}
 	v := labelRand.Float64()
 	// if sim.Log != nil {

--- a/sim/core/warrior/TestWarrior.results
+++ b/sim/core/warrior/TestWarrior.results
@@ -539,7 +539,7 @@ dps_results: {
 dps_results: {
  key: "TestWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 268.8258410589127
+  dps: 271.0628423139226
  }
 }
 dps_results: {

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -35,301 +35,301 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1461.4280636045112
+  dps: 1435.5742754974299
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1423.8387969437726
+  dps: 1397.537942176432
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1206.382427998823
+  dps: 1184.5039219380428
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1394.5286071687904
+  dps: 1369.3057609538935
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1430.7066818619367
+  dps: 1403.93987649529
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1390.3556315504115
+  dps: 1364.6690530698636
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1431.9611975468943
+  dps: 1405.5636694241555
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1478.9321620582996
+  dps: 1451.8269787740203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1393.2800560612598
+  dps: 1367.8892154610533
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1395.638531744092
+  dps: 1369.8392572221358
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1425.5314772409547
+  dps: 1399.983083513914
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1398.7071517963686
+  dps: 1373.2029884005851
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1413.259865182049
+  dps: 1387.3154182016629
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1403.1220207719982
+  dps: 1377.1953655186637
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1406.1029757510794
+  dps: 1380.3805989855482
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1405.3487429539555
+  dps: 1380.1809721993143
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1410.0413839185167
+  dps: 1384.146350748128
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1384.7630997248207
+  dps: 1359.45283778377
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1363.0637853855064
+  dps: 1335.6910211630952
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Despair-28573"
  value: {
-  dps: 1006.40188905264
+  dps: 994.6026165787804
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Devastation-30316"
  value: {
-  dps: 1283.227962534676
+  dps: 1245.7221892935058
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1373.2444808332768
+  dps: 1348.333660993611
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1411.5994716307114
+  dps: 1387.2421580237585
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DragonstrikeP5--23"
  value: {
-  dps: 1252.2277367952395
+  dps: 1231.2038209600112
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1321.2559570946764
+  dps: 1296.610554547131
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1391.775894362362
+  dps: 1366.2717309665788
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1400.105837618848
+  dps: 1374.4654066902385
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1420.5025913251902
+  dps: 1394.3662299327423
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 969.4540127516476
+  dps: 945.9919043223334
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HandofJustice-11815"
  value: {
-  dps: 1403.3377561870213
+  dps: 1378.3949291939164
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Heartrazor-29962"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1399.4084587223128
+  dps: 1373.6296240280064
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1443.5901747772684
+  dps: 1418.0220968046099
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
@@ -341,510 +341,510 @@ dps_results: {
 dps_results: {
  key: "TestRogue-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1455.4430085200343
+  dps: 1429.6514062997016
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1006.2981694791592
+  dps: 987.8240553234207
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1032.122776025724
+  dps: 1013.6268301788742
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1429.8107735852093
+  dps: 1403.8735960117106
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1038.7080881064421
+  dps: 1020.7772936166766
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1420.0822727643465
+  dps: 1393.9044679883398
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1255.8656530527542
+  dps: 1232.1746592316242
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1397.7323433025829
+  dps: 1372.0174892389175
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Primalstrike"
  value: {
-  dps: 1430.7424565170516
+  dps: 1404.8365317074501
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1367.9010013845996
+  dps: 1343.736062645476
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1437.3916916960552
+  dps: 1412.0597598350926
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1374.7768255911074
+  dps: 1349.9385746367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1460.7642706039564
+  dps: 1434.2158572578066
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 897.1001930011693
+  dps: 885.3616018510616
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1480.1492575996372
+  dps: 1452.6468223115562
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1415.083797466911
+  dps: 1389.128332249752
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellfireSet"
  value: {
-  dps: 1241.789322765661
+  dps: 1219.5130500870132
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1229.1907235313051
+  dps: 1207.552986631953
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1397.7323433025829
+  dps: 1372.0174892389175
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1396.4827202997958
+  dps: 1370.802981347444
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1390.2346052858604
+  dps: 1364.7304418900774
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheBladefist-29348"
  value: {
-  dps: 1318.860161059876
+  dps: 1302.5217900893608
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1326.9312814752427
+  dps: 1310.4329319665153
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1264.1789601256505
+  dps: 1249.0816331430428
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1374.7768255911074
+  dps: 1349.9385746367345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1635.8951242800913
+  dps: 1599.568951028479
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1351.239008216475
+  dps: 1326.5152256265417
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1421.2537471551914
+  dps: 1395.3805502735374
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1378.1535197546173
+  dps: 1353.3152688002442
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1431.890215257675
+  dps: 1405.8155594456541
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1438.2482097079799
+  dps: 1412.4392102898141
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1250.2121126578634
+  dps: 1228.2841445204128
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1276.534032062211
+  dps: 1254.3647063845954
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1018.7367095340387
+  dps: 994.6015124197633
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1372.3481755911073
+  dps: 1347.5099246367345
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1399.369449610554
+  dps: 1372.2052274212601
  }
 }
 dps_results: {
  key: "TestRogue-SelfDrums-DPS"
  value: {
-  dps: 1421.5095288852533
+  dps: 1395.0746344587812
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1399.9493524883737
+  dps: 1373.509528096883
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1399.9493524883737
+  dps: 1373.509528096883
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1231.7391478432742
+  dps: 1208.19726010557
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1653.7301716186896
+  dps: 1622.039479226227
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 789.3851699017115
+  dps: 774.2296226360128
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 789.3851699017115
+  dps: 774.2296226360128
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 710.5328997092769
+  dps: 696.3619623937269
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 885.4058498528956
+  dps: 868.4934794412695
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1155.076677499597
+  dps: 1168.8630735550576
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1155.076677499597
+  dps: 1168.8630735550576
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1004.8675086440421
+  dps: 1017.8488030570456
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1377.6171528901184
+  dps: 1395.8792177619846
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 669.3522226501949
+  dps: 677.7251523367703
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 669.3522226501949
+  dps: 677.7251523367703
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 600.2761258890721
+  dps: 607.456084772753
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 724.9354290746501
+  dps: 733.4828788723426
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1419.1782441654118
+  dps: 1393.1135588339957
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1275.7428057656332
+  dps: 1252.0849483597242
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1701.1343963501279
+  dps: 1669.1662405858456
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 806.607817867753
+  dps: 791.3056379047474
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 806.607817867753
+  dps: 791.3056379047474
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 719.8772514317247
+  dps: 705.9725307326117
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 967.3351533588269
+  dps: 948.4996429652253
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1142.5088927334755
+  dps: 1156.2272263628975
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1142.5088927334755
+  dps: 1156.2272263628975
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1014.2535473962055
+  dps: 1027.157340194784
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1379.8488385223293
+  dps: 1397.82391496282
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 665.8081072253907
+  dps: 674.5261162700473
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 665.8081072253907
+  dps: 674.5261162700473
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 606.6986267288848
+  dps: 614.011678985389
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 729.0501115650507
+  dps: 739.3575160611861
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -49,8 +49,9 @@ func (rogue *Rogue) newBackstabTemplate(sim *core.Simulation) core.SimpleSpellTe
 				},
 			},
 			WeaponInput: core.WeaponDamageInput{
+				Normalized:       true,
+				FlatDamageBonus:  170,
 				DamageMultiplier: 1.5,
-				FlatDamageBonus:  255,
 			},
 		},
 	}
@@ -68,7 +69,6 @@ func (rogue *Rogue) newBackstabTemplate(sim *core.Simulation) core.SimpleSpellTe
 
 	ability.Effect.BonusCritRating += 10 * core.MeleeCritRatingPerCritChance * float64(rogue.Talents.PuncturingWounds)
 	ability.Effect.WeaponInput.DamageMultiplier += 0.01 * float64(rogue.Talents.SinisterCalling)
-	ability.Effect.WeaponInput.FlatDamageBonus *= (1.5 + 0.01*float64(rogue.Talents.SinisterCalling)) / 1.5
 
 	return core.NewSimpleSpellTemplate(ability)
 }

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -77,6 +77,7 @@ func (rogue *Rogue) newHemorrhageTemplate(sim *core.Simulation) core.SimpleSpell
 				},
 			},
 			WeaponInput: core.WeaponDamageInput{
+				Normalized:       true,
 				DamageMultiplier: 1.1,
 			},
 		},

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -33,8 +33,9 @@ func (rogue *Rogue) newMutilateTemplate(sim *core.Simulation) core.SimpleSpellTe
 			ThreatMultiplier:       1,
 		},
 		WeaponInput: core.WeaponDamageInput{
-			DamageMultiplier: 1,
+			Normalized:       true,
 			FlatDamageBonus:  101,
+			DamageMultiplier: 1,
 		},
 	}
 

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -53,8 +53,9 @@ func (rogue *Rogue) newSinisterStrikeTemplate(sim *core.Simulation) core.SimpleS
 				},
 			},
 			WeaponInput: core.WeaponDamageInput{
-				DamageMultiplier: 1,
+				Normalized:       true,
 				FlatDamageBonus:  98,
+				DamageMultiplier: 1,
 			},
 		},
 	}

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -575,7 +575,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 1637.9146224018962
+  dps: 1630.8962183397446
  }
 }
 dps_results: {


### PR DESCRIPTION
[build-system] macOS is using a BSD sed by default, which has incompatible options; slightly simplified sed's regular expression

[core] Weapon now has a NormalizedSwingSpeed field, and a corresponding calculateNormalizedWeaponDamage();WeaponDamageInput has a Normalized field, specifying whether normalized or non-normalized weapon damage is dealt in calculateDamage()

[core] in calculateDamage(), WeaponInput.FlatDamageBonus is now added _before_ multiplying by WeaponInput.DamageMultiplier; this is simpler because the game handles it in this order, too

[rogue] changed backstab accordingly (*150% +255 -> +170 *150%)

[core] Simulation's testRands is now a map[string]*rand.Rand instead of a map[uint32]*rand.Rand - this is simpler and faster

[rogue] backstab, hemorrhage, mutilate, and sinister_strike are now using normalized damage; hunter's aimed_shot and multi_shot could do the same

[common] updated "The Fists of Fury" from 1 to 2 ppm, as per my testing; weirdly, the shaman test (TestEnhancement-AllItems-TheFistsofFury) has _lower_ dps now