### PR TITLE
Ret consecration

### DIFF
--- a/sim/paladin/consecration.go
+++ b/sim/paladin/consecration.go
@@ -53,7 +53,7 @@ func (paladin *Paladin) RegisterConsecrationSpell(rank int32) {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 			BaseDamage:       core.BaseDamageConfigMagicNoRoll(baseDamage, 0.119),
-			OutcomeApplier:   paladin.OutcomeFuncTick(),
+			OutcomeApplier:   paladin.OutcomeFuncMagicHit(),
 			IsPeriodic:       true,
 		}),
 	})

--- a/sim/paladin/retribution/retribution.go
+++ b/sim/paladin/retribution/retribution.go
@@ -249,7 +249,8 @@ func (ret *RetributionPaladin) useFillers(sim *core.Simulation, target *core.Tar
 	// If we can't exorcise, try to consecrate
 	// Only cast consecration when above 60% mana
 	if ret.Rotation.ConsecrationRank != proto.RetributionPaladin_Rotation_None &&
-		ret.Consecration.IsReady(sim) && ret.CurrentMana() > ret.GetStat(stats.Mana)*0.6 {
+		ret.Consecration.IsReady(sim) &&
+		ret.CurrentMana() > ret.GetStat(stats.Mana)*0.6 {
 		ret.Consecration.Cast(sim, target)
 		return
 	}

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -14,4 +14,5 @@ export const launchedSpecs: Array<Spec> = [
 	Spec.SpecShadowPriest,
 	Spec.SpecSmitePriest,
 	Spec.SpecWarrior,
+	Spec.SpecRetributionPaladin,
 ];

--- a/ui/raid/index.scss
+++ b/ui/raid/index.scss
@@ -8,6 +8,7 @@
 @import "../shadow_priest/sim";
 @import "../smite_priest/sim";
 @import "../warrior/sim";
+@import "../retribution_paladin/sim";
 
 @import "./raid_sim_ui";
 

--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -545,7 +545,7 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 		talents: RetributionPaladinPresets.RetKingsPaladinTalents.data,
 		specOptions: RetributionPaladinPresets.DefaultOptions,
 		consumes: RetributionPaladinPresets.DefaultConsumes,
-		defaultName: 'Retribution Paladin',
+		defaultName: 'Ret Paladin',
 		defaultFactionRaces: {
 			[Faction.Unknown]: Race.RaceUnknown,
 			[Faction.Alliance]: Race.RaceHuman,
@@ -568,7 +568,7 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 				5: RetributionPaladinPresets.P5_PRESET.gear,
 			},
 		},
-		tooltip: 'Retribution Paladin',
+		tooltip: 'Ret Paladin',
 		iconUrl: talentTreeIcons[Class.ClassPaladin][2],
 	},
 ];

--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -29,6 +29,8 @@ import * as RoguePresets from '/tbc/rogue/presets.js';
 import * as ShadowPriestPresets from '/tbc/shadow_priest/presets.js';
 import * as SmitePriestPresets from '/tbc/smite_priest/presets.js';
 import * as WarriorPresets from '/tbc/warrior/presets.js';
+import * as RetributionPaladinPresets from '/tbc/retribution_paladin/presets.js';
+
 
 import { BalanceDruidSimUI } from '/tbc/balance_druid/sim.js';
 import { EnhancementShamanSimUI } from '/tbc/enhancement_shaman/sim.js';
@@ -536,6 +538,38 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 		},
 		tooltip: 'Fury Warrior',
 		iconUrl: talentTreeIcons[Class.ClassWarrior][1],
+	},
+	{
+		spec: Spec.SpecRetributionPaladin,
+		rotation: RetributionPaladinPresets.DefaultRotation,
+		talents: RetributionPaladinPresets.RetKingsPaladinTalents.data,
+		specOptions: RetributionPaladinPresets.DefaultOptions,
+		consumes: RetributionPaladinPresets.DefaultConsumes,
+		defaultName: 'Retribution Paladin',
+		defaultFactionRaces: {
+			[Faction.Unknown]: Race.RaceUnknown,
+			[Faction.Alliance]: Race.RaceHuman,
+			[Faction.Horde]: Race.RaceBloodElf,
+		},
+		defaultGear: {
+			[Faction.Unknown]: {},
+			[Faction.Alliance]: {
+				1: RetributionPaladinPresets.P1_PRESET.gear,
+				2: RetributionPaladinPresets.P2_PRESET.gear,
+				3: RetributionPaladinPresets.P3_PRESET.gear,
+				4: RetributionPaladinPresets.P4_PRESET.gear,
+				5: RetributionPaladinPresets.P5_PRESET.gear,
+			},
+			[Faction.Horde]: {
+				1: RetributionPaladinPresets.P1_PRESET.gear,
+				2: RetributionPaladinPresets.P2_PRESET.gear,
+				3: RetributionPaladinPresets.P3_PRESET.gear,
+				4: RetributionPaladinPresets.P4_PRESET.gear,
+				5: RetributionPaladinPresets.P5_PRESET.gear,
+			},
+		},
+		tooltip: 'Retribution Paladin',
+		iconUrl: talentTreeIcons[Class.ClassPaladin][2],
 	},
 ];
 

