### PR TITLE
Prot warrior updates

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -219,19 +219,19 @@ func (ahe *SpellHitEffect) calculateWeaponDamage(sim *Simulation, ability *Simpl
 		// ... but for other's, BonusAttackPowerOnTarget only applies to weapon damage based attacks
 		if ahe.WeaponInput.Normalized {
 			if ability.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
-				dmg += character.AutoAttacks.Ranged.calculateNormalizedWeaponDamage(sim, attackPower) + bonusWeaponDamage
+				dmg += character.AutoAttacks.Ranged.calculateNormalizedWeaponDamage(sim, attackPower)
 			} else if !ahe.WeaponInput.Offhand {
-				dmg += character.AutoAttacks.MH.calculateNormalizedWeaponDamage(sim, attackPower+ahe.BonusAttackPowerOnTarget) + bonusWeaponDamage
+				dmg += character.AutoAttacks.MH.calculateNormalizedWeaponDamage(sim, attackPower+ahe.BonusAttackPowerOnTarget)
 			} else {
-				dmg += character.AutoAttacks.OH.calculateNormalizedWeaponDamage(sim, attackPower+2*ahe.BonusAttackPowerOnTarget)*0.5 + bonusWeaponDamage
+				dmg += character.AutoAttacks.OH.calculateNormalizedWeaponDamage(sim, attackPower+2*ahe.BonusAttackPowerOnTarget)*0.5
 			}
 		} else {
 			if ability.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
-				dmg += character.AutoAttacks.Ranged.calculateWeaponDamage(sim, attackPower) + bonusWeaponDamage
+				dmg += character.AutoAttacks.Ranged.calculateWeaponDamage(sim, attackPower)
 			} else if !ahe.WeaponInput.Offhand {
-				dmg += character.AutoAttacks.MH.calculateWeaponDamage(sim, attackPower+ahe.BonusAttackPowerOnTarget) + bonusWeaponDamage
+				dmg += character.AutoAttacks.MH.calculateWeaponDamage(sim, attackPower+ahe.BonusAttackPowerOnTarget)
 			} else {
-				dmg += character.AutoAttacks.OH.calculateWeaponDamage(sim, attackPower+2*ahe.BonusAttackPowerOnTarget)*0.5 + bonusWeaponDamage
+				dmg += character.AutoAttacks.OH.calculateWeaponDamage(sim, attackPower+2*ahe.BonusAttackPowerOnTarget)*0.5
 			}
 		}
 		dmg += ahe.WeaponInput.FlatDamageBonus
@@ -239,9 +239,13 @@ func (ahe *SpellHitEffect) calculateWeaponDamage(sim *Simulation, ability *Simpl
 	}
 
 	if ahe.DirectInput.SpellCoefficient > 0 {
-		bonus := (character.GetStat(stats.SpellPower) + character.GetStat(ability.SpellSchool.Stat())) * ahe.DirectInput.SpellCoefficient * ahe.WeaponInput.DamageMultiplier
-		bonus += ahe.SpellEffect.BonusSpellPower * ahe.DirectInput.SpellCoefficient // does not get changed by weapon input multiplier
-		dmg += bonus
+		if ability.SpellSchool.Matches(SpellSchoolMagic) {
+			bonus := (character.GetStat(stats.SpellPower) + character.GetStat(ability.SpellSchool.Stat())) * ahe.DirectInput.SpellCoefficient * ahe.WeaponInput.DamageMultiplier
+			bonus += ahe.SpellEffect.BonusSpellPower * ahe.DirectInput.SpellCoefficient // does not get changed by weapon input multiplier
+			dmg += bonus
+		} else {
+			dmg += bonusWeaponDamage * ahe.DirectInput.SpellCoefficient * ahe.WeaponInput.DamageMultiplier
+		}
 	}
 	dmg += ahe.DirectInput.FlatDamageBonus
 
@@ -382,6 +386,9 @@ func (character *Character) EnableAutoAttacks(agent Agent, options AutoAttackOpt
 				WeaponInput: WeaponDamageInput{
 					DamageMultiplier: 1,
 				},
+				DirectInput: DirectDamageInput{
+					SpellCoefficient: 1,
+				},
 			},
 		},
 		OHAuto: SimpleSpell{
@@ -405,6 +412,9 @@ func (character *Character) EnableAutoAttacks(agent Agent, options AutoAttackOpt
 					Offhand:          true,
 					DamageMultiplier: 1,
 				},
+				DirectInput: DirectDamageInput{
+					SpellCoefficient: 1,
+				},
 			},
 		},
 		RangedAuto: SimpleSpell{
@@ -427,6 +437,9 @@ func (character *Character) EnableAutoAttacks(agent Agent, options AutoAttackOpt
 				},
 				WeaponInput: WeaponDamageInput{
 					DamageMultiplier: 1,
+				},
+				DirectInput: DirectDamageInput{
+					SpellCoefficient: 1,
 				},
 			},
 		},

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -18,7 +18,7 @@ func applyBuffEffects(agent Agent, raidBuffs proto.RaidBuffs, partyBuffs proto.P
 		})
 	}
 
