### PR TITLE
Ret lightbringer

### DIFF
--- a/sim/paladin/items.go
+++ b/sim/paladin/items.go
@@ -7,6 +7,7 @@ import (
 func init() {
 	core.AddItemSet(&ItemSetJusticarBattlegear)
 	core.AddItemSet(&ItemSetCrystalforgeBattlegear)
+	core.AddItemSet(&ItemSetLightbringerBattlegear)
 }
 
 var ItemSetJusticarBattlegear = core.ItemSet{

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -424,6 +424,12 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-LightbringerBattlegear"
+ value: {
+  dps: 1849.4443094391893
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-LionheartChampion-28429"
  value: {
   dps: 1884.3379334050564


### PR DESCRIPTION
Fixed a bug where lightbringer set bonus was implemented but never initialized in paladin/items.go