### PR TITLE
Warlock dungeon set and ISB 

### DIFF
--- a/sim/warlock/items.go
+++ b/sim/warlock/items.go
@@ -71,3 +71,15 @@ var ItemSetVoidheartRaiment = core.ItemSet{
 		},
 	},
 }
+
+var ItemSetOblivionRaiment = core.ItemSet{
+	Name: "Oblivion Raiment",
+	Bonuses: map[int32]core.ApplyEffect{
+		2: func(agent core.Agent) {
+			// in pet.go constructor
+		},
+		4: func(agent core.Agent) {
+			// in seed.go
+		},
+	},
+}

--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -123,6 +123,10 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 		})
 	}
 
+	if ItemSetOblivionRaiment.CharacterHasSetBonus(&warlock.Character, 2) {
+		wp.AddStat(stats.MP5, 45)
+	}
+
 	core.ApplyPetConsumeEffects(&wp.Character, warlock.Consumes)
 
 	warlock.AddPet(wp)

--- a/sim/warlock/rotations.go
+++ b/sim/warlock/rotations.go
@@ -127,7 +127,7 @@ func (warlock *Warlock) tryUseGCD(sim *core.Simulation) {
 		spell = warlock.UnstableAff
 	} else if warlock.Rotation.Corruption && !warlock.CorruptionDot.IsActive() {
 		spell = warlock.Corruption
-	} else if warlock.Talents.SiphonLife && !warlock.SiphonLifeDot.IsActive() && warlock.ImpShadowboltAura.IsActive() {
+	} else if warlock.Talents.SiphonLife && !warlock.SiphonLifeDot.IsActive() && (warlock.ImpShadowboltAura == nil || warlock.ImpShadowboltAura.IsActive()) {
 		spell = warlock.SiphonLife
 	} else if warlock.Rotation.Immolate && !warlock.ImmolateDot.IsActive() {
 		spell = warlock.Immolate

--- a/sim/warlock/seed.go
+++ b/sim/warlock/seed.go
@@ -27,11 +27,15 @@ func (warlock *Warlock) registerSeedSpell() {
 func (warlock *Warlock) makeSeed(targetIdx int, cap float64) {
 	baseCost := 882.0
 
+	flatBonus := 0.0
+	if ItemSetOblivionRaiment.CharacterHasSetBonus(&warlock.Character, 4) {
+		flatBonus += 180
+	}
 	baseSeedExplosionEffect := core.SpellEffect{
 		ProcMask:         core.ProcMaskSpellDamage,
 		DamageMultiplier: 1 * (1 + 0.02*float64(warlock.Talents.ShadowMastery)) * (1 + 0.01*float64(warlock.Talents.Contagion)),
 		ThreatMultiplier: 1 - 0.05*float64(warlock.Talents.ImprovedDrainSoul),
-		BaseDamage:       core.BaseDamageConfigMagic(1110, 1290, 0.143),
+		BaseDamage:       core.BaseDamageConfigMagic(1110+flatBonus, 1290+flatBonus, 0.143),
 		OutcomeApplier:   warlock.OutcomeFuncMagicHitAndCrit(warlock.SpellCritMultiplier(1, core.TernaryFloat64(warlock.Talents.Ruin, 1, 0))),
 	}
 

--- a/sim/warlock/shadowbolt.go
+++ b/sim/warlock/shadowbolt.go
@@ -8,7 +8,6 @@ import (
 )
 
 func (warlock *Warlock) registerShadowboltSpell() {
-	warlock.ImpShadowboltAura = warlock.impShadowboltDebuffAura(warlock.Env.GetPrimaryTarget())
 	has4pMal := ItemSetMaleficRaiment.CharacterHasSetBonus(&warlock.Character, 4)
 
 	effect := core.SpellEffect{
@@ -20,7 +19,9 @@ func (warlock *Warlock) registerShadowboltSpell() {
 		BaseDamage:       core.BaseDamageConfigMagic(544.0, 607.0, 0.857+0.04*float64(warlock.Talents.ShadowAndFlame)),
 		OutcomeApplier:   warlock.OutcomeFuncMagicHitAndCrit(warlock.SpellCritMultiplier(1, core.TernaryFloat64(warlock.Talents.Ruin, 1, 0))),
 	}
-	if warlock.Talents.ImprovedShadowBolt > 0 {
+	// Don't add ISB debuff aura if the target is initialized with the 'estimated ISB uptime' debuff.
+	if warlock.Talents.ImprovedShadowBolt > 0 && !warlock.Env.Encounter.Targets[0].HasAura("Improved Shadow Bolt") {
+		warlock.ImpShadowboltAura = warlock.impShadowboltDebuffAura(warlock.Env.GetPrimaryTarget())
 		effect.OnSpellHit = func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if !spellEffect.Landed() || !spellEffect.Outcome.Matches(core.OutcomeCrit) {
 				return

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -387,6 +387,9 @@ const petNameToIcon: Record<string, string> = {
 	'Warp Stalker': 'https://wow.zamimg.com/images/wow/icons/medium/ability_hunter_pet_warpstalker.jpg',
 	'Wind Serpent': 'https://wow.zamimg.com/images/wow/icons/medium/ability_hunter_pet_windserpent.jpg',
 	'Wolf': 'https://wow.zamimg.com/images/wow/icons/medium/ability_hunter_pet_wolf.jpg',
+	'Succubus': 'https://wow.zamimg.com/images/wow/icons/large/spell_shadow_summonsuccubus.jpg',
+	'Felguard': 'https://wow.zamimg.com/images/wow/icons/large/spell_shadow_summonfelguard.jpg',
+	'Imp': 'https://wow.zamimg.com/images/wow/icons/large/spell_shadow_summonimp.jpg',
 };
 
 export const resourceTypeToIcon: Record<ResourceType, string> = {

--- a/ui/warlock/_sim.scss
+++ b/ui/warlock/_sim.scss
@@ -16,7 +16,7 @@
   grid-template-columns: repeat(5, 1fr);
 }
 .warlock-sim-ui .debuffs-section {
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(4, 1fr);
 }
 
 .warlock-sim-ui .warlock-summon-picker {

--- a/ui/warlock/presets.ts
+++ b/ui/warlock/presets.ts
@@ -56,6 +56,191 @@ export const DefaultConsumes = Consumes.create({
 	defaultPotion: Potions.DestructionPotion,
 });
 
+export const P1_DESTRO = {
+	name: 'P1 Destro',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	gear: EquipmentSpec.fromJsonString(`{"items": [
+	{
+	  "id": 28963,
+	  "enchant": 29191,
+	  "gems": [
+		34220,
+		31867
+	  ]
+	},
+	{
+	  "id": 28762
+	},
+	{
+	  "id": 28967,
+	  "enchant": 28886,
+	  "gems": [
+		24056,
+		31861
+	]
+	},
+	{
+	  "id": 28766,
+	  "enchant": 33150
+	},
+	{
+	  "id": 28964,
+	  "enchant": 24003,
+	  "gems": [
+		31861,
+		24059,
+		24030
+	  ]
+	},
+	{
+	  "id": 24250,
+	  "enchant": 22534,
+	  "gems": [
+		31867
+	  ]
+	},
+	{
+	  "id": 28968,
+	  "enchant": 28272
+	},
+	{
+	  "id": 24256,
+	  "gems": [
+		31867,
+		31867
+	  ]
+	},
+	{
+	  "id": 24262,
+	  "enchant": 24274,
+	  "gems": [
+		31867,
+		31867,
+		31867
+	  ]
+	},
+	{
+	  "id": 21870,
+	  "enchant": 35297,
+	  "gems": [
+		31861,
+		24057
+	  ]
+	},
+	{
+	  "id": 28753
+	},
+	{
+	  "id": 28793
+	},
+	{
+	  "id": 27683
+	},
+	{
+	  "id": 29370
+	},
+	{
+	  "id": 28802,
+	  "enchant": 22561
+	},
+	{
+	  "id": 29273
+	},
+	{
+	  "id": 28783
+	}
+  ]}`),
+};
+
+export const P2_DESTRO = {
+	name: 'P2 Destro',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	gear: EquipmentSpec.fromJsonString(`{"items": [
+	{
+	  "id": 30212,
+	  "enchant": 29191,
+	  "gems": [
+		34220,
+		30606
+	  ]
+	},
+	{
+	  "id": 30015
+	},
+	{
+	  "id": 28967,
+	  "enchant": 28886,
+	  "gems": [
+		30600,
+		30564
+	  ]
+	},
+	{
+	  "id": 29992,
+	  "enchant": 33150
+	},
+	{
+	  "id": 30107,
+	  "enchant": 24003,
+	  "gems": [
+		31867,
+		31867,
+		30605
+	  ]
+	},
+	{
+	  "id": 29918,
+	  "enchant": 22534
+	},
+	{
+	  "id": 28968,
+	  "enchant": 28272
+	},
+	{
+	  "id": 30038,
+	  "gems": [
+		24030,
+		24030
+	  ]
+	},
+	{
+	  "id": 24262,
+	  "enchant": 24274,
+	  "gems": [
+		31867,
+		31867,
+		31867
+	  ]
+	},
+	{
+	  "id": 30037,
+	  "enchant": 35297
+	},
+	{
+	  "id": 30109
+	},
+	{
+	  "id": 29302
+	},
+	{
+	  "id": 27683
+	},
+	{
+	  "id": 29370
+	},
+	{
+	  "id": 30095,
+	  "enchant": 22561
+	},
+	{
+	  "id": 30049
+	},
+	{
+	  "id": 29982
+	}
+  ]}`),
+};
+
 export const P3_DESTRO = {
 	name: 'P3 Destro',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
@@ -248,3 +433,4 @@ export const P4_DESTRO = {
 		}
 	]}`),
 };
+

--- a/ui/warlock/sim.ts
+++ b/ui/warlock/sim.ts
@@ -190,6 +190,8 @@ export class WarlockSimUI extends IndividualSimUI<Spec.SpecWarlock> {
 				],
 				battleElixirs: [
 					BattleElixir.AdeptsElixir,
+					BattleElixir.ElixirOfMajorShadowPower,
+					BattleElixir.ElixirOfMajorFirePower,
 				],
 				guardianElixirs: [
 					GuardianElixir.ElixirOfDraenicWisdom,
@@ -238,12 +240,14 @@ export class WarlockSimUI extends IndividualSimUI<Spec.SpecWarlock> {
 			presets: {
 				// Preset talents that the user can quickly select.
 				talents: [
-					Presets.DestructionTalents,
 					Presets.AfflicationTalents,
 					Presets.DemonologistTalents,
+					Presets.DestructionTalents,	
 				],
 				// Preset gear configurations that the user can quickly select.
 				gear: [
+					Presets.P1_DESTRO,
+					Presets.P2_DESTRO,
 					Presets.P3_DESTRO,
 					Presets.P4_DESTRO,
 				],

--- a/ui/warlock/sim.ts
+++ b/ui/warlock/sim.ts
@@ -219,6 +219,7 @@ export class WarlockSimUI extends IndividualSimUI<Spec.SpecWarlock> {
 					OtherInputs.StartingPotion,
 					OtherInputs.NumStartingPotions,
 					OtherInputs.SnapshotImprovedWrathOfAirTotem,
+					OtherInputs.ISBUptime,
 				],
 			},
 			encounterPicker: {


### PR DESCRIPTION
When testing warlock you might want to simulate a higher ISB uptime than you get from yourself only. This adds the ISB debuff which disables the warlocks own ISB effect if used.

Also added dungeon set bonuses (pet mp5 and additional seed damage)