### PR TITLE
vigo/bonusAttackPowerOnTarget

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -202,7 +202,8 @@ func (ahe *SpellHitEffect) calculateWeaponDamage(sim *Simulation, ability *Simpl
 	var attackPower float64
 	var bonusWeaponDamage float64
 	if ability.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
-		attackPower = character.stats[stats.RangedAttackPower] + ahe.BonusAttackPower
+		// all ranged attacks honor BonusAttackPowerOnTarget...
+		attackPower = character.stats[stats.RangedAttackPower] + ahe.BonusAttackPower + ahe.BonusAttackPowerOnTarget
 		bonusWeaponDamage = character.PseudoStats.BonusDamage + ahe.BonusWeaponDamage
 	} else {
 		attackPower = character.stats[stats.AttackPower] + ahe.BonusAttackPower
@@ -215,21 +216,22 @@ func (ahe *SpellHitEffect) calculateWeaponDamage(sim *Simulation, ability *Simpl
 	} else if ahe.WeaponInput.DamageMultiplier != 0 {
 		// Bonus weapon damage applies after OH penalty: https://www.youtube.com/watch?v=bwCIU87hqTs
 		// TODO not all weapon damage based attacks "scale" with +bonusWeaponDamage (e.g. Devastate, Shiv, Mutilate don't)
+		// ... but for other's, BonusAttackPowerOnTarget only applies to weapon damage based attacks
 		if ahe.WeaponInput.Normalized {
 			if ability.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
 				dmg += character.AutoAttacks.Ranged.calculateNormalizedWeaponDamage(sim, attackPower) + bonusWeaponDamage
 			} else if !ahe.WeaponInput.Offhand {
-				dmg += character.AutoAttacks.MH.calculateNormalizedWeaponDamage(sim, attackPower) + bonusWeaponDamage
+				dmg += character.AutoAttacks.MH.calculateNormalizedWeaponDamage(sim, attackPower+ahe.BonusAttackPowerOnTarget) + bonusWeaponDamage
 			} else {
-				dmg += character.AutoAttacks.OH.calculateNormalizedWeaponDamage(sim, attackPower)*0.5 + bonusWeaponDamage
+				dmg += character.AutoAttacks.OH.calculateNormalizedWeaponDamage(sim, attackPower+2*ahe.BonusAttackPowerOnTarget)*0.5 + bonusWeaponDamage
 			}
 		} else {
 			if ability.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
 				dmg += character.AutoAttacks.Ranged.calculateWeaponDamage(sim, attackPower) + bonusWeaponDamage
 			} else if !ahe.WeaponInput.Offhand {
-				dmg += character.AutoAttacks.MH.calculateWeaponDamage(sim, attackPower) + bonusWeaponDamage
+				dmg += character.AutoAttacks.MH.calculateWeaponDamage(sim, attackPower+ahe.BonusAttackPowerOnTarget) + bonusWeaponDamage
 			} else {
-				dmg += character.AutoAttacks.OH.calculateWeaponDamage(sim, attackPower)*0.5 + bonusWeaponDamage
+				dmg += character.AutoAttacks.OH.calculateWeaponDamage(sim, attackPower+2*ahe.BonusAttackPowerOnTarget)*0.5 + bonusWeaponDamage
 			}
 		}
 		dmg += ahe.WeaponInput.FlatDamageBonus

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -437,7 +437,7 @@ func ExposeWeaknessAura(currentTime time.Duration, hunterAgility float64, multip
 		ActionID: ActionID{SpellID: 34503},
 		Expires:  currentTime + time.Second*7,
 		OnBeforeSpellHit: func(sim *Simulation, spellCast *SpellCast, spellEffect *SpellHitEffect) {
-			spellEffect.BonusAttackPower += apBonus
+			spellEffect.BonusAttackPowerOnTarget += apBonus
 		},
 	}
 }