-	gotwAmount := GetTristateValueFloat(raidBuffs.GiftOfTheWild, 14.0, 14.0*1.35)
+	gotwAmount := GetTristateValueFloat(raidBuffs.GiftOfTheWild, 14.0, 18.0)
 	character.AddStats(stats.Stats{
 		stats.Stamina:   gotwAmount,
 		stats.Agility:   gotwAmount,
@@ -123,15 +123,14 @@ func applyBuffEffects(agent Agent, raidBuffs proto.RaidBuffs, partyBuffs proto.P
 	if partyBuffs.BattleShout != proto.TristateEffect_TristateEffectMissing {
 		talentMultiplier := GetTristateValueFloat(partyBuffs.BattleShout, 1, 1.25)
 
-		character.AddStats(stats.Stats{
-			stats.AttackPower: 306 * talentMultiplier,
-		})
+		BattleShoutAp := 306 * talentMultiplier
 		if partyBuffs.BsSolarianSapphire {
 			partyBuffs.SnapshotBsSolarianSapphire = false
-			character.AddStats(stats.Stats{
-				stats.AttackPower: 70 * talentMultiplier,
-			})
+			BattleShoutAp += 70 * talentMultiplier
 		}
+		character.AddStats(stats.Stats{
+			stats.AttackPower: math.Floor(BattleShoutAp),
+		})
 
 		snapshotAp := 0.0
 		if partyBuffs.SnapshotBsSolarianSapphire {
@@ -141,6 +140,7 @@ func applyBuffEffects(agent Agent, raidBuffs proto.RaidBuffs, partyBuffs proto.P
 			snapshotAp += 30 * talentMultiplier
 		}
 		if snapshotAp > 0 {
+			snapshotAp = math.Floor(snapshotAp)
 			character.AddPermanentAuraWithOptions(PermanentAura{
 				AuraFactory:     SnapshotBattleShoutAura(character, snapshotAp),
 				RespectDuration: true,
@@ -167,7 +167,7 @@ func applyBuffEffects(agent Agent, raidBuffs proto.RaidBuffs, partyBuffs proto.P
 		})
 	}
 	character.AddStats(stats.Stats{
-		stats.Agility: GetTristateValueFloat(partyBuffs.GraceOfAirTotem, 77.0, 88.55),
+		stats.Agility: GetTristateValueFloat(partyBuffs.GraceOfAirTotem, 77.0, 88.0),
 	})
 	switch partyBuffs.StrengthOfEarthTotem {
 	case proto.StrengthOfEarthType_Basic:
@@ -175,9 +175,9 @@ func applyBuffEffects(agent Agent, raidBuffs proto.RaidBuffs, partyBuffs proto.P
 	case proto.StrengthOfEarthType_CycloneBonus:
 		character.AddStat(stats.Strength, 98)
 	case proto.StrengthOfEarthType_EnhancingTotems:
-		character.AddStat(stats.Strength, 98.9)
+		character.AddStat(stats.Strength, 98.0)
 	case proto.StrengthOfEarthType_EnhancingAndCyclone:
-		character.AddStat(stats.Strength, 110.9)
+		character.AddStat(stats.Strength, 112.0)
 	}
 	if (partyBuffs.StrengthOfEarthTotem == proto.StrengthOfEarthType_Basic || partyBuffs.StrengthOfEarthTotem == proto.StrengthOfEarthType_EnhancingTotems) && partyBuffs.SnapshotImprovedStrengthOfEarthTotem {
 		character.AddPermanentAuraWithOptions(PermanentAura{

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -16,7 +16,7 @@ type DirectDamageInput struct {
 	MinBaseDamage float64
 	MaxBaseDamage float64
 
-	// Increase in damage per point of spell power (or attack power, if a physical spell).
+	// Increase in damage per point of spell power (or weapon damage, if a physical spell).
 	SpellCoefficient float64
 
 	// Adds a fixed amount of damage to the spell, before multipliers.

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -219,7 +219,7 @@ func (ss SpellSchool) Stat() stats.Stat {
 	case SpellSchoolShadow:
 		return stats.ShadowSpellPower
 	case SpellSchoolPhysical:
-		return stats.AttackPower
+		return 0 // should be weapon damage (mod_damage_done (physical))
 	}
 
 	return 0

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestBalance-CharacterStats-Default"
  value: {
-  final_stats: 116.49000000000001
-  final_stats: 98.89000000000001
-  final_stats: 363.99
-  final_stats: 475.09000000000003
-  final_stats: 240.79000000000002
-  final_stats: 1058.0288
+  final_stats: 115.50000000000001
+  final_stats: 97.9
+  final_stats: 363.00000000000006
+  final_stats: 474.1
+  final_stats: 239.8
+  final_stats: 1057.712
   final_stats: 732
   final_stats: 302
   final_stats: 172
@@ -14,9 +14,9 @@ character_stats_results: {
   final_stats: 80
   final_stats: 80
   final_stats: 0
-  final_stats: 227.50900000000001
+  final_stats: 227.41
   final_stats: 108.47999999999999
-  final_stats: 557.1757078085642
+  final_stats: 556.9004030226699
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -25,18 +25,18 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 9216.35
+  final_stats: 9201.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1640.78
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 1638.8
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 7427.595
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 7417.200000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,924 +47,924 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1296.593368350042
+  dps: 1296.3914890714639
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1260.4023105613749
+  dps: 1260.2022340186245
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1306.3989140542265
+  dps: 1306.1970347756487
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1287.5596331371364
+  dps: 1287.357753858557
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1276.7264647791046
+  dps: 1276.5245855005262
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1244.0134221286507
+  dps: 1243.817617091261
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1292.179575367266
+  dps: 1291.9797217545747
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1244.0134221286507
+  dps: 1243.817617091261
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1266.0673886991974
+  dps: 1265.8675350865085
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1304.295415893617
+  dps: 1304.0935366150393
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1297.251981180727
+  dps: 1297.0481304957839
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1286.4268544607792
+  dps: 1286.224975182202
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1328.0127157854793
+  dps: 1327.8108365069018
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1267.7538455576928
+  dps: 1267.5519662791146
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HandofJustice-11815"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartrazor-29962"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1314.7740103444607
+  dps: 1314.572131065883
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 1298.366037491073
+  dps: 1298.1641582124948
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1295.3338306180465
+  dps: 1295.1339770053567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1289.1666307517187
+  dps: 1288.9667771390295
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 1313.4051930065918
+  dps: 1313.203313728014
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MalorneRaiment"
  value: {
-  dps: 988.893913133098
+  dps: 976.2074489545098
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1043.6698806872307
+  dps: 1043.5238022221263
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1311.7749506433236
+  dps: 1311.5730713647451
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1310.8689408632636
+  dps: 1310.665315460001
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NordrassilRegalia"
  value: {
-  dps: 1227.9598629144107
+  dps: 1227.7962705925138
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PrimalIntent"
  value: {
-  dps: 1071.0092536719437
+  dps: 1070.8625657939654
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1263.2571929496544
+  dps: 1263.0994747632644
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1334.3456719113383
+  dps: 1334.1335713755936
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1275.5160496356673
+  dps: 1275.3141703570886
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1269.746612308167
+  dps: 1269.5447330295888
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1335.3970327329414
+  dps: 1335.1883815316694
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1292.1065926679628
+  dps: 1291.9059186588656
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1202.63897701142
+  dps: 1204.4912236967355
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1049.1757960406874
+  dps: 1049.030948326323
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1294.0721285177347
+  dps: 1293.8722749050448
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1249.31963610826
+  dps: 1249.1238076235895
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1297.5103754410422
+  dps: 1297.308496162464
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1351.8802864200798
+  dps: 1351.6691014308765
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheTwinStars"
  value: {
-  dps: 1251.3977393934301
+  dps: 1251.203602076189
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1362.4735303766086
+  dps: 1362.2952051707514
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1286.5019159158594
+  dps: 1286.30206230317
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1291.8729369213563
+  dps: 1291.672577340122
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1257.609108853167
+  dps: 1257.4072295745887
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WastewalkerArmor"
  value: {
-  dps: 795.184629490723
+  dps: 794.8356736654194
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WindhawkArmor"
  value: {
-  dps: 1220.6354711359718
+  dps: 1220.4786945663648
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1077.6137523491336
+  dps: 1077.4179473117442
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathofSpellfire"
  value: {
-  dps: 1248.993963415479
+  dps: 1248.7937380229805
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1274.6502076875422
+  dps: 1274.4483284089642
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 1258.823743728843
+  dps: 1258.1495053352633
  }
 }
 dps_results: {
  key: "TestBalance-SelfDrums-DPS"
  value: {
-  dps: 1267.4734604779107
+  dps: 1267.2775818598186
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1061.8408590929112
+  dps: 1061.6717439414306
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1385.4737545931691
+  dps: 1385.2622061108164
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 679.4495652389951
+  dps: 693.6302664415097
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 679.4495652389951
+  dps: 693.6302664415097
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 512.9600537629336
+  dps: 512.8729089205339
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Adaptive-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1264.4453735908198
+  dps: 1264.2518633595203
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1302.1935453964481
+  dps: 1301.9916661178702
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1017.3425421505817
+  dps: 1021.303255706584
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1385.4737545931691
+  dps: 1385.2622061108164
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 547.9595557625443
+  dps: 554.3589716241706
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 547.9595557625443
+  dps: 554.3589716241706
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 425.3069473177069
+  dps: 424.53152206050686
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1264.4453735908198
+  dps: 1264.2518633595203
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1043.5780805133093
+  dps: 1035.6696031038439
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1043.5780805133093
+  dps: 1035.6696031038439
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 836.9753574233794
+  dps: 836.0929831086092
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1158.84801288489
+  dps: 1158.6638314390648
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-NoBuffs-LongMultiTarget"
  value: {
-  dps: 432.7428379233039
+  dps: 428.7385549497353
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 432.7428379233039
+  dps: 428.7385549497353
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 340.4381566113987
+  dps: 340.3861829683587
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1032.9670921531854
+  dps: 1032.801066559682
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1417.0136879889321
+  dps: 1416.8378516205153
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1417.0136879889321
+  dps: 1416.8378516205153
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1198.9225868833373
+  dps: 1198.773729374744
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1495.1377533702912
+  dps: 1494.9548550106024
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 899.6138420655408
+  dps: 898.5252101499195
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 899.6138420655408
+  dps: 898.5252101499195
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 682.320297653084
+  dps: 680.1292791387489
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Adaptive-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1318.5216798620288
+  dps: 1318.359023809877
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1417.0136879889321
+  dps: 1416.8378516205153
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1417.0136879889321
+  dps: 1416.8378516205153
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1198.9225868833373
+  dps: 1198.773729374744
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1495.1377533702912
+  dps: 1494.9548550106024
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 733.0402684741649
+  dps: 737.1435445733729
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 733.0402684741649
+  dps: 737.1435445733729
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 521.0891594211881
+  dps: 522.7565703774508
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Starfire-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1318.5216798620288
+  dps: 1318.359023809877
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1328.9913283255698
+  dps: 1323.8558113834501
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1328.9913283255698
+  dps: 1323.8558113834501
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1078.7340089394218
+  dps: 1072.9809527804468
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1311.7175883180907
+  dps: 1311.5651122305837
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-NoBuffs-LongMultiTarget"
  value: {
-  dps: 585.7612175201592
+  dps: 592.857575264333
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 585.7612175201592
+  dps: 592.857575264333
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 484.1478800776118
+  dps: 483.66017358544497
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1166.6990559000378
+  dps: 1166.562019033545
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestHunter-CharacterStats-Default"
  value: {
-  final_stats: 101.09000000000002
-  final_stats: 758.89
-  final_stats: 374.99
-  final_stats: 235.29000000000002
-  final_stats: 121.99000000000001
+  final_stats: 100.10000000000001
+  final_stats: 757.9000000000001
+  final_stats: 374.00000000000006
+  final_stats: 234.3
+  final_stats: 121.00000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -16,27 +16,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 111
   final_stats: 0
-  final_stats: 94.45824
+  final_stats: 94.06079999999999
   final_stats: 0
   final_stats: 0
-  final_stats: 1965.59
+  final_stats: 1964.1
   final_stats: 82
-  final_stats: 660.5248799999999
+  final_stats: 659.9784
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 6632.35
+  final_stats: 6617.5
   final_stats: 0
   final_stats: 0
-  final_stats: 5049.78
-  final_stats: 2250.89
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 5047.8
+  final_stats: 2249.9
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 7137.9
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 7128
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,775 +47,775 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1628.4783570769314
+  dps: 1619.3701523630698
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 1656.1756371260633
+  dps: 1639.4544680532465
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1639.7199150644851
+  dps: 1625.849816505906
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1634.1322484734976
+  dps: 1616.9731583424666
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1668.369125745245
+  dps: 1650.107593074943
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1629.63119787072
+  dps: 1628.879235331667
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1633.1129743573508
+  dps: 1612.9413203176234
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1639.1887445191744
+  dps: 1622.0544342058784
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1602.0370082401093
+  dps: 1601.2783803777156
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 1454.679884228535
+  dps: 1453.9589695083166
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1670.3044060003413
+  dps: 1651.9253455720382
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 1671.3032357422123
+  dps: 1670.565416150986
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1647.5198436398853
+  dps: 1661.1211452843563
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1635.932985150251
+  dps: 1615.3029413135926
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1664.9896555273801
+  dps: 1646.8684403525951
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1576.670063843152
+  dps: 1575.943250041135
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1601.8964481658961
+  dps: 1587.4249778197418
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1629.784635417713
+  dps: 1619.7679574007361
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1572.3911054964549
+  dps: 1571.6838857530422
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1646.99987555349
+  dps: 1629.3113066160927
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1634.3223011708735
+  dps: 1617.0974523295404
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1649.3739834473456
+  dps: 1632.0760409541622
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1609.0273288302021
+  dps: 1605.4438078841195
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 1524.169304056666
+  dps: 1523.1293801510385
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DesolationBattlegear"
  value: {
-  dps: 1447.7476244307825
+  dps: 1446.6354704899534
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 1533.4115064763823
+  dps: 1532.7074147290487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Devastation-30316"
  value: {
-  dps: 1587.8558377170548
+  dps: 1587.1486179736435
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1636.6787514209154
+  dps: 1635.5136631178425
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1630.6340667962907
+  dps: 1620.6234346725594
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelstalkerArmor"
  value: {
-  dps: 1593.1830092639245
+  dps: 1592.167160645667
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1604.6789029558943
+  dps: 1603.5276324694091
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1641.8531288138786
+  dps: 1624.8310627775081
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1660.8305407537
+  dps: 1643.5704201631168
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 1533.4115064763823
+  dps: 1532.7074147290487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 1691.0876287874075
+  dps: 1690.347337504578
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 1622.2460700628183
+  dps: 1605.3572080193503
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 1664.9896555273801
+  dps: 1646.8684403525951
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1637.9103702071088
+  dps: 1616.7204069556742
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1628.991812005602
+  dps: 1628.2276741126398
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1668.0021804914468
+  dps: 1667.2585763562722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1603.841762392813
+  dps: 1603.0829313552101
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1578.1439785840842
+  dps: 1595.6452131093154
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1554.3207375708218
+  dps: 1553.6147538610937
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1554.3207375708218
+  dps: 1553.6147538610937
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1646.7228753957936
+  dps: 1645.9599128605591
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1293.5693472930986
+  dps: 1303.5065996201467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1651.8322322093993
+  dps: 1634.2596152440094
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 1624.0207372986654
+  dps: 1622.6991557893514
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1519.2890598955134
+  dps: 1518.5465614897928
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1634.4883141972696
+  dps: 1624.4350652337553
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 1639.8305332719237
+  dps: 1639.077365411001
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1634.2933987826327
+  dps: 1624.2589886037556
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 1600.6021921911563
+  dps: 1596.8141719431014
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1526.8706450289721
+  dps: 1526.164282189987
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1673.4609927555593
+  dps: 1655.2170534458608
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1627.2630004423318
+  dps: 1626.5010514574594
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1603.0085702694844
+  dps: 1586.1954571009562
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1642.93151711183
+  dps: 1625.8750726272774
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1533.4115064763823
+  dps: 1532.7074147290487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1655.1037241789459
+  dps: 1637.1654252425772
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1434.2135381903333
+  dps: 1433.4909261679675
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1542.6588102634123
+  dps: 1523.2517397641127
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1417.0065265972155
+  dps: 1401.325704121595
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1634.4883141972696
+  dps: 1624.4350652337553
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1633.3819145559798
+  dps: 1623.3358710637224
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1672.896236940346
+  dps: 1654.6604792396433
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalonofAl'ar-30448"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1627.8499163495324
+  dps: 1617.839900213557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheBladefist-29348"
  value: {
-  dps: 1533.4115064763823
+  dps: 1532.7074147290487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1668.755303145335
+  dps: 1668.0099420366678
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 1573.4882971324384
+  dps: 1572.78231342271
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheTwinStars"
  value: {
-  dps: 1563.3073165459264
+  dps: 1562.1733495664016
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1631.471281093216
+  dps: 1617.5633619148705
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1622.3227843647503
+  dps: 1621.580150391709
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1637.781028381449
+  dps: 1633.4248420274373
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1685.752836399469
+  dps: 1663.823563176469
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WastewalkerArmor"
  value: {
-  dps: 1420.7530496808115
+  dps: 1396.7826010266729
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WindhawkArmor"
  value: {
-  dps: 1506.6024662850723
+  dps: 1505.8632740071941
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1533.4115064763823
+  dps: 1532.7074147290487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofSpellfire"
  value: {
-  dps: 1493.5093554009202
+  dps: 1489.730872668902
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1616.5985119106997
+  dps: 1599.7914659571722
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 1613.224975411109
+  dps: 1611.888372629602
  }
 }
 dps_results: {
  key: "TestHunter-SelfDrums-DPS"
  value: {
-  dps: 1658.3567081682036
+  dps: 1657.4258614406742
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1830.1105689748633
+  dps: 1829.352401970693
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1619.5992221866643
+  dps: 1618.8828369782789
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1129.8997651838008
+  dps: 1110.0529389311719
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1878.4659401573497
+  dps: 1877.6103974236137
  }
 }
 dps_results: {
@@ -845,25 +845,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1747.7618698046674
+  dps: 1757.8942671047237
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1585.9832668336594
+  dps: 1590.137614373423
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1132.9779892546137
+  dps: 1134.345096016423
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1980.7112357418512
+  dps: 1979.7742873951197
  }
 }
 dps_results: {
@@ -893,25 +893,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1942.96327340017
+  dps: 2023.7600389814993
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1800.6019506942912
+  dps: 1799.789595482798
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1285.9500079453978
+  dps: 1311.9046052901797
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2220.057935162782
+  dps: 2219.084514400039
  }
 }
 dps_results: {
@@ -941,25 +941,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1777.8347379358897
+  dps: 1778.0416117818347
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1601.9055501284208
+  dps: 1644.3976190267779
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1175.9932178752504
+  dps: 1185.8873873439468
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1925.3097237219679
+  dps: 1940.1015560283427
  }
 }
 dps_results: {
@@ -989,25 +989,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1869.9366770912443
+  dps: 1869.1544042394682
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1658.777341560049
+  dps: 1640.7461240842028
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1169.5553735821752
+  dps: 1168.0553992233424
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1939.875171925424
+  dps: 1938.9905735727161
  }
 }
 dps_results: {
@@ -1037,25 +1037,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1815.1977933827636
+  dps: 1814.4242363161395
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1630.076040443771
+  dps: 1631.9317958024633
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1163.0193016317833
+  dps: 1146.3479388688963
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2006.8826964294049
+  dps: 2005.9312977930933
  }
 }
 dps_results: {
@@ -1085,25 +1085,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2060.094470785364
+  dps: 1983.0098933788156
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1861.1942401323352
+  dps: 1860.3510952334827
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1331.6561392549975
+  dps: 1304.2163881341319
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2267.2463171616864
+  dps: 2250.2924995754906
  }
 }
 dps_results: {
@@ -1133,25 +1133,25 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1848.5844578535937
+  dps: 1824.3561900814207
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1648.5521261840597
+  dps: 1646.2783074257231
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1218.0368239776928
+  dps: 1260.4829111392569
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1972.3233038539795
+  dps: 1971.5119157879928
  }
 }
 dps_results: {

--- a/sim/hunter/kill_command.go
+++ b/sim/hunter/kill_command.go
@@ -89,6 +89,9 @@ func (hp *HunterPet) newKillCommandTemplate(sim *core.Simulation) core.SimpleSpe
 				DamageMultiplier: 1,
 				FlatDamageBonus:  127,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -38,6 +38,9 @@ func (hunter *Hunter) newRaptorStrikeTemplate(sim *core.Simulation) core.SimpleS
 				DamageMultiplier: 1,
 				FlatDamageBonus:  170,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestArcane-CharacterStats-Default"
  value: {
-  final_stats: 64.79
-  final_stats: 72.49000000000001
-  final_stats: 371.69
-  final_stats: 569.1234999999999
-  final_stats: 246.29000000000002
-  final_stats: 1125.11952
+  final_stats: 63.800000000000004
+  final_stats: 71.5
+  final_stats: 370.70000000000005
+  final_stats: 567.9849999999999
+  final_stats: 245.3
+  final_stats: 1124.7551999999998
   final_stats: 708
   final_stats: 302
   final_stats: 271
@@ -16,19 +16,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 112.5
   final_stats: 159
-  final_stats: 612.4236503703703
+  final_stats: 612.1133037037037
   final_stats: 0
   final_stats: 0
-  final_stats: 129.58
+  final_stats: 127.60000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 10497.852499999999
+  final_stats: 10480.774999999998
   final_stats: 0
   final_stats: 0
-  final_stats: 1328.98
+  final_stats: 1327
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 11
-  final_stats: 6929.9
+  final_stats: 6920
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,625 +47,625 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AldorRegalia"
  value: {
-  dps: 1254.7920323160815
+  dps: 1266.6472440600326
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1366.7114114167957
+  dps: 1342.5061962890752
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1342.8827005132332
+  dps: 1344.673958216559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1443.5185804048313
+  dps: 1434.7502013305013
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1349.5351154026403
+  dps: 1352.4591747602412
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1331.2630480368755
+  dps: 1334.12057378598
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1339.7766267558516
+  dps: 1342.6770909507034
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1335.8945805882668
+  dps: 1363.4308732246895
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1345.4670607345354
+  dps: 1348.2167899130716
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1335.8945805882668
+  dps: 1363.4308732246895
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1336.2294820317366
+  dps: 1299.3638915515107
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1355.7524281825642
+  dps: 1355.5445225688752
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Despair-28573"
  value: {
-  dps: 1214.5836436971626
+  dps: 1222.914131769748
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1334.591301870877
+  dps: 1354.8467767088432
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1352.7121549576218
+  dps: 1355.6098432509734
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1355.392494333522
+  dps: 1355.1845887198333
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1387.1639816104848
+  dps: 1375.3655288267203
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HandofJustice-11815"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartrazor-29962"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1382.995818982491
+  dps: 1385.9282060445923
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1348.276885554911
+  dps: 1351.0331616709468
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1323.2285948324948
+  dps: 1323.0280256066346
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1214.5836436971626
+  dps: 1222.914131769748
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1214.5836436971626
+  dps: 1222.914131769748
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1214.5836436971626
+  dps: 1222.914131769748
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1154.5341960803837
+  dps: 1167.3898318188842
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1364.5188131031293
+  dps: 1364.310907489441
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1315.2982646032322
+  dps: 1285.3550133047834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1325.851066301916
+  dps: 1375.6246844067412
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1345.8851362934902
+  dps: 1344.274187130885
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1344.190189240739
+  dps: 1348.5919098505901
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1380.6854467503574
+  dps: 1368.7913802313665
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1354.3567259850563
+  dps: 1354.14769377122
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1340.39016322142
+  dps: 1340.1822576077316
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1364.7025954935755
+  dps: 1364.4930943506474
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1322.555764437989
+  dps: 1325.4145901103407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1392.1475781940753
+  dps: 1417.4876636193017
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1268.9725223895614
+  dps: 1284.195907952364
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1347.15295562676
+  dps: 1349.9066129677965
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 1497.025655922327
+  dps: 1465.731543478776
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1372.6420775620547
+  dps: 1372.4333091465055
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1364.0105115653575
+  dps: 1366.9248552677088
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1369.5965984008394
+  dps: 1350.5592788780898
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinStars"
  value: {
-  dps: 1483.3924024815535
+  dps: 1413.8312436830133
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1340.4093760578603
+  dps: 1343.1473207488973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1416.1803333139108
+  dps: 1415.9602853941171
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirisfalRegalia"
  value: {
-  dps: 1537.3244316413234
+  dps: 1537.1345013099801
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1316.012068583139
+  dps: 1315.80416296945
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofSpellfire"
  value: {
-  dps: 1315.9206931761541
+  dps: 1315.7150618954574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1345.2899286466145
+  dps: 1349.6914759333658
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 1341.4008755220316
+  dps: 1338.9190476004069
  }
 }
 dps_results: {
  key: "TestArcane-SelfDrums-DPS"
  value: {
-  dps: 1322.515860363889
+  dps: 1320.892432375975
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1369.2890588298783
+  dps: 1372.20756638448
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1035.3212040090648
+  dps: 1046.280060876221
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2387.641191067592
+  dps: 2387.2936076912697
  }
 }
 dps_results: {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestFire-CharacterStats-Default"
  value: {
-  final_stats: 64.79
-  final_stats: 72.49000000000001
-  final_stats: 371.69
-  final_stats: 494.89000000000004
-  final_stats: 246.29000000000002
-  final_stats: 977.6423
+  final_stats: 63.800000000000004
+  final_stats: 71.5
+  final_stats: 370.70000000000005
+  final_stats: 493.90000000000003
+  final_stats: 245.3
+  final_stats: 977.573
   final_stats: 708
   final_stats: 222
   final_stats: 351
@@ -16,19 +16,19 @@ character_stats_results: {
   final_stats: 80
   final_stats: 100
   final_stats: 196.86
-  final_stats: 592.1881481481482
+  final_stats: 591.9182814814815
   final_stats: 0
   final_stats: 0
-  final_stats: 129.58
+  final_stats: 127.60000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 9384.35
+  final_stats: 9369.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1328.98
+  final_stats: 1327
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 11
-  final_stats: 6929.9
+  final_stats: 6920
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,409 +47,409 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AldorRegalia"
  value: {
-  dps: 1601.5734166817315
+  dps: 1628.0149354354887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1778.3849878233418
+  dps: 1783.6188049337861
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1878.7008976594018
+  dps: 1878.6403810008953
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1989.0684719430635
+  dps: 1989.0058965029623
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1883.6581848879853
+  dps: 1883.5976682294797
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1842.73748920076
+  dps: 1888.4667056100661
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1868.8128285443868
+  dps: 1868.7523118858812
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1732.0601065284743
+  dps: 1803.7039452445915
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1797.513008206102
+  dps: 1810.9789211034883
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1732.0601065284743
+  dps: 1803.7039452445915
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1784.6206155546033
+  dps: 1791.2398834658748
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1911.5928304091349
+  dps: 1911.5323137506275
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Despair-28573"
  value: {
-  dps: 1568.5463137319214
+  dps: 1565.9254960856915
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1872.414823916162
+  dps: 1872.3554768196184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1890.7916788724021
+  dps: 1861.988691896769
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1885.6525803358159
+  dps: 1885.5920636773087
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1896.23463427079
+  dps: 1896.174117612283
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1844.9894990086668
+  dps: 1811.6696239170751
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HandofJustice-11815"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartrazor-29962"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1928.5108715908664
+  dps: 1928.4503549323597
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1801.59862320358
+  dps: 1815.0954992744723
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1835.4279599137872
+  dps: 1869.245457576485
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1568.5463137319214
+  dps: 1565.9254960856915
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1568.5463137319214
+  dps: 1565.9254960856915
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1568.5463137319214
+  dps: 1565.9254960856915
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1502.665435106653
+  dps: 1504.3274509929145
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1916.8419225972063
+  dps: 1916.7814059386992
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1768.5912200353412
+  dps: 1768.5329776517938
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1839.550287289916
+  dps: 1832.8844777651411
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1824.5334578038937
+  dps: 1838.4532524442125
  }
 }
 dps_results: {
@@ -461,91 +461,91 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1872.7820856615056
+  dps: 1872.7215690029986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1842.73748920076
+  dps: 1888.4667056100661
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1874.6402716272871
+  dps: 1921.8307680664589
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1867.5055655269805
+  dps: 1913.2347819362876
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1852.0144691218518
+  dps: 1800.3115490147168
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1958.8968576056793
+  dps: 1935.969379651871
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1710.5201003988839
+  dps: 1711.2895570615706
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1799.9643772045877
+  dps: 1813.4488680060786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
@@ -557,49 +557,49 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1799.4664291888305
+  dps: 1799.311713604965
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1901.9515967491122
+  dps: 1901.8910800906065
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1815.512982986124
+  dps: 1793.1835082030425
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinStars"
  value: {
-  dps: 1857.3046506405346
+  dps: 1864.2656612018518
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1790.1589012106404
+  dps: 1803.569080395719
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1891.7351975294607
+  dps: 1908.3899532126395
  }
 }
 dps_results: {
@@ -611,61 +611,61 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1842.6151408792143
+  dps: 1842.5546242207072
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WrathofSpellfire"
  value: {
-  dps: 1750.4537002933018
+  dps: 1769.5967917476494
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1870.974237892055
+  dps: 1918.548411116709
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 1761.4366364189584
+  dps: 1759.3473052404795
  }
 }
 dps_results: {
  key: "TestFire-SelfDrums-DPS"
  value: {
-  dps: 1863.3843725066563
+  dps: 1781.7691435173142
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll10-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll10-P1Fire-FireRotation-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1909.2648666021034
+  dps: 1909.2043499435977
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll10-P1Fire-FireRotation-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1299.7282098193268
+  dps: 1276.9626957001376
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll10-P1Fire-FireRotation-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2438.034919526872
+  dps: 2437.9601439392454
  }
 }
 dps_results: {

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestFrost-CharacterStats-Default"
  value: {
-  final_stats: 64.79
-  final_stats: 72.49000000000001
-  final_stats: 371.69
-  final_stats: 494.89000000000004
-  final_stats: 246.29000000000002
-  final_stats: 977.6423
+  final_stats: 63.800000000000004
+  final_stats: 71.5
+  final_stats: 370.70000000000005
+  final_stats: 493.90000000000003
+  final_stats: 245.3
+  final_stats: 977.573
   final_stats: 708
   final_stats: 222
   final_stats: 351
@@ -16,19 +16,19 @@ character_stats_results: {
   final_stats: 80
   final_stats: 100
   final_stats: 196.86
-  final_stats: 592.1881481481482
+  final_stats: 591.9182814814815
   final_stats: 0
   final_stats: 0
-  final_stats: 129.58
+  final_stats: 127.60000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 9384.35
+  final_stats: 9369.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1328.98
+  final_stats: 1327
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 11
-  final_stats: 6929.9
+  final_stats: 6920
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,13 +47,13 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
@@ -65,337 +65,337 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1577.837102445224
+  dps: 1577.7751448139184
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1595.4979104050437
+  dps: 1595.4368536882416
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1659.5105823758925
+  dps: 1659.4488555862058
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1595.783159073544
+  dps: 1595.7221023567417
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1571.6715374932346
+  dps: 1571.6098107035484
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1580.8053208970432
+  dps: 1580.744264180242
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1589.640959471183
+  dps: 1589.58053371192
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1578.574010282645
+  dps: 1578.5150953483162
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1589.640959471183
+  dps: 1589.58053371192
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1589.9370220275825
+  dps: 1589.8762807895503
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1622.8970621924436
+  dps: 1622.8360054756417
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Despair-28573"
  value: {
-  dps: 1431.7518511025683
+  dps: 1431.6914253433067
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1586.1254170073653
+  dps: 1586.065923212908
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1590.709540464079
+  dps: 1590.6491520123998
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1600.8076851686437
+  dps: 1600.7466284518416
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1617.1415071070437
+  dps: 1617.0804503902418
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1571.1836069203132
+  dps: 1571.122550203511
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HandofJustice-11815"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartrazor-29962"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1647.4563404339435
+  dps: 1647.3952837171425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1582.8247270451452
+  dps: 1582.7658121108168
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1578.9465422556418
+  dps: 1578.8873378912492
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1431.7518511025683
+  dps: 1431.6914253433067
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1431.7518511025683
+  dps: 1431.6914253433067
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1431.7518511025683
+  dps: 1431.6914253433067
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
@@ -407,49 +407,49 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1625.1610012820433
+  dps: 1625.0999445652421
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1561.9644954483588
+  dps: 1561.9030033507465
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1621.6000959399541
+  dps: 1621.5390611418404
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1609.7636964445744
+  dps: 1609.703270685312
  }
 }
 dps_results: {
@@ -461,91 +461,91 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1582.7788144820438
+  dps: 1582.7177577652424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1584.1349463110905
+  dps: 1584.0735350001735
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1607.1723585472348
+  dps: 1607.1106317575488
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1592.3932481885906
+  dps: 1592.331836877674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1685.8587075051855
+  dps: 1685.7947370992194
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1609.879947945544
+  dps: 1609.8188912287424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1524.5699426303668
+  dps: 1524.5110276960393
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1581.124440340145
+  dps: 1581.0655254058167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
@@ -557,49 +557,49 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1578.7515092973476
+  dps: 1578.69147010929
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1618.1954116640438
+  dps: 1618.134354947242
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1610.0390389279282
+  dps: 1609.977832240778
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 1627.6965102587865
+  dps: 1627.635769020755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1570.9227201101455
+  dps: 1570.8638051758164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1593.1400111600442
+  dps: 1593.0789544432419
  }
 }
 dps_results: {
@@ -611,61 +611,61 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1554.3738417620436
+  dps: 1554.3127850452424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 1581.875126058865
+  dps: 1581.8140693420637
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1600.7593646932348
+  dps: 1600.6976379035484
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 1621.1839636545021
+  dps: 1621.000588781599
  }
 }
 dps_results: {
  key: "TestFrost-SelfDrums-DPS"
  value: {
-  dps: 1648.4714366469964
+  dps: 1648.4095795292062
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1626.334636062544
+  dps: 1626.273579345742
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1436.1153171852127
+  dps: 1436.0612354275925
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2365.1777326422252
+  dps: 2365.0922155846033
  }
 }
 dps_results: {

--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -46,6 +46,9 @@ func (paladin *Paladin) newCrusaderStrikeTemplate(sim *core.Simulation) core.Sim
 			WeaponInput: core.WeaponDamageInput{
 				DamageMultiplier: 1.1, // maybe this isn't the one that should be set to 1.1
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestShadow-CharacterStats-Default"
  value: {
-  final_stats: 69.19
-  final_stats: 74.69000000000001
-  final_stats: 559.79
-  final_stats: 561.99
-  final_stats: 301.29
+  final_stats: 68.2
+  final_stats: 73.7
+  final_stats: 558.8000000000001
+  final_stats: 561
+  final_stats: 300.3
   final_stats: 1282
   final_stats: 1011
   final_stats: 0
@@ -16,7 +16,7 @@ character_stats_results: {
   final_stats: 235
   final_stats: 142
   final_stats: 174.86
-  final_stats: 537.12844
+  final_stats: 536.8552
   final_stats: 122
   final_stats: 0
   final_stats: 0
@@ -25,18 +25,18 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 10769.85
+  final_stats: 10755
   final_stats: 0
   final_stats: 0
-  final_stats: 1651.38
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 1649.4
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 8808.9
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 8799
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -623,7 +623,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-WrathofSpellfire"
  value: {
-  dps: 1313.880732358273
+  dps: 1313.843841698116
  }
 }
 dps_results: {
@@ -635,7 +635,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 1486.997647299497
+  dps: 1487.1135435720862
  }
 }
 dps_results: {
@@ -755,7 +755,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1175.1023202222511
+  dps: 1181.9577932034179
  }
 }
 dps_results: {

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestSmite-CharacterStats-Default"
  value: {
-  final_stats: 69.19
-  final_stats: 74.69000000000001
-  final_stats: 559.79
-  final_stats: 561.99
-  final_stats: 356.29
-  final_stats: 1477.0365749999999
+  final_stats: 68.2
+  final_stats: 73.7
+  final_stats: 558.8000000000001
+  final_stats: 561
+  final_stats: 355.3
+  final_stats: 1476.67275
   final_stats: 1011
   final_stats: 80
   final_stats: 0
@@ -16,7 +16,7 @@ character_stats_results: {
   final_stats: 155
   final_stats: 142
   final_stats: 174.86
-  final_stats: 537.12844
+  final_stats: 536.8552
   final_stats: 122
   final_stats: 0
   final_stats: 0
@@ -25,18 +25,18 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 11846.835000000001
+  final_stats: 11830.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1651.38
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 1649.4
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 8808.9
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 8799
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,625 +47,625 @@ character_stats_results: {
 dps_results: {
  key: "TestSmite-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AbsolutionRegalia"
  value: {
-  dps: 857.134341964138
+  dps: 957.2784674335205
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 1036.2558406954333
+  dps: 1026.3072876538954
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AvatarRegalia"
  value: {
-  dps: 936.9867014476037
+  dps: 934.2728998058984
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1027.974340859181
+  dps: 1014.3089642055288
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1072.6196846542837
+  dps: 1072.4743116032203
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1039.608378195289
+  dps: 1039.4530901313733
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1031.4884690845745
+  dps: 1031.331156120786
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1031.989627584665
+  dps: 1027.7873991349763
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1044.017753773558
+  dps: 1034.4968342845198
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1063.322077457709
+  dps: 1064.3972337767004
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1044.017753773558
+  dps: 1034.4968342845198
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1090.470022214817
+  dps: 1079.1669005837214
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1052.1360246504403
+  dps: 1046.065709771653
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1050.95351471761
+  dps: 1049.7203754019984
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1085.3603869445817
+  dps: 1066.595268295419
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1068.5501726832551
+  dps: 1062.4383302389635
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1041.1203183846642
+  dps: 1035.2865624670383
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1053.0340120559147
+  dps: 1052.8787239919984
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1031.800931095136
+  dps: 1030.6053157737101
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1011.5709645621436
+  dps: 1002.2277182597339
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-HandofJustice-11815"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartrazor-29962"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1063.5153420452898
+  dps: 1065.0167661101236
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1065.5744004983333
+  dps: 1066.6546225423251
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncarnateRaiment"
  value: {
-  dps: 707.2169771556121
+  dps: 688.3867334573872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1088.6413528814028
+  dps: 1088.4805640927382
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 703.8782563183363
+  dps: 703.534262225853
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1055.9048018801104
+  dps: 1054.6692503144977
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1031.1269995839284
+  dps: 1027.2620366723772
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1064.1747158571393
+  dps: 1070.361582498506
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1042.533770562624
+  dps: 1041.6805549789676
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1091.8567014653413
+  dps: 1086.3221156134948
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1051.6051214095742
+  dps: 1051.4478084457858
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1044.3931114908244
+  dps: 1044.235798527036
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1035.6246008701141
+  dps: 1035.4696164681857
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1096.6053955689206
+  dps: 1078.544900698243
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 945.8631514951711
+  dps: 947.7494310621157
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1064.6734712820835
+  dps: 1065.7516670360749
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1034.8919735272323
+  dps: 1033.7346039788397
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1049.543942728414
+  dps: 1049.3886546644985
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheTwinStars"
  value: {
-  dps: 1080.8470215381503
+  dps: 1080.7502984922146
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1052.2361953375178
+  dps: 1058.2060106322433
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1062.635419183137
+  dps: 1062.4787716734643
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1013.3407302079336
+  dps: 1003.9971892663955
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-WorldBreaker-30090"
  value: {
-  dps: 891.0811555327313
+  dps: 899.9082976995277
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-WrathofSpellfire"
  value: {
-  dps: 908.9565815825405
+  dps: 905.6822166468809
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1038.3135945950344
+  dps: 1038.1565762703744
  }
 }
 dps_results: {
  key: "TestSmite-Average-Default"
  value: {
-  dps: 1049.7133258967808
+  dps: 1048.5123906171116
  }
 }
 dps_results: {
  key: "TestSmite-SelfDrums-DPS"
  value: {
-  dps: 1051.3829492776244
+  dps: 1052.4449718715866
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P3-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P3-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1053.4024083490394
+  dps: 1054.4641363038731
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P3-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 940.2050098145666
+  dps: 938.2851593506153
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P3-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1221.9508271399689
+  dps: 1221.7713738923171
  }
 }
 dps_results: {

--- a/sim/raid_test.go
+++ b/sim/raid_test.go
@@ -142,5 +142,5 @@ func TestBasicRaid(t *testing.T) {
 		SimOptions: SimOptions,
 	}
 
-	core.RaidSimTest("P1 ST", t, rsr, 6457.86)
+	core.RaidSimTest("P1 ST", t, rsr, 6437.773763)
 }

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestMutilate-CharacterStats-Default"
  value: {
-  final_stats: 131.89000000000001
-  final_stats: 763.2900000000001
-  final_stats: 502.59000000000003
-  final_stats: 70.29
-  final_stats: 100.30900000000003
+  final_stats: 130.9
+  final_stats: 762.3000000000001
+  final_stats: 501.6
+  final_stats: 69.30000000000001
+  final_stats: 99.22000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -19,16 +19,16 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2709.6800000000003
+  final_stats: 2707.2000000000003
   final_stats: 361.85
-  final_stats: 703.5120800000001
+  final_stats: 702.9656
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3630.58
+  final_stats: 3628.6000000000004
   final_stats: 1312
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 8549.900000000001
+  final_stats: 8540
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,613 +47,613 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1255.7402996044364
+  dps: 1255.0846851493943
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1263.3276840614383
+  dps: 1262.6591773718437
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1088.1154233751595
+  dps: 1087.530181106127
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1237.9857925105107
+  dps: 1237.3359168860834
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1236.4795967261778
+  dps: 1235.8246354532187
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1264.6823128576632
+  dps: 1264.0444432505726
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1227.990360431872
+  dps: 1227.3573771916429
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1241.1499544321698
+  dps: 1240.4923720226511
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1237.819963146554
+  dps: 1237.1761881718155
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1263.8762069082252
+  dps: 1263.2324319334857
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1301.3578532534302
+  dps: 1300.6936101627246
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1245.3346787144783
+  dps: 1244.6806878268983
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1253.8598940851878
+  dps: 1253.216119110447
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1256.8981861591428
+  dps: 1255.1755842445693
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1252.9819619032369
+  dps: 1252.3376445790227
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1234.6857102470447
+  dps: 1234.0553689123028
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1247.0417706856983
+  dps: 1246.4001202182903
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1249.2369844661405
+  dps: 1245.6930133684646
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1243.5850787501809
+  dps: 1242.9413037754412
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1248.0457634993654
+  dps: 1247.4019885246257
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1247.8712089247113
+  dps: 1247.2274339499688
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1236.3620951006449
+  dps: 1235.70748700139
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1197.5522847302127
+  dps: 1196.9372146026883
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1253.8598940851878
+  dps: 1253.216119110447
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1230.9887445893971
+  dps: 1228.8531179337933
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1239.4314960730276
+  dps: 1238.7877210982851
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1256.3889674834343
+  dps: 1255.7451925086948
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HandofJustice-11815"
  value: {
-  dps: 1207.3993839114603
+  dps: 1206.7610263848233
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Heartrazor-29962"
  value: {
-  dps: 1253.8598940851878
+  dps: 1253.216119110447
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1254.317427133214
+  dps: 1253.6610992875696
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1237.9742895791444
+  dps: 1237.317931334972
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1250.2999016568428
+  dps: 1249.6377190632086
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1250.4510052222852
+  dps: 1249.8008616487684
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 941.5488389352271
+  dps: 941.0003966364668
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1255.8693509819852
+  dps: 1255.225576007244
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1156.071432320605
+  dps: 1155.4631813299738
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1232.3859379545763
+  dps: 1231.755596619835
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1243.0335294419172
+  dps: 1242.4048192358575
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1253.8598940851878
+  dps: 1253.216119110447
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1189.734342991524
+  dps: 1189.1084506705245
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1238.3344604416495
+  dps: 1237.6874344286525
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1206.3531920789187
+  dps: 1205.7094171041797
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1223.566317723961
+  dps: 1222.9211113791096
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1270.9816691056847
+  dps: 1270.3242066729533
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1337.460221501565
+  dps: 1336.7787363883026
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1250.6101817718798
+  dps: 1249.9664067971398
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1077.032646298044
+  dps: 1075.5123559324074
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1074.250533818155
+  dps: 1073.6579724179223
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1232.3859379545763
+  dps: 1231.755596619835
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1231.3692583824113
+  dps: 1230.7389170476686
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1226.2858605215883
+  dps: 1225.6555191868472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1253.8598940851878
+  dps: 1253.216119110447
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1223.566317723961
+  dps: 1222.9211113791096
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1200.1612176567444
+  dps: 1196.2233958756806
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1249.4136011034655
+  dps: 1248.7702429936467
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1227.606462897553
+  dps: 1226.961469003435
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1269.7423803246397
+  dps: 1267.5549510436322
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1263.116653134449
+  dps: 1262.4473045951263
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1084.681689631719
+  dps: 1084.096990118095
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1090.9625423820694
+  dps: 1090.3672177580843
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1102.8845141309446
+  dps: 1102.2858822297178
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1217.0530284774889
+  dps: 1216.4092535027505
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1248.270581738793
+  dps: 1247.2709741878793
  }
 }
 dps_results: {
  key: "TestMutilate-SelfDrums-DPS"
  value: {
-  dps: 1274.3423604925424
+  dps: 1273.6911965089073
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1262.080629728486
+  dps: 1261.4370050726616
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1253.5743487334873
+  dps: 1252.9305737587479
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1144.5071921692734
+  dps: 1143.9246234616262
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1453.2818067705666
+  dps: 1452.528574499778
  }
 }
 dps_results: {
@@ -683,25 +683,25 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1262.3661084064745
+  dps: 1261.7224837506478
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1253.8598940851878
+  dps: 1253.216119110447
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1144.7655895799219
+  dps: 1144.1830208722768
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1453.6159017293833
+  dps: 1452.8626694585953
  }
 }
 dps_results: {

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestRogue-CharacterStats-Default"
  value: {
-  final_stats: 131.89000000000001
-  final_stats: 787.5318000000001
-  final_stats: 522.6936000000001
-  final_stats: 70.29
-  final_stats: 100.30900000000003
+  final_stats: 130.9
+  final_stats: 786.522
+  final_stats: 521.6640000000001
+  final_stats: 69.30000000000001
+  final_stats: 99.22000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -19,16 +19,16 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2733.9218
+  final_stats: 2731.422
   final_stats: 346.85
-  final_stats: 716.8935536000001
+  final_stats: 716.3361440000001
   final_stats: 0
   final_stats: 0
   final_stats: 53.4
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3679.0636000000004
+  final_stats: 3677.044
   final_stats: 1312
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 8750.936000000002
+  final_stats: 8740.640000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,739 +47,739 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1440.4085729457022
+  dps: 1439.6154637346942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1448.2522952863405
+  dps: 1447.4432947783223
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1208.485599045643
+  dps: 1207.7952652857352
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1439.7822722002572
+  dps: 1438.986671239854
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1436.2500909287244
+  dps: 1435.4474183740117
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1473.8889569208204
+  dps: 1473.1050562713012
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1428.63668715403
+  dps: 1427.857140825064
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1428.6410971808623
+  dps: 1427.843955272265
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1436.8909675777718
+  dps: 1436.1029991518424
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1471.139844925027
+  dps: 1470.3518764990995
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1486.485453490547
+  dps: 1485.6815984033503
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1433.3424612789536
+  dps: 1432.550486307058
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1436.5450548852293
+  dps: 1435.7662172613277
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1456.3273002355504
+  dps: 1454.8062129177279
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1436.9135234319767
+  dps: 1436.1405839631323
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1451.2010125196584
+  dps: 1450.4148286513325
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1445.1484557499714
+  dps: 1444.36393757618
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1445.3409881719842
+  dps: 1444.5530197460519
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1446.174423799463
+  dps: 1445.3864553735339
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1449.0174597218383
+  dps: 1448.2294912959064
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1421.0918492567146
+  dps: 1416.8377072153824
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1350.4919092079865
+  dps: 1349.1096922316456
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Despair-28573"
  value: {
-  dps: 996.7871063315957
+  dps: 996.2535790002732
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Devastation-30316"
  value: {
-  dps: 1213.0129365980401
+  dps: 1212.4613413760173
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1431.0497872051112
+  dps: 1430.2751641913558
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1440.8524684611614
+  dps: 1440.0645000352292
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1460.6935316779925
+  dps: 1459.9055632520617
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 955.8006719374307
+  dps: 955.3031521561555
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HandofJustice-11815"
  value: {
-  dps: 1420.8036668999875
+  dps: 1420.0096717819463
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Heartrazor-29962"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1439.7972202179997
+  dps: 1439.0035229338707
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1446.1694230331682
+  dps: 1445.3549593749074
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 957.8207897713261
+  dps: 957.3023262094877
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1448.3189051571235
+  dps: 1447.511439854961
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1060.8172363888307
+  dps: 1060.2675589312273
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1096.0640195868593
+  dps: 1095.5143421292573
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1444.7683889710122
+  dps: 1443.9773357754825
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1051.269478605201
+  dps: 1050.6096359985288
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1458.9558486942835
+  dps: 1458.1678802683564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1272.8513945756958
+  dps: 1272.139701581463
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1435.6990576867404
+  dps: 1434.9261182178934
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1426.188210998029
+  dps: 1425.4274769177262
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1370.3129685969834
+  dps: 1369.5486929954461
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1448.275993856127
+  dps: 1447.4713397893734
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1396.728237424999
+  dps: 1395.9402689990693
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1413.1917519514934
+  dps: 1412.404347575065
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1449.4403260864667
+  dps: 1448.6457797431988
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 921.2205724442333
+  dps: 920.7094503474393
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1565.7795744017626
+  dps: 1564.939058083509
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1454.3063311327712
+  dps: 1453.5183627068407
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1236.852510865191
+  dps: 1236.1350660350424
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1196.5899327515485
+  dps: 1195.8853822105486
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1435.6990576867404
+  dps: 1434.9261182178934
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1434.4622555924198
+  dps: 1433.689316123575
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1428.2782451208193
+  dps: 1427.5053056519728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheBladefist-29348"
  value: {
-  dps: 1314.4074263388598
+  dps: 1313.6696126181223
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1292.2194593127465
+  dps: 1291.5494612748093
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1411.5768829027927
+  dps: 1410.7894785263643
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1638.482030949168
+  dps: 1637.6808120776525
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1345.616803946215
+  dps: 1344.8705612655901
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1472.8431590624702
+  dps: 1472.048053906673
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1411.4036951182889
+  dps: 1410.6180462078073
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1471.941814697683
+  dps: 1471.137060337742
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1450.0425433699336
+  dps: 1449.2324535483879
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1256.8743079988033
+  dps: 1256.1472632560426
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1298.8939448724411
+  dps: 1295.9780329971993
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1002.9596606764353
+  dps: 1002.4461512734011
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1222.3172769472237
+  dps: 1221.6107271468109
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1411.6739605874695
+  dps: 1410.8859921615403
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1409.7195529302564
+  dps: 1408.672281175968
  }
 }
 dps_results: {
  key: "TestRogue-SelfDrums-DPS"
  value: {
-  dps: 1450.9916112285298
+  dps: 1450.206114395894
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1735.0819358900585
+  dps: 1734.1478457302055
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1407.4496675958533
+  dps: 1406.691057427322
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1267.6168067061888
+  dps: 1266.9318820825563
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1703.019003896285
+  dps: 1702.1145318108831
  }
 }
 dps_results: {
@@ -809,25 +809,25 @@ dps_results: {
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1807.3585965962968
+  dps: 1803.9715323991138
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1494.7298815422155
+  dps: 1491.620356662467
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1184.6184910642512
+  dps: 1184.0033615999387
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1852.8371378839788
+  dps: 1851.8972523840134
  }
 }
 dps_results: {
@@ -855,75 +855,27 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-LongMultiTarget"
- value: {
-  dps: 1351.3663542194574
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-LongSingleTargetFullDebuffs"
- value: {
-  dps: 1345.1266750321852
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-LongSingleTargetNoDebuffs"
- value: {
-  dps: 1212.8698548535963
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-FullBuffs-ShortSingleTargetFullDebuffs"
- value: {
-  dps: 1635.9804142890632
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-LongMultiTarget"
- value: {
-  dps: 658.0438871716191
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-LongSingleTargetFullDebuffs"
- value: {
-  dps: 658.0438871716191
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-LongSingleTargetNoDebuffs"
- value: {
-  dps: 573.3805122082463
- }
-}
-dps_results: {
- key: "TestRogue-Settings-BloodElf-P1-Mutilate-NoBuffs-ShortSingleTargetFullDebuffs"
- value: {
-  dps: 770.6094639894617
- }
-}
-dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1783.2936982622466
+  dps: 1782.331236870145
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1458.3828694054764
+  dps: 1457.5949009795474
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1288.9754330900626
+  dps: 1288.2820299509847
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1802.693771411003
+  dps: 1801.7353589882325
  }
 }
 dps_results: {
@@ -953,25 +905,25 @@ dps_results: {
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1881.3422195962378
+  dps: 1878.3130433325364
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1539.931038142045
+  dps: 1539.148401481155
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1211.653845509048
+  dps: 1211.0263782258162
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1905.9456745193188
+  dps: 1904.981860725482
  }
 }
 dps_results: {
@@ -996,53 +948,5 @@ dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
   dps: 1004.4388343805124
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-LongMultiTarget"
- value: {
-  dps: 1346.8628331069494
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-LongSingleTargetFullDebuffs"
- value: {
-  dps: 1338.143540575394
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-LongSingleTargetNoDebuffs"
- value: {
-  dps: 1221.580985911789
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-FullBuffs-ShortSingleTargetFullDebuffs"
- value: {
-  dps: 1619.9381628502308
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-LongMultiTarget"
- value: {
-  dps: 646.2372072598347
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-LongSingleTargetFullDebuffs"
- value: {
-  dps: 646.2372072598347
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-LongSingleTargetNoDebuffs"
- value: {
-  dps: 582.1479618549839
- }
-}
-dps_results: {
- key: "TestRogue-Settings-Human-P1-Mutilate-NoBuffs-ShortSingleTargetFullDebuffs"
- value: {
-  dps: 747.5796022402682
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -24,6 +24,9 @@ func (rogue *Rogue) newBackstabTemplate(_ *core.Simulation) core.SimpleSpellTemp
 		FlatDamageBonus:  170,
 		DamageMultiplier: 1.5,
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	// all these use "Apply Aura: Modifies Damage/Healing Done", and stack additively (up to 142%)
 	ability.Effect.StaticDamageMultiplier += 0.02 * float64(rogue.Talents.Aggression)

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -57,6 +57,9 @@ func (rogue *Rogue) newHemorrhageTemplate(_ *core.Simulation) core.SimpleSpellTe
 		Normalized:       true,
 		DamageMultiplier: 1.1,
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	// cp. backstab
 	if ItemSetSlayers.CharacterHasSetBonus(&rogue.Character, 4) {

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -38,6 +38,9 @@ func (rogue *Rogue) newMutilateTemplate(_ *core.Simulation) core.SimpleSpellTemp
 				FlatDamageBonus:  101,
 				DamageMultiplier: 1,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -31,6 +31,9 @@ func (rogue *Rogue) newShivTemplate(_ *core.Simulation) core.SimpleSpellTemplate
 		Offhand:          true,
 		DamageMultiplier: 1 + 0.1*float64(rogue.Talents.DualWieldSpecialization),
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	if rogue.Talents.SurpriseAttacks {
 		ability.Effect.StaticDamageMultiplier += 0.1

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -27,6 +27,9 @@ func (rogue *Rogue) newSinisterStrikeTemplate(_ *core.Simulation) core.SimpleSpe
 		FlatDamageBonus:  98,
 		DamageMultiplier: 1,
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	// cp. backstab
 	ability.Effect.StaticDamageMultiplier += 0.02 * float64(rogue.Talents.Aggression)

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestElemental-CharacterStats-Default"
  value: {
-  final_stats: 140.69000000000003
-  final_stats: 99.99000000000001
-  final_stats: 522.39
-  final_stats: 531.19
-  final_stats: 182.49
+  final_stats: 139.70000000000002
+  final_stats: 99.00000000000001
+  final_stats: 521.4000000000001
+  final_stats: 530.2
+  final_stats: 181.50000000000003
   final_stats: 1109
   final_stats: 791
   final_stats: 80
@@ -14,21 +14,21 @@ character_stats_results: {
   final_stats: 80
   final_stats: 123
   final_stats: 0
-  final_stats: 337.8714
+  final_stats: 337.812
   final_stats: 125.72
-  final_stats: 695.7050985915492
+  final_stats: 695.4252112676056
   final_stats: 0
   final_stats: 0
-  final_stats: 401.38000000000005
+  final_stats: 399.40000000000003
   final_stats: 47.31
-  final_stats: 125.381168
+  final_stats: 124.5068
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 10645.85
+  final_stats: 10631
   final_stats: 0
   final_stats: 0
-  final_stats: 9369.98
+  final_stats: 9368
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 8202.9
+  final_stats: 8193
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,19 +50,19 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.18023853529658934
+  weights: 0.16112783362449817
   weights: 0
-  weights: 0.6806127371492108
-  weights: 0
-  weights: 0
+  weights: 0.6801424906723196
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.5521285960051727
-  weights: 0.568961833403464
+  weights: 0
+  weights: 0
+  weights: 1.5738861004865612
+  weights: 0.5597317644631266
   weights: 0
   weights: 0
   weights: 0
@@ -753,7 +753,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TheTwinStars"
  value: {
-  dps: 1539.6377343286629
+  dps: 1532.1521622827709
  }
 }
 dps_results: {
@@ -807,7 +807,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-WrathofSpellfire"
  value: {
-  dps: 1437.1095849584858
+  dps: 1437.0625450233526
  }
 }
 dps_results: {
@@ -819,7 +819,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 1538.353621763681
+  dps: 1538.2053569429108
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestEnhancement-CharacterStats-Default"
  value: {
-  final_stats: 518.98
-  final_stats: 511.995
-  final_stats: 594.99
-  final_stats: 314.49
-  final_stats: 160.49
-  final_stats: 826.0380000000001
+  final_stats: 517
+  final_stats: 510.40000000000003
+  final_stats: 594
+  final_stats: 313.5
+  final_stats: 159.5
+  final_stats: 824.7000000000002
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -16,19 +16,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 150
   final_stats: 0
-  final_stats: 136.8008732394366
+  final_stats: 136.52098591549296
   final_stats: 0
   final_stats: 0
-  final_stats: 2753.46
+  final_stats: 2749
   final_stats: 270.62
-  final_stats: 879.063984
+  final_stats: 877.65528
   final_stats: 0
   final_stats: 0
   final_stats: 35
-  final_stats: 7765.1175
+  final_stats: 7749.525
   final_stats: 0
   final_stats: 0
-  final_stats: 5451.99
+  final_stats: 5448.8
   final_stats: 1213
   final_stats: 0
   final_stats: 0
@@ -36,7 +36,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 8928.9
+  final_stats: 8919
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,822 +47,822 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1869.3086120844346
+  dps: 1867.558449501429
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 1865.2660757517772
+  dps: 1863.5512303918745
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1821.8437622886734
+  dps: 1820.1232676931513
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1841.738077374654
+  dps: 1839.9969585581055
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1869.8789563667372
+  dps: 1868.169470285684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1850.5281992257246
+  dps: 1848.8035639321358
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1822.7275124735786
+  dps: 1821.0126671136752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1871.4489785327487
+  dps: 1864.9848985444964
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1817.0411517844868
+  dps: 1815.3259553075752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1847.237865841919
+  dps: 1845.5230204820136
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1820.4671618530158
+  dps: 1818.7523164931133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1880.5873805417698
+  dps: 1878.872535181865
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1901.3896182156134
+  dps: 1898.0830612729708
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1872.0348828016029
+  dps: 1870.2653754883827
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1870.1995756734561
+  dps: 1854.6369122067365
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1835.4058307677035
+  dps: 1813.8279283536924
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1839.2393575536173
+  dps: 1833.318004635461
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1840.5592232022268
+  dps: 1819.060991478588
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmHarness"
  value: {
-  dps: 1749.320839967276
+  dps: 1747.6330239089764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmRegalia"
  value: {
-  dps: 1482.6002008651033
+  dps: 1481.0786459381
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1862.8760441205593
+  dps: 1841.2885284212616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1860.255790738876
+  dps: 1857.129696969769
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1852.8634482812718
+  dps: 1851.148602921369
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1843.792398103827
+  dps: 1842.0775527439262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneHarness"
  value: {
-  dps: 1581.3574739473236
+  dps: 1588.3423192160772
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneRegalia"
  value: {
-  dps: 1477.0899528103414
+  dps: 1456.4293360754416
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1826.1114263560137
+  dps: 1824.396580996111
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1865.820366438023
+  dps: 1864.1055210781205
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1871.695446716341
+  dps: 1869.9114581178246
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DesolationBattlegear"
  value: {
-  dps: 1576.0217590824586
+  dps: 1574.429345413526
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1834.5556812084737
+  dps: 1813.054990104286
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Devastation-30316"
  value: {
-  dps: 1759.056386858572
+  dps: 1744.2029791329041
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1809.518030795283
+  dps: 1806.7835124620585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1838.404987979877
+  dps: 1836.7185426989054
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1822.702272751501
+  dps: 1820.9874273915977
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1834.2118582453768
+  dps: 1812.711381891653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1828.7296106699696
+  dps: 1827.0147653100667
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Fathom-BroochoftheTidewalker-30663"
  value: {
-  dps: 1798.7087025790495
+  dps: 1797.0040651661845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelstalkerArmor"
  value: {
-  dps: 1676.9559889461736
+  dps: 1675.34765749783
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1846.1669735275275
+  dps: 1798.8622471471178
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1847.953450622198
+  dps: 1846.2386052622953
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1874.4452961370885
+  dps: 1872.7304507771826
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HandofJustice-11815"
  value: {
-  dps: 1850.759541982557
+  dps: 1849.0146571946482
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartrazor-29962"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1828.8557709544793
+  dps: 1827.1409255945748
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1883.7066953502765
+  dps: 1881.93418643818
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1887.363409813567
+  dps: 1885.5652036179583
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1826.1114263560137
+  dps: 1824.396580996111
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1836.0691488356617
+  dps: 1814.448231943713
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1855.306263518254
+  dps: 1853.366106725512
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1837.6724839079582
+  dps: 1835.9334168310304
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1844.751457677319
+  dps: 1838.79295857173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1458.1743050234786
+  dps: 1447.1615644706806
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1862.97161617423
+  dps: 1861.2567708143242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1827.78006091954
+  dps: 1826.0652155596351
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1834.2118582453768
+  dps: 1812.711381891653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1792.1524406886267
+  dps: 1813.4339029226587
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherscaleArmor"
  value: {
-  dps: 1707.9736434739377
+  dps: 1706.537514374306
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1634.270529624524
+  dps: 1630.5695290256288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1843.2640433685704
+  dps: 1821.6925923040753
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1834.2118582453768
+  dps: 1812.711381891653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrimalIntent"
  value: {
-  dps: 1764.6917307335368
+  dps: 1713.8232375813086
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1821.3978944614832
+  dps: 1819.6830491015796
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1749.4966465122827
+  dps: 1746.4640348768164
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1880.6969586388223
+  dps: 1878.923719531895
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1802.2393991264541
+  dps: 1800.524553766551
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1856.9420197647353
+  dps: 1855.1813307994216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1817.9542899573873
+  dps: 1816.2390934804762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1816.478307816731
+  dps: 1814.7634624568288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1923.2867643586733
+  dps: 1921.4953064993058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1817.9017687414214
+  dps: 1816.1865722645098
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1825.7495145844664
+  dps: 1824.0346692245628
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1384.5630310525046
+  dps: 1352.8573976064931
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 1856.8884716050343
+  dps: 1855.173626245129
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 1757.6714408572857
+  dps: 1790.8664155303222
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1346.6548283198038
+  dps: 1333.0848027403413
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1862.3948103094979
+  dps: 1860.6799649495965
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1824.8549012929298
+  dps: 1823.1400559330273
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1620.4230576373125
+  dps: 1611.3276324007309
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 1880.044323277407
+  dps: 1878.3294779175046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1747.40913839025
+  dps: 1748.7876593208289
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1574.1772775387449
+  dps: 1590.7129181011524
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1843.2640433685704
+  dps: 1821.6925923040753
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1835.8038216084785
+  dps: 1814.200110507705
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1841.7553458480397
+  dps: 1820.1957239020062
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1834.2118582453768
+  dps: 1812.711381891653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheBladefist-29348"
  value: {
-  dps: 1713.3516044096632
+  dps: 1757.2418452721838
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 1569.575195893691
+  dps: 1568.16114780817
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1821.733399215195
+  dps: 1820.0175157169874
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1825.0809665834706
+  dps: 1823.3661212235666
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1860.5539142662687
+  dps: 1858.7932253009542
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheTwinStars"
  value: {
-  dps: 1809.1325111862225
+  dps: 1806.736184336999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1868.221217281944
+  dps: 1863.8951900403442
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 1437.8154213319435
+  dps: 1476.3998011305223
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1852.2516280877296
+  dps: 1850.505821859109
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofthePulsingEarth-29389"
  value: {
-  dps: 1856.8884716050343
+  dps: 1855.173626245129
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1891.3618919779803
+  dps: 1887.871241629977
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WastewalkerArmor"
  value: {
-  dps: 1618.8443160008978
+  dps: 1617.2137808046405
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WindhawkArmor"
  value: {
-  dps: 1607.3127250609277
+  dps: 1637.933234670452
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1438.0186998077602
+  dps: 1426.023323544593
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathofSpellfire"
  value: {
-  dps: 1562.9621090562769
+  dps: 1556.9551689494988
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1821.3870299568632
+  dps: 1819.671833479951
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 1953.3542983923978
+  dps: 1950.1076525388994
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2114.1120977290198
+  dps: 2112.2718423782967
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1892.8484790285409
+  dps: 1891.1171701186654
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1325.6431608806145
+  dps: 1310.1012317748618
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2432.055656826405
+  dps: 2429.856655188821
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1001.0383390097694
+  dps: 1000.602672916403
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 912.2638013338567
+  dps: 911.8458894069128
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 637.4739627929703
+  dps: 637.1719845637165
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1168.1545864361483
+  dps: 1167.6085510490768
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2096.0681238760653
+  dps: 2094.211880021587
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 1866.9459946093534
+  dps: 1865.2311492494475
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 1362.7521630682518
+  dps: 1369.8508176283535
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 2413.5685957323885
+  dps: 2411.3505901614594
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1020.404029592521
+  dps: 1019.9555622334897
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 893.337953040831
+  dps: 892.9200700927648
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 639.5508087398814
+  dps: 616.4370034607172
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 1135.6337970871239
+  dps: 1135.0920389520425
  }
 }

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -86,6 +86,9 @@ func (shaman *Shaman) newStormstrikeTemplate(sim *core.Simulation) core.SimpleSp
 				WeaponInput: core.WeaponDamageInput{
 					DamageMultiplier: 1,
 				},
+				DirectInput: core.DirectDamageInput{
+					SpellCoefficient: 1,
+				},
 			},
 			{
 				SpellEffect: core.SpellEffect{
@@ -98,6 +101,9 @@ func (shaman *Shaman) newStormstrikeTemplate(sim *core.Simulation) core.SimpleSp
 				WeaponInput: core.WeaponDamageInput{
 					Offhand:          true,
 					DamageMultiplier: 1,
+				},
+				DirectInput: core.DirectDamageInput{
+					SpellCoefficient: 1,
 				},
 			},
 		},

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -51,6 +51,9 @@ func (shaman *Shaman) ApplyWindfuryImbue(mh bool, oh bool) {
 		WeaponInput: core.WeaponDamageInput{
 			DamageMultiplier: 1.0,
 		},
+		DirectInput: core.DirectDamageInput{
+			SpellCoefficient: 1,
+		},
 	}
 	if shaman.Talents.ElementalWeapons > 0 {
 		baseEffect.WeaponInput.DamageMultiplier *= 1 + math.Round(float64(shaman.Talents.ElementalWeapons)*13.33)/100

--- a/sim/warrior/demoralizing_shout.go
+++ b/sim/warrior/demoralizing_shout.go
@@ -13,6 +13,8 @@ func (warrior *Warrior) newDemoralizingShoutTemplate(sim *core.Simulation) core.
 		warrior.shoutCost -= 2
 	}
 
+	warrior.demoShoutCost = warrior.shoutCost - float64(warrior.Talents.FocusedRage)
+
 	ability := core.SimpleSpell{
 		SpellCast: core.SpellCast{
 			Cast: core.Cast{
@@ -24,11 +26,11 @@ func (warrior *Warrior) newDemoralizingShoutTemplate(sim *core.Simulation) core.
 				IgnoreHaste:         true,
 				BaseCost: core.ResourceCost{
 					Type:  stats.Rage,
-					Value: warrior.shoutCost,
+					Value: warrior.demoShoutCost,
 				},
 				Cost: core.ResourceCost{
 					Type:  stats.Rage,
-					Value: warrior.shoutCost,
+					Value: warrior.demoShoutCost,
 				},
 			},
 		},
@@ -68,5 +70,5 @@ func (warrior *Warrior) NewDemoralizingShout(_ *core.Simulation) *core.SimpleSpe
 }
 
 func (warrior *Warrior) CanDemoralizingShout(sim *core.Simulation) bool {
-	return warrior.CurrentRage() >= warrior.shoutCost
+	return warrior.CurrentRage() >= warrior.demoShoutCost
 }

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -44,6 +44,9 @@ func (warrior *Warrior) newDevastateTemplate(_ *core.Simulation) core.SimpleSpel
 				Normalized:       true,
 				DamageMultiplier: 0.5,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -9,6 +9,8 @@ import (
 var DevastateActionID = core.ActionID{SpellID: 30022}
 
 func (warrior *Warrior) newDevastateTemplate(_ *core.Simulation) core.SimpleSpellTemplate {
+	warrior.sunderArmorCost = 15.0 - float64(warrior.Talents.ImprovedSunderArmor) - float64(warrior.Talents.FocusedRage)
+
 	ability := core.SimpleSpell{
 		SpellCast: core.SpellCast{
 			Cast: core.Cast{

--- a/sim/warrior/dps/TestWarrior.results
+++ b/sim/warrior/dps/TestWarrior.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestWarrior-CharacterStats-Default"
  value: {
-  final_stats: 514.69
-  final_stats: 306.79
-  final_stats: 570.7900000000001
-  final_stats: 104.39000000000001
-  final_stats: 86.79
+  final_stats: 513.7
+  final_stats: 305.8
+  final_stats: 569.8000000000001
+  final_stats: 103.4
+  final_stats: 85.80000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -19,24 +19,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2609.068
+  final_stats: 2606.34
   final_stats: 159.31
-  final_stats: 781.2416
+  final_stats: 780.5791999999999
   final_stats: 0
   final_stats: 0
   final_stats: 20
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 8441.58
+  final_stats: 8439.6
   final_stats: 770
   final_stats: 0
   final_stats: 0
-  final_stats: 25.734500000000004
-  final_stats: 207.70625330000004
+  final_stats: 25.685000000000002
+  final_stats: 207.08179100000004
   final_stats: 0
   final_stats: 0
-  final_stats: 9971.900000000001
+  final_stats: 9962
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,787 +47,787 @@ character_stats_results: {
 dps_results: {
  key: "TestWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 496.4078453752055
+  dps: 502.61732648621035
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 490.1852929646065
+  dps: 480.64142385181503
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 499.94911782640924
+  dps: 500.0146884819776
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 492.1690756407206
+  dps: 490.95428431652823
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 507.0602894478548
+  dps: 496.18812857170377
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 500.61410633862687
+  dps: 498.7444216052541
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 488.9574843600273
+  dps: 499.64623746284497
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 516.1828334652472
+  dps: 501.90997948567764
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 510.6858372920417
+  dps: 499.1338334946373
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 522.1286188896032
+  dps: 529.6979500770933
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 511.6947440113374
+  dps: 517.9033404614655
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 493.01567218778973
+  dps: 493.5185189999438
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BoldArmor"
  value: {
-  dps: 368.8130930678775
+  dps: 376.96982201626656
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 518.2095520306026
+  dps: 528.0360895982661
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 482.78381136255535
+  dps: 475.09700911887535
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-BurningRage"
  value: {
-  dps: 428.5749315079892
+  dps: 416.78492619191394
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 491.62810259279223
+  dps: 504.82309247886315
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 513.7084125303984
+  dps: 512.6582315623588
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 485.9754572216434
+  dps: 500.66877363222835
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 475.60416486287926
+  dps: 516.4926504446321
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 517.9369490202719
+  dps: 517.1478082165986
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 493.69731745077655
+  dps: 478.2723117561785
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DesolationBattlegear"
  value: {
-  dps: 391.4944298882622
+  dps: 376.6324094468305
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Despair-28573"
  value: {
-  dps: 421.14833962446147
+  dps: 421.9690789025126
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 376.0183422129447
+  dps: 378.5532839693339
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 465.41627679201105
+  dps: 459.488254632097
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 566.3200880936565
+  dps: 548.1277400242266
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 413.8763943163988
+  dps: 413.81390457298846
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 497.71722938979656
+  dps: 494.1067051982549
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-FaithinFelsteel"
  value: {
-  dps: 411.7528986582892
+  dps: 401.4889618606607
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 483.14800736032026
+  dps: 487.07648015591315
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 512.5583864301542
+  dps: 498.4291868922033
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 512.94835360084
+  dps: 510.24720720975677
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-FlameGuard"
  value: {
-  dps: 371.62054784032154
+  dps: 365.90258668626694
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 489.75992311888433
+  dps: 495.4768982960275
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Heartrazor-29962"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 493.5757708406534
+  dps: 469.3618364910718
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 505.08727135768424
+  dps: 511.5697427801542
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 434.48114656778085
+  dps: 438.6947281464774
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 515.4596806781617
+  dps: 536.2348973284835
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 453.9121191660552
+  dps: 450.9232889633507
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 443.0427396348598
+  dps: 424.946400764698
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 517.0489072737092
+  dps: 484.73315448263224
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 341.64713104292093
+  dps: 347.94954794569355
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 519.8748869203082
+  dps: 526.3921493232766
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 501.0223245350907
+  dps: 499.2641138597463
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 415.92511692489165
+  dps: 418.5379359290174
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 337.29321480283505
+  dps: 345.09658226010816
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 504.16586409468505
+  dps: 494.23408940947286
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 493.42808205606724
+  dps: 483.56099086722105
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 481.0215128357401
+  dps: 483.5761081422262
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 478.5196434635575
+  dps: 493.96272208433743
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 515.7278072296479
+  dps: 510.71267106202373
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 474.2689795014332
+  dps: 473.1868331061215
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 518.5187867122742
+  dps: 529.4422499503944
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 391.3953173965261
+  dps: 400.4588854812122
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 512.2383400685009
+  dps: 493.40260358783166
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 443.20392513054134
+  dps: 439.2262362699433
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-StormGauntlets-12632"
  value: {
-  dps: 471.343106978213
+  dps: 482.7679059749936
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 418.64238284488897
+  dps: 429.35249736290183
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 493.42808205606724
+  dps: 483.56099086722105
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 476.0174548790961
+  dps: 482.19743817156916
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 486.7167033298907
+  dps: 493.4736953506251
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 484.17532996474375
+  dps: 458.9944428758968
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheDecapitator-28767"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 493.4249845002134
+  dps: 520.8672038630696
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheNightBlade-31331"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 593.7705974463786
+  dps: 580.9896722779544
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TheTwinStars"
  value: {
-  dps: 457.93785386726523
+  dps: 473.6099362400535
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 494.10150083607857
+  dps: 504.7978138632294
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 490.19824468551764
+  dps: 509.22446017183006
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 372.45868427523084
+  dps: 363.19669837214917
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 465.03127219952916
+  dps: 458.88548316594574
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 410.3022202618627
+  dps: 402.5830110712597
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 415.92511692489165
+  dps: 418.5379359290174
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 447.2237777524387
+  dps: 466.4329387479351
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 423.8909793456363
+  dps: 424.63509026413493
  }
 }
 dps_results: {
  key: "TestWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 487.41743164291586
+  dps: 471.89331777328005
  }
 }
 dps_results: {
  key: "TestWarrior-Average-Default"
  value: {
-  dps: 512.5528417022445
+  dps: 511.88368575768175
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 610.1380722203627
+  dps: 604.7410364537777
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 517.0070683793551
+  dps: 518.3516755739028
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 434.41873729054424
+  dps: 457.20620535907295
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 599.5672757707863
+  dps: 599.1745867131192
  }
 }
 dps_results: {
@@ -857,25 +857,25 @@ dps_results: {
 dps_results: {
  key: "TestWarrior-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 618.254833050646
+  dps: 620.4335504998634
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 499.2227454416278
+  dps: 511.48081842389627
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 443.38193882477424
+  dps: 438.3765516849231
  }
 }
 dps_results: {
  key: "TestWarrior-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 616.9926438600066
+  dps: 616.5531041463976
  }
 }
 dps_results: {

--- a/sim/warrior/heroic_strike.go
+++ b/sim/warrior/heroic_strike.go
@@ -42,6 +42,9 @@ func (warrior *Warrior) newHeroicStrikeTemplate(_ *core.Simulation) core.SimpleS
 				DamageMultiplier: 1,
 				FlatDamageBonus:  176,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestProtectionWarrior-CharacterStats-Default"
  value: {
-  final_stats: 511.588
-  final_stats: 388.19
-  final_stats: 1053.2445
-  final_stats: 104.39000000000001
-  final_stats: 86.79
+  final_stats: 509.4100000000001
+  final_stats: 387.20000000000005
+  final_stats: 1052.2050000000002
+  final_stats: 103.4
+  final_stats: 85.80000000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -19,24 +19,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2272.2436000000002
+  final_stats: 2266.9020000000005
   final_stats: 110
-  final_stats: 532.5455999999999
+  final_stats: 531.8832
   final_stats: 0
   final_stats: 0
   final_stats: 58.64
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 15965.179999999998
+  final_stats: 15963.199999999999
   final_stats: 470
   final_stats: 211.308
   final_stats: 81.423
-  final_stats: 336.13734000000005
-  final_stats: 298.0509313
+  final_stats: 336.01755
+  final_stats: 297.42646900000005
   final_stats: 139.269
   final_stats: 68
-  final_stats: 15876.445
+  final_stats: 15866.050000000001
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -47,799 +47,799 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 471.24786133723035
+  dps: 453.8753857676555
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 452.3378265629577
+  dps: 454.65011089054326
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 447.49350487277763
+  dps: 449.61408090774455
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 440.71105345045976
+  dps: 441.43242457084676
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 480.28352092229005
+  dps: 476.22030051108254
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 446.5467790611962
+  dps: 453.0738622516836
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 458.30600526504713
+  dps: 457.632801236576
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 460.137777488883
+  dps: 458.46299818767847
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 460.5709892410261
+  dps: 463.1935121382505
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 492.6974046948577
+  dps: 479.8993097354297
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 459.34052454332374
+  dps: 458.2641029222937
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 457.3767109079262
+  dps: 475.2967023649762
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 461.7148291210623
+  dps: 460.7887061543186
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 434.9148947376155
+  dps: 439.25317428334375
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 462.3204651816201
+  dps: 465.825689729802
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 462.5427635598268
+  dps: 465.44294026605115
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 470.29027300987394
+  dps: 465.3908850928265
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 467.7613962774072
+  dps: 460.9214568581934
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 459.7197831597286
+  dps: 462.2262738768356
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 456.00466352377913
+  dps: 460.0316414813065
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 459.3567457810246
+  dps: 455.81961979756056
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 452.8807445658962
+  dps: 456.1159030587661
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 454.0460411360356
+  dps: 457.1506311679163
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DesolationBattlegear"
  value: {
-  dps: 433.5889259045619
+  dps: 433.90161731191495
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Despair-28573"
  value: {
-  dps: 479.2763331298768
+  dps: 478.6960450402521
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 452.1467968827897
+  dps: 462.2328297430283
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 500.9941294955403
+  dps: 500.6210891117037
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 670.6323498560923
+  dps: 669.9464194568752
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 463.648891392821
+  dps: 463.0839423547648
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonmaw-28438"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 473.1311027971532
+  dps: 482.9139062037448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 461.7148291210623
+  dps: 460.7887061543186
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 464.89350894922353
+  dps: 463.7045351992656
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FaithinFelsteel"
  value: {
-  dps: 435.47553010615655
+  dps: 437.63623861725716
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 448.45842960743244
+  dps: 440.32667231335984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 447.685522091472
+  dps: 456.79050512942575
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 461.2286479649025
+  dps: 461.0548790954439
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FlameGuard"
  value: {
-  dps: 406.32255425635844
+  dps: 412.61849285767624
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 453.9016237795458
+  dps: 451.19479786854896
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartrazor-29962"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 456.0200285882893
+  dps: 455.4574646299694
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 500.28247991465946
+  dps: 499.68370759917025
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 461.58959395266737
+  dps: 462.0327473144692
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 519.8701670011638
+  dps: 519.4149947385927
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 540.1626192707678
+  dps: 539.5608831882605
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 457.25119654784083
+  dps: 464.0065232162523
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 398.2888614247324
+  dps: 396.4483415024036
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 467.66622328847353
+  dps: 459.8695194722264
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 459.4475973081791
+  dps: 456.3387260523671
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 423.3331950545976
+  dps: 418.62432731824475
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 441.95061996042904
+  dps: 434.09536934999267
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 574.4669793313279
+  dps: 581.7659902700208
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 462.81340269665293
+  dps: 465.71384189759243
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 466.27540504353345
+  dps: 459.52175076685245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 476.6792324583027
+  dps: 474.4476912553659
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 445.04440668911167
+  dps: 449.04316415819494
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 452.13273177612825
+  dps: 459.3368303987556
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 447.6497458365502
+  dps: 432.7467434819642
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 443.3339661321363
+  dps: 448.3838893400256
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 491.26765532449974
+  dps: 489.80009069243124
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 443.3339661321363
+  dps: 448.3838893400256
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 518.7611719618922
+  dps: 520.2009319083105
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 460.37039451363256
+  dps: 461.4469155913933
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 433.3592499036701
+  dps: 434.7768267466278
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormGauntlets-12632"
  value: {
-  dps: 477.2769242949963
+  dps: 469.0890676520298
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 435.86861405202575
+  dps: 438.11842965850985
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 462.81340269665293
+  dps: 465.71384189759243
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 465.8199220615119
+  dps: 464.8014796129057
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 481.7482537641973
+  dps: 476.13863653204095
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheDecapitator-28767"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 586.7660156788614
+  dps: 586.0594444479408
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheNightBlade-31331"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 670.0566485658277
+  dps: 669.2913968542215
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinStars"
  value: {
-  dps: 445.44565436548726
+  dps: 444.92110994114955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 480.2166634613
+  dps: 470.68542296982594
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 445.5505335325001
+  dps: 448.18647470087075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 461.9921139578177
+  dps: 464.2249364618136
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 447.1181982579085
+  dps: 443.8872732028081
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 486.03499187511215
+  dps: 476.31969677733576
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 450.9356027364365
+  dps: 442.4795468593551
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 423.3331950545976
+  dps: 418.62432731824475
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 531.1568388870636
+  dps: 530.5436191300469
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 430.13495050643843
+  dps: 430.7351750049635
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 443.3339661321363
+  dps: 448.3838893400256
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 480.7059881473471
+  dps: 479.9541114469627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SelfDrums-DPS"
  value: {
-  dps: 459.33169075637176
+  dps: 454.8312198362392
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 469.19546711438744
+  dps: 462.0195064159273
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 464.26315516869295
+  dps: 464.6915398718191
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 414.4376935157063
+  dps: 413.8472270681688
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 545.2264395159717
+  dps: 544.5963947056932
  }
 }
 dps_results: {
@@ -869,25 +869,25 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 471.59218603465746
+  dps: 453.9134159726063
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 460.6373591117019
+  dps: 461.50069966886423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 418.4002185370011
+  dps: 417.23965543340626
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 538.2646377764918
+  dps: 549.463666352631
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -47,870 +47,870 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 453.8753857676555
+  dps: 403.1940757624473
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 454.65011089054326
+  dps: 392.85120954823856
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 449.61408090774455
+  dps: 401.2764119820035
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 441.43242457084676
+  dps: 408.02568107958894
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 476.22030051108254
+  dps: 419.36868764308525
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 453.0738622516836
+  dps: 408.2715481102601
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 457.632801236576
+  dps: 417.6136772726204
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 458.46299818767847
+  dps: 398.60508312084505
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 463.1935121382505
+  dps: 408.67418063243053
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 479.8993097354297
+  dps: 430.41918091645033
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 458.2641029222937
+  dps: 407.97435486604815
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 475.2967023649762
+  dps: 394.41603811123343
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 460.7887061543186
+  dps: 407.343370347787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 439.25317428334375
+  dps: 385.97055127978757
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 465.825689729802
+  dps: 406.69422755907016
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 465.44294026605115
+  dps: 406.1452557004049
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 465.3908850928265
+  dps: 442.2543243351414
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 460.9214568581934
+  dps: 414.5984188798151
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 462.2262738768356
+  dps: 401.73146970010714
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 460.0316414813065
+  dps: 392.6383012754895
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 455.81961979756056
+  dps: 398.8388208649365
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 456.1159030587661
+  dps: 422.28788249023944
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 457.1506311679163
+  dps: 417.2515458009453
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DesolationBattlegear"
  value: {
-  dps: 433.90161731191495
+  dps: 396.1925737162187
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Despair-28573"
  value: {
-  dps: 478.6960450402521
+  dps: 452.6026589842461
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 462.2328297430283
+  dps: 405.51750651024514
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 500.6210891117037
+  dps: 451.7194231894781
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 669.9464194568752
+  dps: 632.0080513885146
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 463.0839423547648
+  dps: 408.1579180442848
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonmaw-28438"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 482.9139062037448
+  dps: 437.79362829173596
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 460.7887061543186
+  dps: 407.343370347787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 463.7045351992656
+  dps: 413.9145762493519
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FaithinFelsteel"
  value: {
-  dps: 437.63623861725716
+  dps: 386.5371367418638
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 440.32667231335984
+  dps: 401.8822406977936
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 456.79050512942575
+  dps: 385.25773694111126
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 461.0548790954439
+  dps: 420.4712669232466
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FlameGuard"
  value: {
-  dps: 412.61849285767624
+  dps: 352.7405187830705
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 451.19479786854896
+  dps: 397.0796205384361
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartrazor-29962"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 455.4574646299694
+  dps: 412.32635774721905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 499.68370759917025
+  dps: 450.8203395653743
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 462.0327473144692
+  dps: 398.396709972364
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 519.4149947385927
+  dps: 476.15785979804775
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 539.5608831882605
+  dps: 506.40639726351975
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 464.0065232162523
+  dps: 401.02269430668747
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 396.4483415024036
+  dps: 340.7088544420108
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 459.8695194722264
+  dps: 404.41350508291407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 456.3387260523671
+  dps: 408.4313628384275
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 418.62432731824475
+  dps: 371.2171692350982
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 434.09536934999267
+  dps: 376.5615567398163
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 581.7659902700208
+  dps: 535.9741651575515
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 465.71384189759243
+  dps: 406.422050925157
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 459.52175076685245
+  dps: 410.1623792114123
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 474.4476912553659
+  dps: 413.07576982551956
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 449.04316415819494
+  dps: 391.87634688457376
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 459.3368303987556
+  dps: 403.2603592542707
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 432.7467434819642
+  dps: 394.8567171447287
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 448.3838893400256
+  dps: 400.83336507989077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 489.80009069243124
+  dps: 425.7877659475959
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 448.3838893400256
+  dps: 400.83336507989077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 520.2009319083105
+  dps: 473.6037571662459
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 461.4469155913933
+  dps: 419.68648172614417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 434.7768267466278
+  dps: 383.49680671326354
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormGauntlets-12632"
  value: {
-  dps: 469.0890676520298
+  dps: 399.39821823940883
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 438.11842965850985
+  dps: 389.9821032490502
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 465.71384189759243
+  dps: 406.422050925157
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 464.8014796129057
+  dps: 402.2534639900411
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 476.13863653204095
+  dps: 429.20111538817577
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheDecapitator-28767"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 586.0594444479408
+  dps: 501.01177271852134
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheNightBlade-31331"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 669.2913968542215
+  dps: 593.0122702211407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinStars"
  value: {
-  dps: 444.92110994114955
+  dps: 401.38787476417104
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 470.68542296982594
+  dps: 413.41875290878966
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 448.18647470087075
+  dps: 400.6229997649245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 464.2249364618136
+  dps: 419.99459999248165
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 443.8872732028081
+  dps: 393.06099946166006
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 476.31969677733576
+  dps: 444.81179899208627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 442.4795468593551
+  dps: 412.86847684238256
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 418.62432731824475
+  dps: 371.2171692350982
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 530.5436191300469
+  dps: 499.2342845826574
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 430.7351750049635
+  dps: 375.09729494398346
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 448.3838893400256
+  dps: 400.83336507989077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 479.9541114469627
+  dps: 428.2876704366928
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SelfDrums-DPS"
  value: {
-  dps: 454.8312198362392
+  dps: 401.4696463634637
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 462.0195064159273
+  dps: 401.74712099179476
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 464.6915398718191
+  dps: 402.64848679269363
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 413.8472270681688
+  dps: 362.06666340160007
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 544.5963947056932
+  dps: 511.48176556166555
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 260.32301402216206
+  dps: 167.75006184796783
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 252.51509040505837
+  dps: 164.7658519293114
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 227.7800609748457
+  dps: 144.9053969839689
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 280.9784415751081
+  dps: 173.63846565158852
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 453.9134159726063
+  dps: 413.244382132293
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 461.50069966886423
+  dps: 409.8752349034686
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 417.23965543340626
+  dps: 354.24821553426375
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 549.463666352631
+  dps: 493.0803554405153
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 246.00020620856725
+  dps: 165.89712918920662
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 248.92935639074668
+  dps: 168.67008002479065
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 221.60169240146493
+  dps: 147.1553128763354
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 273.02838903784857
+  dps: 180.43133546946837
  }
 }

--- a/sim/warrior/shield_slam.go
+++ b/sim/warrior/shield_slam.go
@@ -11,9 +11,9 @@ import (
 var ShieldSlamCooldownID = core.NewCooldownID()
 var ShieldSlamActionID = core.ActionID{SpellID: 30356, CooldownID: ShieldSlamCooldownID}
 
-const ShieldSlamCost = 20.0
-
 func (warrior *Warrior) newShieldSlamTemplate(_ *core.Simulation) core.SimpleSpellTemplate {
+	warrior.shieldSlamCost = 20.0 - float64(warrior.Talents.FocusedRage)
+
 	warrior.canShieldSlam = warrior.Talents.ShieldSlam && warrior.Equip[proto.ItemSlot_ItemSlotOffHand].WeaponType == proto.WeaponType_WeaponTypeShield
 
 	ability := core.SimpleSpell{
@@ -29,11 +29,11 @@ func (warrior *Warrior) newShieldSlamTemplate(_ *core.Simulation) core.SimpleSpe
 				IgnoreHaste:         true,
 				BaseCost: core.ResourceCost{
 					Type:  stats.Rage,
-					Value: ShieldSlamCost,
+					Value: warrior.shieldSlamCost,
 				},
 				Cost: core.ResourceCost{
 					Type:  stats.Rage,
-					Value: ShieldSlamCost,
+					Value: warrior.shieldSlamCost,
 				},
 				CritMultiplier: warrior.critMultiplier(true),
 			},
@@ -57,7 +57,7 @@ func (warrior *Warrior) newShieldSlamTemplate(_ *core.Simulation) core.SimpleSpe
 		ability.Effect.SpellEffect.StaticDamageMultiplier *= 1.1
 	}
 
-	refundAmount := ShieldSlamCost * 0.8
+	refundAmount := warrior.shieldSlamCost * 0.8
 	ability.Effect.OnSpellHit = func(sim *core.Simulation, spellCast *core.SpellCast, spellEffect *core.SpellEffect) {
 		if !spellEffect.Landed() {
 			warrior.AddRage(sim, refundAmount, core.ActionID{OtherID: proto.OtherAction_OtherActionRefund})
@@ -79,5 +79,5 @@ func (warrior *Warrior) NewShieldSlam(_ *core.Simulation, target *core.Target) *
 }
 
 func (warrior *Warrior) CanShieldSlam(sim *core.Simulation) bool {
-	return warrior.canShieldSlam && warrior.CurrentRage() >= ShieldSlamCost && !warrior.IsOnCD(ShieldSlamCooldownID, sim.CurrentTime)
+	return warrior.canShieldSlam && warrior.CurrentRage() >= warrior.shieldSlamCost && !warrior.IsOnCD(ShieldSlamCooldownID, sim.CurrentTime)
 }

--- a/sim/warrior/sunder_armor.go
+++ b/sim/warrior/sunder_armor.go
@@ -9,8 +9,6 @@ import (
 var SunderArmorActionID = core.ActionID{SpellID: 25225}
 
 func (warrior *Warrior) newSunderArmorTemplate(_ *core.Simulation) core.SimpleSpellTemplate {
-	warrior.sunderArmorCost = 15.0 - float64(warrior.Talents.ImprovedSunderArmor) - float64(warrior.Talents.FocusedRage)
-
 	ability := core.SimpleSpell{
 		SpellCast: core.SpellCast{
 			Cast: core.Cast{

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -32,6 +32,7 @@ type Warrior struct {
 	shoutDuration    time.Duration
 	bloodthirstCost  float64
 	shoutCost        float64
+	demoShoutCost    float64
 	heroicStrikeCost float64
 	revengeCost      float64
 	shieldSlamCost   float64

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -51,6 +51,9 @@ func (warrior *Warrior) newWhirlwindTemplate(sim *core.Simulation) core.SimpleSp
 			Normalized:       true,
 			DamageMultiplier: 1,
 		},
+		DirectInput: core.DirectDamageInput{
+			SpellCoefficient: 1,
+		},
 	}
 
 	numHits := core.MinInt32(4, sim.GetNumTargets())

--- a/ui/protection_warrior/sim.ts
+++ b/ui/protection_warrior/sim.ts
@@ -218,6 +218,8 @@ export class ProtectionWarriorSimUI extends IndividualSimUI<Spec.SpecProtectionW
 					ProtectionWarriorInputs.PrecastShout,
 					ProtectionWarriorInputs.PrecastShoutWithSapphire,
 					ProtectionWarriorInputs.PrecastShoutWithT2,
+					OtherInputs.ExposeWeaknessUptime,
+					OtherInputs.ExposeWeaknessHunterAgility,
 					OtherInputs.SnapshotImprovedStrengthOfEarthTotem,
 				],
 			},


### PR DESCRIPTION
Rounded stats down for improved gift of the wild, battle shout, grace of air and strength of earth

Also changed strength of earth set tier bonus to benefit from talent

* Note enhancement shaman snapshotting of strength of earth might need a similar update

Updates rage cost of warrior abilities

Adds Expose Weakness UI element to Prot warrior 