--- a/ui/raid/tsconfig.json
+++ b/ui/raid/tsconfig.json
@@ -18,5 +18,6 @@
 		{ "path": "../shadow_priest" },
 		{ "path": "../smite_priest" },
 		{ "path": "../warrior" },
+		{ "path": "../retribution_paladin" }
 	],
 }

--- a/ui/retribution_paladin/sim.ts
+++ b/ui/retribution_paladin/sim.ts
@@ -8,6 +8,7 @@ import { TristateEffect } from '/tbc/core/proto/common.js'
 import { Stats } from '/tbc/core/proto_utils/stats.js';
 import { Player } from '/tbc/core/player.js';
 import { IndividualSimUI } from '/tbc/core/individual_sim_ui.js';
+import { EventID, TypedEvent } from '/tbc/core/typed_event.js';
 
 import { Alchohol } from '/tbc/core/proto/common.js';
 import { BattleElixir } from '/tbc/core/proto/common.js';
@@ -32,7 +33,19 @@ export class RetributionPaladinSimUI extends IndividualSimUI<Spec.SpecRetributio
 			cssClass: 'retribution-paladin-sim-ui',
 			// List any known bugs / issues here and they'll be shown on the site.
 			knownIssues: [
-				"Basically everything is WIP"
+				"<p>Rotation logic can be optimized to use Judgement of Blood more frequently.</p>\
+				<p>Including fillers in rotation sometimes causes seal twists to be prevented at high haste values.</p>\
+				<p>Seal of Command aura will log at expiring at a longer duration than 400ms when changing seals.\
+				However, the 400ms duration is correctly calculated internally for determining procs and damage.</p>"
+			],
+			warnings: [
+				(simUI: IndividualSimUI<Spec.SpecRetributionPaladin>) => {
+					return {
+						updateOn: TypedEvent.onAny([simUI.player.rotationChangeEmitter]),
+						shouldDisplay: () => true,
+						getContent: () => 'This sim is newly released, and there are likely a few bugs. Please let us know if you encounter any issues!',
+					};
+				},
 			],
 
 			// All stats for which EP should be calculated.
@@ -73,7 +86,7 @@ export class RetributionPaladinSimUI extends IndividualSimUI<Spec.SpecRetributio
 			],
 			defaults: {
 				// Default equipped gear.
-				gear: Presets.P3_PRESET.gear,
+				gear: Presets.P4_PRESET.gear,
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatStrength]: 2.42,
@@ -106,10 +119,10 @@ export class RetributionPaladinSimUI extends IndividualSimUI<Spec.SpecRetributio
 				partyBuffs: PartyBuffs.create({
 					bloodlust: 1,
 					drums: Drums.DrumsOfBattle,
-					braidedEterniumChain: true,
 					manaSpringTotem: TristateEffect.TristateEffectRegular,
 					strengthOfEarthTotem: StrengthOfEarthType.EnhancingTotems,
 					windfuryTotemRank: 5,
+					graceOfAirTotem: TristateEffect.TristateEffectImproved,
 					battleShout: TristateEffect.TristateEffectImproved,
 					windfuryTotemIwt: 2,
 				}),
@@ -122,16 +135,16 @@ export class RetributionPaladinSimUI extends IndividualSimUI<Spec.SpecRetributio
 				debuffs: Debuffs.create({
 					judgementOfWisdom: true,
 					misery: true,
-					curseOfElements: TristateEffect.TristateEffectImproved,
-					isbUptime: 1,
+					curseOfElements: TristateEffect.TristateEffectRegular,
+					isbUptime: 0.95,
 					bloodFrenzy: true,
 					exposeArmor: TristateEffect.TristateEffectImproved,
 					sunderArmor: true,
 					faerieFire: TristateEffect.TristateEffectImproved,
 					curseOfRecklessness: true,
 					huntersMark: TristateEffect.TristateEffectImproved,
-					exposeWeaknessUptime: 1,
-					exposeWeaknessHunterAgility: 800,
+					exposeWeaknessUptime: 0.95,
+					exposeWeaknessHunterAgility: 1200,
 				}),
 			},
 


### PR DESCRIPTION
Fixed a bug with consecration damage not being able to be resisted. Fixed a bug where consecration casts and damage did not appear in the detailed results. Pushed ret sim to be publicly available (beta). Added ret to the raid sim.