### PR TITLE
Added ISB uptime back to smite priest options

### DIFF
--- a/ui/smite_priest/sim.ts
+++ b/ui/smite_priest/sim.ts
@@ -206,6 +206,7 @@ export class SmitePriestSimUI extends IndividualSimUI<Spec.SpecSmitePriest> {
 			// Inputs to include in the 'Other' section on the settings tab.
 			otherInputs: {
 				inputs: [
+					OtherInputs.ISBUptime,
 					OtherInputs.ShadowPriestDPS,
 					OtherInputs.StartingPotion,
 					OtherInputs.NumStartingPotions,


### PR DESCRIPTION
ISB uptime affect sw:p dps but also shadowfiend mana return