### PR TITLE
Pending Action pool removal

### DIFF
--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -135,9 +135,9 @@ func ProtoToActionID(protoID proto.ActionID) ActionID {
 type AgentFactory func(Character, proto.Player) Agent
 type SpecSetter func(*proto.Player, interface{})
 
-var agentFactories map[string]AgentFactory = make(map[string]AgentFactory)
-var specSetters map[string]SpecSetter = make(map[string]SpecSetter)
-var configSpecs map[string]proto.Spec = make(map[string]proto.Spec)
+var agentFactories = make(map[string]AgentFactory)
+var specSetters = make(map[string]SpecSetter)
+var configSpecs = make(map[string]proto.Spec)
 
 func PlayerProtoToSpec(player proto.Player) proto.Spec {
 	typeName := reflect.TypeOf(player.GetSpec()).Elem().Name()

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -292,8 +292,10 @@ func (aa *AutoAttacks) resetAutoSwing(sim *Simulation) {
 		aa.autoSwingAction.Cancel(sim)
 	}
 
-	pa := sim.pendingActionPool.Get()
-	pa.Priority = ActionPriorityAuto
+	pa := &PendingAction{
+		NextActionAt: aa.NextAttackAt(),
+		Priority:     ActionPriorityAuto,
+	}
 
 	pa.OnAction = func(sim *Simulation) {
 		aa.SwingMelee(sim, sim.GetPrimaryTarget())
@@ -302,11 +304,8 @@ func (aa *AutoAttacks) resetAutoSwing(sim *Simulation) {
 		// Cancelled means we made a new one because of a swing speed change.
 		if !pa.cancelled {
 			sim.AddPendingAction(pa)
-		} else {
-			sim.pendingActionPool.Put(pa)
 		}
 	}
-	pa.NextActionAt = aa.NextAttackAt()
 
 	aa.autoSwingAction = pa
 	sim.AddPendingAction(pa)

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -438,9 +438,6 @@ func (character *Character) reset(sim *Simulation, agent Agent) {
 		petAgent.GetPet().reset(sim, petAgent)
 	}
 
-	if character.gcdAction != nil {
-		sim.pendingActionPool.Put(character.gcdAction)
-	}
 	character.gcdAction = character.newGCDAction(sim, agent)
 
 	agent.Reset(sim)

--- a/sim/core/energy.go
+++ b/sim/core/energy.go
@@ -130,9 +130,8 @@ func (eb *energyBar) newTickAction(sim *Simulation, randomTickTime bool) {
 	}
 
 	pa := &PendingAction{
-		Name:         "Energy Tick",
-		Priority:     ActionPriorityRegen,
 		NextActionAt: sim.CurrentTime + nextTickDuration,
+		Priority:     ActionPriorityRegen,
 	}
 	pa.OnAction = func(sim *Simulation) {
 		eb.addEnergyInternal(sim, EnergyPerTick*eb.EnergyTickMultiplier, ActionID{OtherID: proto.OtherAction_OtherActionEnergyRegen})

--- a/sim/core/mana.go
+++ b/sim/core/mana.go
@@ -187,10 +187,8 @@ func (sim *Simulation) initManaTickAction() {
 
 	interval := time.Second * 2
 	pa := &PendingAction{
-		Name:     "Mana Tick",
-		Priority: ActionPriorityRegen,
-
 		NextActionAt: interval,
+		Priority:     ActionPriorityRegen,
 	}
 	pa.OnAction = func(sim *Simulation) {
 		for _, player := range playersWithManaBars {

--- a/sim/core/metrics_aggregator.go
+++ b/sim/core/metrics_aggregator.go
@@ -7,19 +7,9 @@ import (
 	"github.com/wowsims/tbc/sim/core/proto"
 )
 
-// A unique number based on an ActionID.
-// This works by making item IDs negative to avoid collisions, and assumes
-// there are no collisions with OtherID. Tag adds decimals.
-// Actual key values dont matter, just need something unique and fast to compute.
-type ActionKey float64
-
-func NewActionKey(actionID ActionID) ActionKey {
-	return ActionKey(float64((int32(actionID.OtherID) + actionID.SpellID - actionID.ItemID)) + (float64(actionID.Tag) / 256))
-}
-
 type ResourceKey struct {
-	ActionKey ActionKey
-	Type      proto.ResourceType
+	ActionID ActionID
+	Type     proto.ResourceType
 }
 
 type DistributionMetrics struct {
@@ -74,8 +64,8 @@ type CharacterMetrics struct {
 
 	// Aggregate values. These are updated after each iteration.
 	oomTimeSum float64
-	actions    map[ActionKey]ActionMetrics
-	resources  map[ResourceKey]ResourceMetrics
+	actions    map[ActionID]*ActionMetrics
+	resources  map[ResourceKey]*ResourceMetrics
 }
 
 // Metrics for the current iteration, for 1 agent. Keep this as a separate
@@ -91,8 +81,7 @@ type CharacterIterationMetrics struct {
 }
 
 type ActionMetrics struct {
-	ActionID ActionID
-	IsMelee  bool // True if melee action, false if spell action.
+	IsMelee bool // True if melee action, false if spell action.
 
 	Casts  int32
 	Hits   int32
@@ -109,9 +98,9 @@ type ActionMetrics struct {
 	Threat float64
 }
 
-func (actionMetrics *ActionMetrics) ToProto() *proto.ActionMetrics {
+func (actionMetrics *ActionMetrics) ToProto(actionID ActionID) *proto.ActionMetrics {
 	return &proto.ActionMetrics{
-		Id:      actionMetrics.ActionID.ToProto(),
+		Id:      actionID.ToProto(),
 		IsMelee: actionMetrics.IsMelee,
 
 		Casts:   actionMetrics.Casts,
@@ -131,24 +120,21 @@ func NewCharacterMetrics() CharacterMetrics {
 	return CharacterMetrics{
 		dps:       NewDistributionMetrics(),
 		threat:    NewDistributionMetrics(),
-		actions:   make(map[ActionKey]ActionMetrics),
-		resources: make(map[ResourceKey]ResourceMetrics),
+		actions:   make(map[ActionID]*ActionMetrics),
+		resources: make(map[ResourceKey]*ResourceMetrics),
 	}
 }
 
 type ResourceMetrics struct {
-	ActionID ActionID
-	Type     proto.ResourceType
-
 	Events     int32
 	Gain       float64
 	ActualGain float64
 }
 
-func (resourceMetrics *ResourceMetrics) ToProto() *proto.ResourceMetrics {
+func (resourceMetrics *ResourceMetrics) ToProto(actionID ActionID, resourceType proto.ResourceType) *proto.ResourceMetrics {
 	return &proto.ResourceMetrics{
-		Id:   resourceMetrics.ActionID.ToProto(),
-		Type: resourceMetrics.Type,
+		Id:   actionID.ToProto(),
+		Type: resourceType,
 
 		Events:     resourceMetrics.Events,
 		Gain:       resourceMetrics.Gain,
@@ -157,34 +143,29 @@ func (resourceMetrics *ResourceMetrics) ToProto() *proto.ResourceMetrics {
 }
 
 func (characterMetrics *CharacterMetrics) AddResourceEvent(actionID ActionID, resourceType proto.ResourceType, gain float64, actualGain float64) {
-	actionKey := NewActionKey(actionID)
 	resourceKey := ResourceKey{
-		ActionKey: actionKey,
-		Type:      resourceType,
+		ActionID: actionID,
+		Type:     resourceType,
 	}
 	resourceMetrics, ok := characterMetrics.resources[resourceKey]
 
 	if !ok {
-		resourceMetrics.ActionID = actionID
-		resourceMetrics.Type = resourceType
+		resourceMetrics = &ResourceMetrics{}
+		characterMetrics.resources[resourceKey] = resourceMetrics
 	}
 
 	resourceMetrics.Events++
 	resourceMetrics.Gain += gain
 	resourceMetrics.ActualGain += actualGain
-
-	characterMetrics.resources[resourceKey] = resourceMetrics
 }
 
 // Adds the results of a spell to the character metrics.
 func (characterMetrics *CharacterMetrics) addSpell(spell *Spell) {
-	actionID := spell.ActionID
-	actionKey := NewActionKey(actionID)
-	actionMetrics, ok := characterMetrics.actions[actionKey]
+	actionMetrics, ok := characterMetrics.actions[spell.ActionID]
 
 	if !ok {
-		actionMetrics.ActionID = actionID
-		actionMetrics.IsMelee = spell.SpellExtras.Matches(SpellExtrasMeleeMetrics)
+		actionMetrics = &ActionMetrics{IsMelee: spell.SpellExtras.Matches(SpellExtrasMeleeMetrics)}
+		characterMetrics.actions[spell.ActionID] = actionMetrics
 	}
 
 	actionMetrics.Casts += spell.Casts
@@ -199,8 +180,6 @@ func (characterMetrics *CharacterMetrics) addSpell(spell *Spell) {
 	actionMetrics.Threat += spell.TotalThreat
 	characterMetrics.dps.Total += spell.TotalDamage
 	characterMetrics.threat.Total += spell.TotalThreat
-
-	characterMetrics.actions[actionKey] = actionMetrics
 }
 
 // This should be called at the end of each iteration, to include metrics from Pets in
@@ -235,11 +214,11 @@ func (characterMetrics *CharacterMetrics) ToProto(numIterations int32) *proto.Pl
 		SecondsOomAvg: characterMetrics.oomTimeSum / float64(numIterations),
 	}
 
-	for _, action := range characterMetrics.actions {
-		protoMetrics.Actions = append(protoMetrics.Actions, action.ToProto())
+	for actionID, action := range characterMetrics.actions {
+		protoMetrics.Actions = append(protoMetrics.Actions, action.ToProto(actionID))
 	}
-	for _, resource := range characterMetrics.resources {
-		protoMetrics.Resources = append(protoMetrics.Resources, resource.ToProto())
+	for rk, resource := range characterMetrics.resources {
+		protoMetrics.Resources = append(protoMetrics.Resources, resource.ToProto(rk.ActionID, rk.Type))
 	}
 
 	return protoMetrics

--- a/sim/core/pending_action.go
+++ b/sim/core/pending_action.go
@@ -4,31 +4,32 @@ import (
 	"time"
 )
 
+type ActionPriority int32
+
 const (
-	ActionPriorityLow = -1
-	ActionPriorityGCD = 0
+	ActionPriorityLow ActionPriority = -1
+	ActionPriorityGCD ActionPriority = 0
 
 	// Higher than GCD because regen can cause GCD actions (if we were waiting
 	// for mana).
-	ActionPriorityRegen = 1
+	ActionPriorityRegen ActionPriority = 1
 
 	// Autos can cause regen (JoW, rage, energy procs, etc) so they should be
 	// higher prio so that we never go backwards in the priority order.
-	ActionPriorityAuto = 2
+	ActionPriorityAuto ActionPriority = 2
 
 	// DOTs need to be higher than anything else so that dots can properly expire before we take other actions.
-	ActionPriorityDOT = 3
+	ActionPriorityDOT ActionPriority = 3
 )
 
 type PendingAction struct {
-	Name         string
-	Priority     int
-	OnAction     func(*Simulation)
-	CleanUp      func(*Simulation)
 	NextActionAt time.Duration
+	Priority     ActionPriority
+
+	OnAction func(*Simulation)
+	CleanUp  func(*Simulation)
 
 	cancelled bool
-	id        int
 }
 
 func (pa *PendingAction) Cancel(sim *Simulation) {
@@ -42,55 +43,4 @@ func (pa *PendingAction) Cancel(sim *Simulation) {
 	}
 
 	pa.cancelled = true
-}
-
-type paPool struct {
-	objs  []*PendingAction
-	maxid int
-}
-
-func newPAPool() *paPool {
-	objs := make([]*PendingAction, 64)
-	for i := range objs {
-		objs[i] = &PendingAction{
-			id: i + 1,
-		}
-	}
-	return &paPool{
-		objs:  objs,
-		maxid: len(objs) + 1,
-	}
-}
-
-func (pap *paPool) Get() *PendingAction {
-	if len(pap.objs) == 0 {
-		// Allocate more
-		newObjs := make([]*PendingAction, 128)
-		copy(newObjs, pap.objs)
-		pap.objs = newObjs
-		for i := range pap.objs {
-			if pap.objs[i] == nil {
-				pap.objs[i] = &PendingAction{
-					id: pap.maxid,
-				}
-				pap.maxid++
-			}
-		}
-	}
-
-	pa := pap.objs[len(pap.objs)-1]
-	pap.objs = pap.objs[:len(pap.objs)-1]
-	pa.cancelled = false
-	return pa
-}
-
-func (pap *paPool) Put(pa *PendingAction) {
-	pa.cancelled = true
-	pa.CleanUp = nil
-	pa.Name = ""
-	pa.NextActionAt = 0
-	pa.OnAction = nil
-	pa.Priority = 0
-
-	pap.objs = append(pap.objs, pa)
 }

--- a/sim/core/periodic_action.go
+++ b/sim/core/periodic_action.go
@@ -17,8 +17,10 @@ type PeriodicActionOptions struct {
 }
 
 func NewPeriodicAction(sim *Simulation, options PeriodicActionOptions) *PendingAction {
-	pa := sim.pendingActionPool.Get()
-	pa.NextActionAt = sim.CurrentTime + options.Period
+	pa := &PendingAction{
+		NextActionAt: sim.CurrentTime + options.Period,
+		//Priority:     ActionPriorityDOT,
+	}
 
 	tickIndex := 0
 

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -156,10 +156,11 @@ func (pet *Pet) EnableWithTimeout(sim *Simulation, petAgent PetAgent, petDuratio
 	pet.EnableGCDTimer(sim, petAgent)
 	pet.Enable(sim, petAgent)
 
-	pet.timeoutAction = sim.pendingActionPool.Get()
-	pet.timeoutAction.NextActionAt = sim.CurrentTime + petDuration
-	pet.timeoutAction.OnAction = func(sim *Simulation) {
-		pet.Disable(sim)
+	pet.timeoutAction = &PendingAction{
+		NextActionAt: sim.CurrentTime + petDuration,
+		OnAction: func(sim *Simulation) {
+			pet.Disable(sim)
+		},
 	}
 	sim.AddPendingAction(pet.timeoutAction)
 }


### PR DESCRIPTION
[core] removed paPool, since it rather hurts than helps performance, and thusly adds needless complexity
[core] removed PendingAction's Name field, which was hardly used at all, and turned Priority into a named type ("ActionPriority")