### PR TITLE
Standardized bonus weapon damage

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -225,6 +225,9 @@ func (character *Character) EnableAutoAttacks(agent Agent, options AutoAttackOpt
 				WeaponInput: WeaponDamageInput{
 					DamageMultiplier: 1,
 				},
+				DirectInput: DirectDamageInput{
+					SpellCoefficient: 1,
+				},
 			},
 		},
 		OHAuto: SimpleSpell{
@@ -248,6 +251,9 @@ func (character *Character) EnableAutoAttacks(agent Agent, options AutoAttackOpt
 					Offhand:          true,
 					DamageMultiplier: 1,
 				},
+				DirectInput: DirectDamageInput{
+					SpellCoefficient: 1,
+				},
 			},
 		},
 		RangedAuto: SimpleSpell{
@@ -270,6 +276,9 @@ func (character *Character) EnableAutoAttacks(agent Agent, options AutoAttackOpt
 				},
 				WeaponInput: WeaponDamageInput{
 					DamageMultiplier: 1,
+				},
+				DirectInput: DirectDamageInput{
+					SpellCoefficient: 1,
 				},
 			},
 		},

--- a/sim/core/direct_cast.go
+++ b/sim/core/direct_cast.go
@@ -16,7 +16,7 @@ type DirectDamageInput struct {
 	MinBaseDamage float64
 	MaxBaseDamage float64
 
-	// Increase in damage per point of spell power (or attack power, if a physical spell).
+	// Increase in damage per point of spell power (or weapon damage, if a physical school).
 	SpellCoefficient float64
 
 	// Adds a fixed amount of damage to the spell, before multipliers.

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -219,7 +219,7 @@ func (ss SpellSchool) Stat() stats.Stat {
 	case SpellSchoolShadow:
 		return stats.ShadowSpellPower
 	case SpellSchoolPhysical:
-		return stats.AttackPower
+		return 0 // should be weapon damage (mod_damage_done (physical))
 	}
 
 	return 0

--- a/sim/core/spell_cast.go
+++ b/sim/core/spell_cast.go
@@ -167,30 +167,25 @@ func (hitEffect *SpellHitEffect) calculateBaseDamage(sim *Simulation, spellCast 
 			// ... but for other's, BonusAttackPowerOnTarget only applies to weapon damage based attacks
 			if hitEffect.WeaponInput.Normalized {
 				if spellCast.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
-					damage += character.AutoAttacks.Ranged.calculateNormalizedWeaponDamage(sim, attackPower) + bonusWeaponDamage
+					damage += character.AutoAttacks.Ranged.calculateNormalizedWeaponDamage(sim, attackPower)
 				} else if !hitEffect.WeaponInput.Offhand {
-					damage += character.AutoAttacks.MH.calculateNormalizedWeaponDamage(sim, attackPower+hitEffect.BonusAttackPowerOnTarget) + bonusWeaponDamage
+					damage += character.AutoAttacks.MH.calculateNormalizedWeaponDamage(sim, attackPower+hitEffect.BonusAttackPowerOnTarget)
 				} else {
-					damage += character.AutoAttacks.OH.calculateNormalizedWeaponDamage(sim, attackPower+2*hitEffect.BonusAttackPowerOnTarget)*0.5 + bonusWeaponDamage
+					damage += character.AutoAttacks.OH.calculateNormalizedWeaponDamage(sim, attackPower+2*hitEffect.BonusAttackPowerOnTarget)*0.5
 				}
 			} else {
 				if spellCast.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
-					damage += character.AutoAttacks.Ranged.calculateWeaponDamage(sim, attackPower) + bonusWeaponDamage
+					damage += character.AutoAttacks.Ranged.calculateWeaponDamage(sim, attackPower)
 				} else if !hitEffect.WeaponInput.Offhand {
-					damage += character.AutoAttacks.MH.calculateWeaponDamage(sim, attackPower+hitEffect.BonusAttackPowerOnTarget) + bonusWeaponDamage
+					damage += character.AutoAttacks.MH.calculateWeaponDamage(sim, attackPower+hitEffect.BonusAttackPowerOnTarget)
 				} else {
-					damage += character.AutoAttacks.OH.calculateWeaponDamage(sim, attackPower+2*hitEffect.BonusAttackPowerOnTarget)*0.5 + bonusWeaponDamage
+					damage += character.AutoAttacks.OH.calculateWeaponDamage(sim, attackPower+2*hitEffect.BonusAttackPowerOnTarget)*0.5
 				}
 			}
 			damage += hitEffect.WeaponInput.FlatDamageBonus
 			damage *= hitEffect.WeaponInput.DamageMultiplier
 		}
 
