### PR TITLE
More damage generalization

### DIFF
--- a/sim/paladin/judgement.go
+++ b/sim/paladin/judgement.go
@@ -41,11 +41,9 @@ func (paladin *Paladin) newJudgementOfBloodTemplate(sim *core.Simulation) core.S
 				},
 			},
 			DirectInput: core.DirectDamageInput{
-				// MinBaseDamage: 295,
-				// MaxBaseDamage: 325,
-				SpellCoefficient: 0.7,
-				MinBaseDamage:    paladin.GetMHWeapon().WeaponDamageMin,
-				MaxBaseDamage:    paladin.GetMHWeapon().WeaponDamageMax,
+				MinBaseDamage:    295,
+				MaxBaseDamage:    325,
+				SpellCoefficient: 0.429,
 			},
 		},
 	}
@@ -91,7 +89,6 @@ func (paladin *Paladin) newJudgementOfTheCrusaderTemplate(sim *core.Simulation) 
 			Cast: core.Cast{
 				ActionID:            JudgementOfTheCrusaderActionID,
 				Character:           &paladin.Character,
-				CritRollCategory:    core.CritRollCategoryMagical,
 				OutcomeRollCategory: core.OutcomeRollCategoryMagic,
 				SpellSchool:         core.SpellSchoolHoly,
 				SpellExtras:         core.SpellExtrasAlwaysHits,

--- a/sim/paladin/retribution/retribution_test.go
+++ b/sim/paladin/retribution/retribution_test.go
@@ -28,6 +28,11 @@ func TestRetribution(t *testing.T) {
 	// 	Debuffs:     FullDebuffs,
 
 	// 	ItemFilter: core.ItemFilter{
+	// 		WeaponTypes: []proto.WeaponType{
+	// 			proto.WeaponType_WeaponTypeAxe,
+	// 			proto.WeaponType_WeaponTypeSword,
+	// 			proto.WeaponType_WeaponTypePolearm,
+	// 		},
 	// 		ArmorType: proto.ArmorType_ArmorTypePlate,
 	// 		RangedWeaponTypes: []proto.RangedWeaponType{
 	// 			proto.RangedWeaponType_RangedWeaponTypeLibram,

--- a/sim/paladin/seals.go
+++ b/sim/paladin/seals.go
@@ -24,7 +24,6 @@ func (paladin *Paladin) setupSealOfBlood() {
 				OutcomeRollCategory: core.OutcomeRollCategorySpecial,
 				CritRollCategory:    core.CritRollCategoryPhysical,
 				SpellSchool:         core.SpellSchoolHoly,
-				SpellExtras:         core.SpellExtrasIgnoreResists,
 				CritMultiplier:      paladin.DefaultMeleeCritMultiplier(),
 				IsPhantom:           true,
 			},
@@ -102,7 +101,6 @@ func (paladin *Paladin) setupSealOfCommand() {
 				OutcomeRollCategory: core.OutcomeRollCategorySpecial,
 				CritRollCategory:    core.CritRollCategoryPhysical,
 				SpellSchool:         core.SpellSchoolHoly,
-				SpellExtras:         core.SpellExtrasIgnoreResists,
 				CritMultiplier:      paladin.DefaultMeleeCritMultiplier(),
 			},
 		},
@@ -114,6 +112,10 @@ func (paladin *Paladin) setupSealOfCommand() {
 			},
 			WeaponInput: core.WeaponDamageInput{
 				DamageMultiplier: 0.70, // should deal 70% weapon deamage
+			},
+			// By having no base damage, this will be added to weapon input
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 0.29,
 			},
 		},
 	}
@@ -140,7 +142,7 @@ func (paladin *Paladin) setupSealOfCommand() {
 				return
 			}
 
-			if !ppmm.Proc(sim, true, false, "Frostbrand Weapon") {
+			if !ppmm.Proc(sim, true, false, "seal of command") {
 				return
 			}
 

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -52,6 +52,7 @@ func (rogue *Rogue) newMutilateTemplate(_ *core.Simulation) core.SimpleSpellTemp
 	ohDamageAbility.SpellCast.Cast.ActionID = MutilateOHActionID
 	ohDamageAbility.SpellCast.Cast.CritMultiplier = rogue.critMultiplier(false, true)
 	ohDamageAbility.Effect.SpellEffect.ProcMask = core.ProcMaskMeleeOHSpecial
+	ohDamageAbility.Effect.WeaponInput.Offhand = true
 
 	if rogue.Talents.DualWieldSpecialization > 0 {
 		ohDamageAbility.Effect.WeaponInput.DamageMultiplier *= 1 + 0.1*float64(rogue.Talents.DualWieldSpecialization)

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -28,6 +28,7 @@ func (rogue *Rogue) newShivTemplate(_ *core.Simulation) core.SimpleSpellTemplate
 	}
 	ability.Effect.WeaponInput = core.WeaponDamageInput{
 		Normalized:       true,
+		Offhand:          true,
 		DamageMultiplier: 1 + 0.1*float64(rogue.Talents.DualWieldSpecialization),
 	}
 

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -96,6 +96,7 @@ func (shaman *Shaman) newStormstrikeTemplate(sim *core.Simulation) core.SimpleSp
 					ReuseMainHitRoll:       true,
 				},
 				WeaponInput: core.WeaponDamageInput{
+					Offhand:          true,
 					DamageMultiplier: 1,
 				},
 			},

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -100,7 +100,10 @@ func (shaman *Shaman) ApplyWindfuryImbue(mh bool, oh bool) {
 				for i := 0; i < 2; i++ {
 					wfAtk.Effects[i].Target = spellEffect.Target
 					wfAtk.Effects[i].ProcMask = attackProc
-					if !isMHHit {
+					if isMHHit {
+						wfAtk.Effects[i].WeaponInput.Offhand = false
+					} else {
+						wfAtk.Effects[i].WeaponInput.Offhand = true
 						// For whatever reason, OH penalty does not apply to the bonus AP from WF OH
 						// hits. Implement this by doubling the AP bonus we provide.
 						wfAtk.Effects[i].BonusAttackPower += apBonus


### PR DESCRIPTION
1. Offhand is now part of weapon damage input instead of part of proc mask. This allows you to have a spell with no proc mask but still is offhand or main hand (seal of blood)
2. Spell Coefficient is now applied to weapon damage. This is to support seal of command.