@@ -463,9 +463,9 @@ func HuntersMarkAura(points int32, fullyStacked bool) Aura {
 		Stacks:   points, // Use this to check whether to override in hunter/hunter.go
 		OnBeforeSpellHit: func(sim *Simulation, spellCast *SpellCast, spellEffect *SpellHitEffect) {
 			if spellEffect.ProcMask.Matches(ProcMaskMelee) {
-				spellEffect.BonusAttackPower += meleeBonus
+				spellEffect.BonusAttackPowerOnTarget += meleeBonus
 			} else {
-				spellEffect.BonusAttackPower += rangedBonus
+				spellEffect.BonusAttackPowerOnTarget += rangedBonus
 			}
 		},
 		OnSpellHit: func(sim *Simulation, spellCast *SpellCast, spellEffect *SpellEffect) {

--- a/sim/core/spell_cast.go
+++ b/sim/core/spell_cast.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/wowsims/tbc/sim/core/stats"
 )
 
@@ -61,6 +59,8 @@ type SpellEffect struct {
 	BonusExpertiseRating  float64
 	BonusArmorPenetration float64
 	BonusWeaponDamage     float64
+
+	BonusAttackPowerOnTarget float64
 
 	// Additional multiplier that is always applied.
 	DamageMultiplier float64
@@ -365,10 +365,7 @@ func (spellEffect *SpellEffect) String() string {
 	if !spellEffect.Landed() {
 		return outcomeStr
 	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "%s for %0.3f damage", outcomeStr, spellEffect.Damage)
-	return sb.String()
+	return fmt.Sprintf("%s for %0.3f damage", outcomeStr, spellEffect.Damage)
 }
 
 func (spellEffect *SpellEffect) DotResultString() string {

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -29,7 +29,7 @@ func (rogue *Rogue) newRuptureTemplate(sim *core.Simulation) core.SimpleSpellTem
 		NumberOfTicks:  0, // Set dynamically.
 		TickLength:     time.Second * 2,
 		TickBaseDamage: 0, // Set dynamically.
-		DebuffID:       DeadlyPoisonDebuffID,
+		DebuffID:       RuptureDebuffID,
 	}
 
 	ability.Effect.StaticDamageMultiplier += 0.1 * float64(rogue.Talents.SerratedBlades)

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -35,169 +35,169 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1843.5417345561787
+  dps: 1860.9721516762752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 1852.7371547640737
+  dps: 1868.8140830300085
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1874.719870075753
+  dps: 1891.6754209507535
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1828.4598589878537
+  dps: 1844.8532864496915
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1877.3845637330953
+  dps: 1893.6665100978466
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1834.7378730730297
+  dps: 1851.2874511721805
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1864.8331313445885
+  dps: 1880.910059610525
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1910.8126648263801
+  dps: 1928.2826079583203
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1861.4530989735383
+  dps: 1877.8488211480803
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1819.4791462731762
+  dps: 1835.5560745391133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1821.590375067847
+  dps: 1837.3730746568344
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1870.2423989861563
+  dps: 1886.5349656578278
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1826.7719316259006
+  dps: 1842.554631214887
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmHarness"
  value: {
-  dps: 1707.5085891688784
+  dps: 1722.7741259860766
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmRegalia"
  value: {
-  dps: 1475.197402453239
+  dps: 1488.715206153285
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1849.3622646387753
+  dps: 1865.4391929047104
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1844.9364065779819
+  dps: 1861.0133348439176
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1838.0558150671725
+  dps: 1854.1327433331082
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1830.816914269779
+  dps: 1846.8938425357135
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneHarness"
  value: {
-  dps: 1586.458494084043
+  dps: 1601.2322645155703
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneRegalia"
  value: {
-  dps: 1436.711882087167
+  dps: 1450.6914382620203
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1811.9184212749115
+  dps: 1827.9953495408467
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1851.4876569391563
+  dps: 1867.5645852050911
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1860.7444772625295
+  dps: 1877.0912536747428
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DesolationBattlegear"
  value: {
-  dps: 1593.349841630806
+  dps: 1608.3036955275109
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1820.7858977468177
+  dps: 1836.568597335805
  }
 }
 dps_results: {
@@ -209,271 +209,271 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonstrike(StackingAuras)--23"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EbonNetherscale"
  value: {
-  dps: 1739.9960924407187
+  dps: 1755.816193980162
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1818.0503889395254
+  dps: 1833.8330885285127
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1822.9836267736573
+  dps: 1838.7663263626448
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1808.7068605771462
+  dps: 1824.783788843081
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1820.4420747837203
+  dps: 1836.2247743727078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1816.5837837258114
+  dps: 1832.6607119917458
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Fathom-BroochoftheTidewalker-30663"
  value: {
-  dps: 1813.1673595558052
+  dps: 1829.2442878217398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Felstalker"
  value: {
-  dps: 1720.2789261002254
+  dps: 1735.6321958876401
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1815.036939014562
+  dps: 1831.1138672804973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1835.6811985780892
+  dps: 1851.7581268440244
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1862.3721157136529
+  dps: 1878.4490439795877
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HandofJustice-11815"
  value: {
-  dps: 1861.5807163476334
+  dps: 1878.7702833768699
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartrazor-29962"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1814.4905628471822
+  dps: 1830.5674911131175
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1869.8170113814945
+  dps: 1886.2127335560356
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1864.267453747538
+  dps: 1881.0572500580786
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1811.9184212749115
+  dps: 1827.9953495408467
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1822.228319670139
+  dps: 1838.0110192591267
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1823.7166811088864
+  dps: 1839.499380697874
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1833.5597336071385
+  dps: 1850.8259515471907
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1872.25344956676
+  dps: 1888.6332253180499
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1475.0447396169823
+  dps: 1488.7449355445785
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1850.045328369385
+  dps: 1866.1222566353204
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1813.7098630934097
+  dps: 1829.7867913593445
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1820.4420747837203
+  dps: 1836.2247743727078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1840.7187010416126
+  dps: 1857.8520266194173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1627.0100345595924
+  dps: 1642.6849611209584
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1829.574066261691
+  dps: 1845.3567658506772
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1820.4420747837203
+  dps: 1836.2247743727078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Primalstrike"
  value: {
-  dps: 1724.2794132290164
+  dps: 1740.7130914569907
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1807.571439488641
+  dps: 1823.648367754576
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1720.6525466776484
+  dps: 1736.9355088978439
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1900.316023466907
+  dps: 1917.2907832448634
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1826.6947744383103
+  dps: 1842.7717027042454
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1804.4994514967432
+  dps: 1820.5763797626776
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1909.702829716714
+  dps: 1927.2360329377018
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1804.455054660403
+  dps: 1820.5319829263378
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1810.2933632734337
+  dps: 1826.3702915393685
  }
 }
 dps_results: {
@@ -485,175 +485,175 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 1842.1528186481667
+  dps: 1858.2297469141004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 1763.9191763040508
+  dps: 1779.196256933121
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1372.9052778626956
+  dps: 1385.2640828509698
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1847.2250927909831
+  dps: 1863.3020210569184
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1810.8964189412238
+  dps: 1826.973347207159
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpellfireSet"
  value: {
-  dps: 1589.618884825736
+  dps: 1604.878880613237
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1601.683735058736
+  dps: 1617.2009269747066
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 1864.568270472691
+  dps: 1880.6451987386242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1724.4480385190352
+  dps: 1740.6820549769006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1829.574066261691
+  dps: 1845.3567658506772
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1821.9731418292224
+  dps: 1837.7558414182097
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1828.052067682029
+  dps: 1843.8347672710156
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1820.4420747837203
+  dps: 1836.2247743727078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheBladefist-29348"
  value: {
-  dps: 1747.717311243619
+  dps: 1763.1685649061874
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 1559.0357046800439
+  dps: 1567.7822200578833
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1801.175832886251
+  dps: 1817.252761152186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1810.9574022454742
+  dps: 1827.034330511409
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1846.0729216097009
+  dps: 1862.3798026080904
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheTwinStars"
  value: {
-  dps: 1794.660736613013
+  dps: 1810.818194510553
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1848.3872065556254
+  dps: 1864.6870689163986
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 1458.522575413143
+  dps: 1472.5021315879965
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1821.5544821365806
+  dps: 1837.6314104025155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofthePulsingEarth-29389"
  value: {
-  dps: 1842.1528186481667
+  dps: 1858.2297469141004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1884.1829500175909
+  dps: 1900.4413470061259
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WastewalkerArmor"
  value: {
-  dps: 1613.7540552830571
+  dps: 1629.3451275949967
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WindhawkArmor"
  value: {
-  dps: 1633.3952170002096
+  dps: 1648.810176918258
  }
 }
 dps_results: {
@@ -665,25 +665,25 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1807.3980523094299
+  dps: 1823.4749805753643
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 1939.8690278339386
+  dps: 1955.9665081904475
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2101.8797434960206
+  dps: 2118.086147155893
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1906.5802344758813
+  dps: 1922.7866381357528
  }
 }
 dps_results: {
@@ -695,19 +695,19 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2422.4929070018043
+  dps: 2442.0342717357394
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 991.1656651929584
+  dps: 1000.8904261718038
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 906.5544419578523
+  dps: 916.2151961729058
  }
 }
 dps_results: {
@@ -719,19 +719,19 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1155.0624807517504
+  dps: 1167.7336864238357
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2054.36536258605
+  dps: 2070.4422908519855
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1851.6815427183326
+  dps: 1867.7584709842677
  }
 }
 dps_results: {
@@ -743,19 +743,19 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2398.4102993628894
+  dps: 2420.2761260550155
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1015.8872169127934
+  dps: 1025.7263366429477
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 885.4248248297281
+  dps: 895.2263939251243
  }
 }
 dps_results: {
@@ -767,6 +767,6 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1122.7644709751585
+  dps: 1135.222320767936
  }
 }


### PR DESCRIPTION
[core] IHM and EW now apply BonusAttackPowerOnTarget instead of BonusAttackPower. It only applies to ranged and weapon-damage based melee attacks, but is doubly effective for offhand attacks (applying after the dual wield penalty)

[rogue] Rupture was using the DeadlyPoisonDebuffID