-		if hitEffect.DirectInput.SpellCoefficient > 0 {
-			bonus := (character.GetStat(stats.SpellPower) + character.GetStat(spellCast.SpellSchool.Stat())) * hitEffect.DirectInput.SpellCoefficient * hitEffect.WeaponInput.DamageMultiplier
-			bonus += hitEffect.SpellEffect.BonusSpellPower * hitEffect.DirectInput.SpellCoefficient // does not get changed by weapon input multiplier
-			damage += bonus
-		}
 
 		//if sim.Log != nil {
 		//	character.Log(sim, "Melee damage calcs: AP=%0.1f, bonusWepdamage:%0.1f, damageMultiplier:%0.2f, staticMultiplier:%0.2f, result:%d, weapondamageCalc: %0.1f, critMultiplier: %0.3f, Target armor: %0.1f\n", attackPower, bonusWeaponDamage, hitEffect.DamageMultiplier, hitEffect.StaticDamageMultiplier, hitEffect.HitType, damage, spellCast.CritMultiplier, hitEffect.Target.currentArmor)
@@ -199,22 +194,19 @@ func (hitEffect *SpellHitEffect) calculateBaseDamage(sim *Simulation, spellCast 
 
 	// Direct Damage Effects
 	if hitEffect.DirectInput.MaxBaseDamage != 0 {
-		baseDamage := hitEffect.DirectInput.MinBaseDamage + sim.RandomFloat("Base Damage Direct")*(hitEffect.DirectInput.MaxBaseDamage-hitEffect.DirectInput.MinBaseDamage)
+		damage += hitEffect.DirectInput.MinBaseDamage + sim.RandomFloat("Base Damage Direct")*(hitEffect.DirectInput.MaxBaseDamage-hitEffect.DirectInput.MinBaseDamage)
+	}
 
+	if hitEffect.DirectInput.SpellCoefficient > 0 {
 		schoolBonus := 0.0
 		// Use outcome roll to decide if it should use AP or spell school for bonus damage.
-		isPhysical := spellCast.OutcomeRollCategory.Matches(OutcomeRollCategoryPhysical)
+		isPhysical := spellCast.SpellSchool.Matches(SpellSchoolPhysical)
 		if isPhysical {
-			if spellCast.OutcomeRollCategory.Matches(OutcomeRollCategoryRanged) {
-				schoolBonus = character.stats[stats.RangedAttackPower]
-			} else if spellCast.SpellSchool == SpellSchoolPhysical {
-				schoolBonus = character.stats[stats.AttackPower]
-			}
-			schoolBonus += hitEffect.BonusAttackPower
+			schoolBonus = (character.PseudoStats.BonusDamage + hitEffect.BonusWeaponDamage)  * hitEffect.WeaponInput.DamageMultiplier  //DamageMultiplier may be removed later
 		} else {
 			schoolBonus = character.GetStat(stats.SpellPower) + character.GetStat(spellCast.SpellSchool.Stat()) + hitEffect.SpellEffect.BonusSpellPower
 		}
-		damage += baseDamage + (schoolBonus * hitEffect.DirectInput.SpellCoefficient)
+		damage += schoolBonus * hitEffect.DirectInput.SpellCoefficient
 	}
 
 	damage += hitEffect.DirectInput.FlatDamageBonus

--- a/sim/hunter/kill_command.go
+++ b/sim/hunter/kill_command.go
@@ -89,6 +89,9 @@ func (hp *HunterPet) newKillCommandTemplate(sim *core.Simulation) core.SimpleSpe
 				DamageMultiplier: 1,
 				FlatDamageBonus:  127,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -38,6 +38,9 @@ func (hunter *Hunter) newRaptorStrikeTemplate(sim *core.Simulation) core.SimpleS
 				DamageMultiplier: 1,
 				FlatDamageBonus:  170,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -46,6 +46,9 @@ func (paladin *Paladin) newCrusaderStrikeTemplate(sim *core.Simulation) core.Sim
 			WeaponInput: core.WeaponDamageInput{
 				DamageMultiplier: 1.1, // maybe this isn't the one that should be set to 1.1
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -24,6 +24,9 @@ func (rogue *Rogue) newBackstabTemplate(_ *core.Simulation) core.SimpleSpellTemp
 		FlatDamageBonus:  170,
 		DamageMultiplier: 1.5,
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	// all these use "Apply Aura: Modifies Damage/Healing Done", and stack additively (up to 142%)
 	ability.Effect.StaticDamageMultiplier += 0.02 * float64(rogue.Talents.Aggression)

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -57,6 +57,9 @@ func (rogue *Rogue) newHemorrhageTemplate(_ *core.Simulation) core.SimpleSpellTe
 		Normalized:       true,
 		DamageMultiplier: 1.1,
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	// cp. backstab
 	if ItemSetSlayers.CharacterHasSetBonus(&rogue.Character, 4) {

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -38,6 +38,9 @@ func (rogue *Rogue) newMutilateTemplate(_ *core.Simulation) core.SimpleSpellTemp
 				FlatDamageBonus:  101,
 				DamageMultiplier: 1,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -31,6 +31,9 @@ func (rogue *Rogue) newShivTemplate(_ *core.Simulation) core.SimpleSpellTemplate
 		Offhand:          true,
 		DamageMultiplier: 1 + 0.1*float64(rogue.Talents.DualWieldSpecialization),
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	if rogue.Talents.SurpriseAttacks {
 		ability.Effect.StaticDamageMultiplier += 0.1

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -27,6 +27,9 @@ func (rogue *Rogue) newSinisterStrikeTemplate(_ *core.Simulation) core.SimpleSpe
 		FlatDamageBonus:  98,
 		DamageMultiplier: 1,
 	}
+	ability.Effect.DirectInput = core.DirectDamageInput{
+		SpellCoefficient: 1,
+	}
 
 	// cp. backstab
 	ability.Effect.StaticDamageMultiplier += 0.02 * float64(rogue.Talents.Aggression)

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -86,6 +86,9 @@ func (shaman *Shaman) newStormstrikeTemplate(sim *core.Simulation) core.SimpleSp
 				WeaponInput: core.WeaponDamageInput{
 					DamageMultiplier: 1,
 				},
+				DirectInput: core.DirectDamageInput{
+					SpellCoefficient: 1,
+				},
 			},
 			{
 				SpellEffect: core.SpellEffect{
@@ -98,6 +101,9 @@ func (shaman *Shaman) newStormstrikeTemplate(sim *core.Simulation) core.SimpleSp
 				WeaponInput: core.WeaponDamageInput{
 					Offhand:          true,
 					DamageMultiplier: 1,
+				},
+				DirectInput: core.DirectDamageInput{
+					SpellCoefficient: 1,
 				},
 			},
 		},

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -51,6 +51,9 @@ func (shaman *Shaman) ApplyWindfuryImbue(mh bool, oh bool) {
 		WeaponInput: core.WeaponDamageInput{
 			DamageMultiplier: 1.0,
 		},
+		DirectInput: core.DirectDamageInput{
+			SpellCoefficient: 1,
+		},
 	}
 	if shaman.Talents.ElementalWeapons > 0 {
 		baseEffect.WeaponInput.DamageMultiplier *= 1 + math.Round(float64(shaman.Talents.ElementalWeapons)*13.33)/100

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -42,6 +42,9 @@ func (warrior *Warrior) newDevastateTemplate(_ *core.Simulation) core.SimpleSpel
 				Normalized:       true,
 				DamageMultiplier: 0.5,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/warrior/heroic_strike.go
+++ b/sim/warrior/heroic_strike.go
@@ -42,6 +42,9 @@ func (warrior *Warrior) newHeroicStrikeTemplate(_ *core.Simulation) core.SimpleS
 				DamageMultiplier: 1,
 				FlatDamageBonus:  176,
 			},
+			DirectInput: core.DirectDamageInput{
+				SpellCoefficient: 1,
+			},
 		},
 	}
 

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -51,6 +51,9 @@ func (warrior *Warrior) newWhirlwindTemplate(sim *core.Simulation) core.SimpleSp
 			Normalized:       true,
 			DamageMultiplier: 1,
 		},
+		DirectInput: core.DirectDamageInput{
+			SpellCoefficient: 1,
+		},
 	}
 
 	numHits := core.MinInt32(4, sim.GetNumTargets())


### PR DESCRIPTION
Adds support for physical spellpower also known as bonus weapon damage or "Mod Damage Done (Physical)"

This is a one to one refactoring that does not fix the spells that have previously been flagged to add bonus weapon damage.

It's worth considering if spellCoefficient should be renamed BonusCoefficient to match terminology used in the game database

Note, this also fixes spells such as Seal of Command which uses melee defense type (here: OutcomeRollCategoryPhysical) so that it can once again benefit from spellpowwer