### PR TITLE
Fix warrior bugs with sunder refresh and extra attacks/HS

### DIFF
--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -48,223 +48,223 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 693.5902060960635
+  dps: 691.6450185457993
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 676.5299860484506
+  dps: 672.1226904677565
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 677.3904236987044
+  dps: 672.4968204513884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 676.0761642765885
+  dps: 680.3506126827572
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 700.5930515443886
+  dps: 705.0117992685216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 684.1612721566494
+  dps: 683.287480231715
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 704.3050126188801
+  dps: 708.3766599301625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 715.4174559326385
+  dps: 708.3586281247642
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 680.6520061858029
+  dps: 686.132351936184
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 682.2806480469249
+  dps: 679.8236781098936
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blinkstrike-31332"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BoldArmor"
  value: {
-  dps: 529.1871376132598
+  dps: 526.3829329579833
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 701.7386058081207
+  dps: 697.0234156556293
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 685.569512042174
+  dps: 680.7021430329952
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 702.970657356564
+  dps: 696.1019395812506
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 703.0817276554694
+  dps: 697.1802805307775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningRage"
  value: {
-  dps: 618.2376861665482
+  dps: 622.9396157414578
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 695.0635590577568
+  dps: 693.9449028865504
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 699.4112127614708
+  dps: 693.244866796469
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 693.8431466395741
+  dps: 686.0248301516216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 688.9300567232921
+  dps: 686.5151638979451
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 698.6432183344434
+  dps: 693.4347013509188
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 681.5577610437924
+  dps: 675.1119818340728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DesolationBattlegear"
  value: {
-  dps: 561.2763838029429
+  dps: 558.8933696374453
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Despair-28573"
  value: {
-  dps: 768.2001000229588
+  dps: 763.5183186848274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestroyerArmor"
  value: {
-  dps: 541.76295397687
+  dps: 539.6028959132042
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestroyerBattlegear"
  value: {
-  dps: 639.6111115225351
+  dps: 635.5700537972533
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 675.4535837973184
+  dps: 672.6046402283007
  }
 }
 dps_results: {
@@ -276,337 +276,337 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DoomplateBattlegear"
  value: {
-  dps: 572.609146483684
+  dps: 572.2605319391432
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dragonstrike-28439"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 684.4024185441419
+  dps: 680.5438502791824
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FaithinFelsteel"
  value: {
-  dps: 553.3442737047378
+  dps: 551.8039853544751
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FelstalkerArmor"
  value: {
-  dps: 651.5959164957028
+  dps: 650.3967303434996
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 689.0324386077665
+  dps: 684.5052459621928
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 699.4361878159649
+  dps: 694.9542608669483
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FlameGuard"
  value: {
-  dps: 528.4037752365157
+  dps: 528.8889963955368
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HandofJustice-11815"
  value: {
-  dps: 690.025592678778
+  dps: 684.2363241651104
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heartrazor-29962"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 690.7640672873864
+  dps: 683.9295283418928
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 687.4385320413936
+  dps: 682.8444220116143
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 725.6815949031036
+  dps: 728.7102177624937
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 689.6597994094057
+  dps: 692.2546757314667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LionheartChampion-28429"
  value: {
-  dps: 786.8303428569228
+  dps: 785.2573309987619
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 813.1446020273754
+  dps: 812.3462605040434
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 698.185625219662
+  dps: 698.766130582947
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 472.1912403151522
+  dps: 470.28010824341794
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 699.8006739961
+  dps: 696.8360921789182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 674.1407656468248
+  dps: 676.090096966549
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherscaleArmor"
  value: {
-  dps: 663.1415931143545
+  dps: 659.6449693037212
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherstrikeArmor"
  value: {
-  dps: 605.9951335957808
+  dps: 601.5106802095435
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 448.5443396981565
+  dps: 443.08747833431784
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 694.3739761620018
+  dps: 695.172878453374
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 679.2653349185348
+  dps: 683.1774690806933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PrimalIntent"
  value: {
-  dps: 674.4066159454709
+  dps: 679.0237642438972
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 668.7279072495772
+  dps: 665.3895487521745
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 658.0075563286483
+  dps: 655.8944682236557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 691.85671767652
+  dps: 694.0313921857881
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 660.9725290573863
+  dps: 662.2378132027956
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 674.560798232595
+  dps: 676.5286323323941
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 672.7323987684128
+  dps: 662.4265974961536
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofContempt-34472"
  value: {
-  dps: 706.4166139458162
+  dps: 705.0404388836748
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 680.4026866892124
+  dps: 675.570607466065
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 699.3071598489088
+  dps: 696.7201780525372
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 672.7251680362709
+  dps: 662.4119031777839
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 672.9314475137741
+  dps: 664.2295844945133
  }
 }
 dps_results: {
@@ -618,73 +618,73 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 698.7380528384497
+  dps: 694.2343537691839
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 577.862271148899
+  dps: 572.4747027673591
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormGauntlets-12632"
  value: {
-  dps: 669.3552547921281
+  dps: 662.7375155088498
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 588.5885533969242
+  dps: 589.2219678708743
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 679.2653349185348
+  dps: 683.1774690806933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 683.688174930531
+  dps: 680.9055852171703
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 675.4413283191118
+  dps: 672.5985124891974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheBladefist-29348"
  value: {
-  dps: 643.0602732814505
+  dps: 640.2660324748707
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheDecapitator-28767"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
@@ -696,85 +696,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheNightBlade-31331"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 672.7112580685065
+  dps: 662.3966573628946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 675.8151380535264
+  dps: 670.7757892986323
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 796.9003191284577
+  dps: 796.0609608892081
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinStars"
  value: {
-  dps: 665.054912691016
+  dps: 658.3165445547154
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 691.9496362568847
+  dps: 684.2460710615695
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 674.6306170817893
+  dps: 670.2450722091519
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 698.6481223505155
+  dps: 692.3155731293991
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarbringerArmor"
  value: {
-  dps: 514.7167376108549
+  dps: 515.7199743116142
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarbringerBattlegear"
  value: {
-  dps: 612.4193700624295
+  dps: 612.9448183253404
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarpSlicer-30311"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WastewalkerArmor"
  value: {
-  dps: 576.0278338246223
+  dps: 568.5779849918083
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WindhawkArmor"
  value: {
-  dps: 606.3431258246854
+  dps: 601.5034494774014
  }
 }
 dps_results: {
@@ -786,120 +786,120 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-WrathofSpellfire"
  value: {
-  dps: 598.1985678216466
+  dps: 594.3262374574584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 672.7251680362709
+  dps: 662.4119031777839
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 695.2266761265579
+  dps: 691.621798370029
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1144.038826760946
+  dps: 1134.53314827108
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 697.8887006129668
+  dps: 687.2922443793516
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 622.4188614128975
+  dps: 625.2085289748758
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 851.9325385605941
+  dps: 841.813906827943
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 936.1329370546623
+  dps: 927.2590585429882
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 558.5491854399548
+  dps: 557.829212002526
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 504.4185574214488
+  dps: 500.3659248436725
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 685.2820547485206
+  dps: 689.130336716113
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1152.9589399428005
+  dps: 1149.3683755738818
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 701.5021422280936
+  dps: 693.3236573129884
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 625.8388542320215
+  dps: 623.4810179139045
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 855.0588481173695
+  dps: 835.7566314494526
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 948.6072987957948
+  dps: 937.1963495284148
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTargetFullDebuffs"
  value: {
-  dps: 566.6902243964121
+  dps: 559.5234077086569
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTargetNoDebuffs"
  value: {
-  dps: 506.0388336807316
+  dps: 504.4610530755929
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTargetFullDebuffs"
  value: {
-  dps: 702.5281121007765
+  dps: 704.3266034247811
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 597.0088181528279
+  dps: 594.4357749693637
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -378,7 +378,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-HandofJustice-11815"
  value: {
-  dps: 902.4332600843211
+  dps: 901.5548364252089
  }
 }
 dps_results: {

--- a/sim/warrior/dps/dps_warrior.go
+++ b/sim/warrior/dps/dps_warrior.go
@@ -87,12 +87,7 @@ func NewDpsWarrior(character core.Character, options proto.Player) *DpsWarrior {
 		OffHand:        war.WeaponFromOffHand(war.DefaultMeleeCritMultiplier()),
 		AutoSwingMelee: true,
 		ReplaceMHSwing: func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
-			if war.CurrentRage() < war.HSRageThreshold {
-				war.DequeueHSOrCleave(sim)
-				return nil
-			} else {
-				return war.TryHSOrCleave(sim, mhSwingSpell)
-			}
+			return war.TryHSOrCleave(sim, mhSwingSpell)
 		},
 	})
 

--- a/sim/warrior/dps/rotation.go
+++ b/sim/warrior/dps/rotation.go
@@ -231,7 +231,7 @@ func (war *DpsWarrior) shouldSunder(sim *core.Simulation) bool {
 		war.maintainSunder = false
 	}
 
-	return stacks < 5 || war.SunderArmorAura.RemainingDuration(sim) < SunderWindow
+	return stacks < 5 || war.SunderArmorAura.RemainingDuration(sim) <= SunderWindow
 }
 
 // Returns whether any ability was cast.

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -102,14 +102,23 @@ func (warrior *Warrior) DequeueHSOrCleave(sim *core.Simulation) {
 // Returns true if the regular melee swing should be used, false otherwise.
 func (warrior *Warrior) TryHSOrCleave(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
 	if !warrior.HSOrCleaveQueueAura.IsActive() {
+		if sim.Log != nil {
+			sim.Log("HS not queued")
+		}
 		return nil
 	}
 
 	if warrior.CurrentRage() < warrior.HeroicStrikeOrCleave.DefaultCast.Cost {
 		warrior.DequeueHSOrCleave(sim)
+		if sim.Log != nil {
+			sim.Log("HS not enough rage")
+		}
 		return nil
 	} else if warrior.CurrentRage() < warrior.HSRageThreshold {
 		if mhSwingSpell == warrior.AutoAttacks.MHAuto {
+			if sim.Log != nil {
+				sim.Log("HS MS auto below thresh")
+			}
 			warrior.DequeueHSOrCleave(sim)
 			return nil
 		}

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -390,7 +390,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 512.1499087674388
+  dps: 514.1399527887912
  }
 }
 dps_results: {

--- a/sim/warrior/protection/protection_warrior.go
+++ b/sim/warrior/protection/protection_warrior.go
@@ -57,12 +57,7 @@ func NewProtectionWarrior(character core.Character, options proto.Player) *Prote
 		OffHand:        war.WeaponFromOffHand(war.DefaultMeleeCritMultiplier()),
 		AutoSwingMelee: true,
 		ReplaceMHSwing: func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
-			if war.CurrentRage() < war.HSRageThreshold {
-				war.DequeueHSOrCleave(sim)
-				return nil
-			} else {
-				return war.TryHSOrCleave(sim, mhSwingSpell)
-			}
+			return war.TryHSOrCleave(sim, mhSwingSpell)
 		},
 	})
 

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -158,6 +158,11 @@ func (warrior *Warrior) applyWeaponSpecializations() {
 					return
 				}
 
+				if spell == warrior.Whirlwind && spellEffect.ProcMask.Matches(core.ProcMaskMeleeOHSpecial) {
+					// OH WW hits cant proc this
+					return
+				}
+
 				if !ppmm.Proc(sim, spellEffect.IsMH(), false, "Mace Specialization") {
 					return
 				}
@@ -196,6 +201,11 @@ func (warrior *Warrior) applyWeaponSpecializations() {
 				}
 
 				if !spellEffect.ProcMask.Matches(swordSpecMask) {
+					return
+				}
+
+				if spell == warrior.Whirlwind && spellEffect.ProcMask.Matches(core.ProcMaskMeleeOHSpecial) {
+					// OH WW hits cant proc this
 					return
 				}
 


### PR DESCRIPTION
 - HS should finally stop being dequeued when falling below threshold unless its a regular MH swing being replaced.
 - WW OH hits no longer proc sword/mace spec.
 - Fixed bug where sunder didn't get 2 chances to be maintained if it lined up exactly with the 3s window.