### PR TITLE
Fix for multithreaded EPs

### DIFF
--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -424,13 +424,14 @@ func RegisterTemporaryStatsOnUseCD(character *Character, auraLabel string, tempS
 // Helper function to make an ApplyEffect for a temporary stats on-use cooldown.
 func MakeTemporaryStatsOnUseCDRegistration(auraLabel string, tempStats stats.Stats, duration time.Duration, config SpellConfig, cdFunc func(*Character) Cooldown, sharedCDFunc func(*Character) Cooldown) ApplyEffect {
 	return func(agent Agent) {
+		localConfig := config
 		character := agent.GetCharacter()
 		if cdFunc != nil {
-			config.Cast.CD = cdFunc(character)
+			localConfig.Cast.CD = cdFunc(character)
 		}
 		if sharedCDFunc != nil {
-			config.Cast.SharedCD = sharedCDFunc(character)
+			localConfig.Cast.SharedCD = sharedCDFunc(character)
 		}
-		RegisterTemporaryStatsOnUseCD(character, auraLabel, tempStats, duration, config)
+		RegisterTemporaryStatsOnUseCD(character, auraLabel, tempStats, duration, localConfig)
 	}
 }


### PR DESCRIPTION
clone spell config so the CD function isn't shared