### PR TITLE
Feral dps work

### DIFF
--- a/sim/common/melee_trinkets.go
+++ b/sim/common/melee_trinkets.go
@@ -199,7 +199,7 @@ func ApplyBadgeOfTheSwarmguard(agent core.Agent) {
 
 	character.AddMajorCooldown(core.MajorCooldown{
 		Spell: spell,
-		Type:  core.CooldownTypeDPS,
+		Type:  core.CooldownTypeDPS | core.CooldownTypeUsableShapeShifted,
 	})
 }
 

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -538,7 +538,7 @@ type externalConsecutiveCDApproximation struct {
 	ActionID         ActionID
 	AuraTag          string
 	CooldownPriority float64
-	Type             int32
+	Type             CooldownType
 	AuraDuration     time.Duration
 	AuraCD           time.Duration
 
@@ -630,7 +630,7 @@ func registerBloodlustCD(agent Agent, numBloodlusts int32) {
 			CooldownPriority: CooldownPriorityBloodlust,
 			AuraDuration:     BloodlustDuration,
 			AuraCD:           BloodlustCD,
-			Type:             CooldownTypeDPS,
+			Type:             CooldownTypeDPS | CooldownTypeUsableShapeShifted,
 
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// Haste portion doesn't stack with Power Infusion, so prefer to wait.
@@ -697,7 +697,7 @@ func registerPowerInfusionCD(agent Agent, numPowerInfusions int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     PowerInfusionDuration,
 			AuraCD:           PowerInfusionCD,
-			Type:             CooldownTypeDPS,
+			Type:             CooldownTypeDPS | CooldownTypeUsableShapeShifted,
 
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// Haste portion doesn't stack with Bloodlust, so prefer to wait.
@@ -777,7 +777,7 @@ func registerInnervateCD(agent Agent, numInnervates int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     InnervateDuration,
 			AuraCD:           InnervateCD,
-			Type:             CooldownTypeMana,
+			Type:             CooldownTypeMana | CooldownTypeUsableShapeShifted,
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// Only cast innervate when very low on mana, to make sure all other mana CDs are prioritized.
 				if character.CurrentMana() > innervateThreshold {
@@ -867,7 +867,7 @@ func registerManaTideTotemCD(agent Agent, numManaTideTotems int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     ManaTideTotemDuration,
 			AuraCD:           ManaTideTotemCD,
-			Type:             CooldownTypeMana,
+			Type:             CooldownTypeMana | CooldownTypeUsableShapeShifted,
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// A normal resto shaman would wait to use MTT.
 				if sim.CurrentTime < initialDelay {

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -374,7 +374,7 @@ func registerDrumsCD(agent Agent, partyBuffs proto.PartyBuffs, consumes proto.Co
 	}
 
 	var actionID ActionID
-	var cooldownType int32
+	var cooldownType CooldownType
 	if drumsType == proto.Drums_DrumsOfBattle {
 		actionID = DrumsOfBattleActionID
 		cooldownType = CooldownTypeDPS
@@ -390,7 +390,7 @@ func registerDrumsCD(agent Agent, partyBuffs proto.PartyBuffs, consumes proto.Co
 
 	mcd := MajorCooldown{
 		Priority: CooldownPriorityDrums,
-		Type:     cooldownType,
+		Type:     cooldownType | CooldownTypeUsableShapeShifted,
 	}
 
 	if drumsSelfCast {

--- a/sim/druid/faerie_fire.go
+++ b/sim/druid/faerie_fire.go
@@ -16,7 +16,7 @@ func (druid *Druid) registerFaerieFireSpell() {
 	ignoreHaste := false
 	cd := core.Cooldown{}
 
-	if druid.Form.Matches(Cat | Bear) {
+	if druid.InForm(Cat | Bear) {
 		if !druid.Talents.FaerieFire {
 			return
 		}

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -14,7 +14,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 50
+  final_stats: 66
   final_stats: 0
   final_stats: 116.65513309823677
   final_stats: 0
@@ -48,700 +48,700 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1538.4872615874965
-  tps: 1092.3259557271224
+  dps: 2243.4813854261574
+  tps: 1629.2773712949988
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1530.401590384113
-  tps: 1086.5851291727206
+  dps: 2218.5045878474307
+  tps: 1611.246646804392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1537.350376648624
-  tps: 1091.5187674205229
+  dps: 2231.1033754589644
+  tps: 1620.1140416866394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1528.1733775662756
-  tps: 1085.0030980720555
+  dps: 2227.4163091067376
+  tps: 1617.5739688984995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1544.720564056006
-  tps: 1096.7516004797644
+  dps: 2237.0543363040783
+  tps: 1624.3743281313427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1506.7622619176282
-  tps: 1069.8012059615162
+  dps: 2201.883537298579
+  tps: 1599.3519791381277
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1506.7622619176282
-  tps: 1069.8012059615162
+  dps: 2208.697739722386
+  tps: 1604.4807479403473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1554.0964084272593
-  tps: 1103.4084499833543
+  dps: 2258.141276302338
+  tps: 1639.3886956073752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1567.9568659918532
-  tps: 1113.2493748542156
+  dps: 2278.9017596248545
+  tps: 1654.2532844003965
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1535.3548869785302
-  tps: 1090.1019697547567
+  dps: 2225.2099867490974
+  tps: 1615.8107177128054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1550.5830832918548
-  tps: 1100.9139891372167
+  dps: 2253.464993146311
+  tps: 1636.0685345665966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1533.367285425272
-  tps: 1088.6907726519428
+  dps: 2226.3619604785604
+  tps: 1616.6653492639487
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1534.0493814018866
-  tps: 1089.175060795339
+  dps: 2219.7850272837204
+  tps: 1611.8253089503203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1535.0845508004288
-  tps: 1089.9100310683043
+  dps: 2221.7464966055427
+  tps: 1613.3574447569322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1536.285157102025
-  tps: 1090.7624615424384
+  dps: 2233.8820194115565
+  tps: 1622.1646232149196
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1539.793254439432
-  tps: 1093.2532106519968
+  dps: 2237.48091991058
+  tps: 1624.7198425692272
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1540.9730461284767
-  tps: 1094.0908627512179
+  dps: 2240.9566224460823
+  tps: 1627.187591369432
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1521.6257021007934
-  tps: 1080.354248491563
+  dps: 2212.0745752461407
+  tps: 1606.6813378574755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1521.8387975261055
-  tps: 1080.5055462435346
+  dps: 2202.14669136018
+  tps: 1599.4525072614038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2217.258686260164
+  tps: 1610.520915179185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1532.7821570046924
-  tps: 1088.2753314733313
+  dps: 2229.4667504420495
+  tps: 1619.0297822465698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1548.3425718964663
-  tps: 1099.3232260464906
+  dps: 2250.216570142103
+  tps: 1633.7621542336083
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HandofJustice-11815"
  value: {
-  dps: 1525.5234260261052
-  tps: 1083.1216324785348
+  dps: 2217.9522184557263
+  tps: 1610.9518460391002
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartrazor-29962"
  value: {
-  dps: 1561.5068217960327
-  tps: 1108.6698434751831
+  dps: 2264.830718192055
+  tps: 1644.179067963678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1541.1589122850057
-  tps: 1094.2228277223542
+  dps: 2242.20433962529
+  tps: 1628.1284206744258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1526.0661587055654
-  tps: 1083.5069726809522
+  dps: 2221.550782987879
+  tps: 1613.40944535411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofTerror-33509"
  value: {
-  dps: 1543.0186167142663
-  tps: 1095.5432178671283
+  dps: 2196.5373623944433
+  tps: 1595.3228036833887
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 1513.459244707534
-  tps: 1074.5560637423491
+  dps: 2184.18310357959
+  tps: 1586.8783929742233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 1535.8470989665811
-  tps: 1090.4514402662721
+  dps: 2203.2055228943764
+  tps: 1600.3843106877225
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1535.7554075767162
-  tps: 1090.3863393794686
+  dps: 2211.680916926029
+  tps: 1606.6007306984536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 1528.6806435974247
-  tps: 1085.3632569541721
+  dps: 2226.1178035689154
+  tps: 1616.6520299666445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1539.0754141533534
-  tps: 1092.7435440488805
+  dps: 2239.8903380743814
+  tps: 1626.4305294655258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneHarness"
  value: {
-  dps: 1507.3062288956935
-  tps: 1070.1874225159422
+  dps: 1927.918881520924
+  tps: 1404.1627249331257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneRegalia"
  value: {
-  dps: 1213.2018089923238
-  tps: 861.37328438455
+  dps: 1606.4675557211842
+  tps: 1175.6737920403893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1213.2018089923238
-  tps: 861.37328438455
+  dps: 1590.6268309033342
+  tps: 1164.378828991837
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1489.165520511942
-  tps: 1057.3075195634792
+  dps: 2116.181034219014
+  tps: 1543.9552213656573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1542.5961665036948
-  tps: 1095.2432782176234
+  dps: 2243.0320957312397
+  tps: 1628.6611774018943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilHarness"
  value: {
-  dps: 1455.1215028106963
-  tps: 1033.1362669955943
+  dps: 1898.8932919279596
+  tps: 1383.2222381249917
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilRegalia"
  value: {
-  dps: 1213.2018089923238
-  tps: 861.37328438455
+  dps: 1613.4381315643698
+  tps: 1180.7200894098632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PrimalIntent"
  value: {
-  dps: 1439.906076913428
-  tps: 1022.3333146085338
+  dps: 2134.558800862366
+  tps: 1551.4258846466319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1394.8707426656597
-  tps: 990.3582272926185
+  dps: 2080.854353751136
+  tps: 1513.356533385353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1557.7587269580233
-  tps: 1106.0086961401962
+  dps: 2263.3775631149997
+  tps: 1643.1064592443645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1518.280630301053
-  tps: 1077.9792475137472
+  dps: 2208.214653658326
+  tps: 1603.9407935301272
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1503.9462857771455
-  tps: 1067.8018629017731
+  dps: 2189.7121127062524
+  tps: 1590.8039894541548
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1558.8520652974628
-  tps: 1106.7849663611987
+  dps: 2259.356922809483
+  tps: 1639.878159484486
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1521.5223566371465
-  tps: 1080.280873212373
+  dps: 2218.562063641919
+  tps: 1611.1586830352544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1558.8835291287196
-  tps: 1106.807305681391
+  dps: 2265.483438441922
+  tps: 1644.4853998877684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1542.4262030740265
-  tps: 1095.1226041825587
+  dps: 2242.2357979979474
+  tps: 1628.0958060112575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1460.8012825961434
-  tps: 1037.1689106432618
+  dps: 1859.7859947781483
+  tps: 1355.6977664328072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1286.1330192255173
-  tps: 913.1544436501175
+  dps: 1911.9652911525973
+  tps: 1393.2228245871208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1557.280350713612
-  tps: 1105.6690490066646
+  dps: 2262.716725117086
+  tps: 1642.6372642658462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheTwinStars"
  value: {
-  dps: 1482.686066230886
-  tps: 1052.7071070239292
+  dps: 2183.416393578873
+  tps: 1586.243418218567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 1541.5852555206347
-  tps: 1094.5255314196502
+  dps: 2004.52933085293
+  tps: 1456.3013681132259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1101.526956709309
-  tps: 782.0841392636092
+  dps: 1481.2429894995716
+  tps: 1087.1606526876935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1519.911133379025
-  tps: 1079.136904699108
+  dps: 2209.594943088682
+  tps: 1604.9207990256803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1546.0625219680667
-  tps: 1097.7043905973273
+  dps: 2237.0220689108655
+  tps: 1624.4175725968366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WastewalkerArmor"
  value: {
-  dps: 1358.343528884825
-  tps: 964.423905508226
+  dps: 1752.530884869724
+  tps: 1278.9726035442945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WindhawkArmor"
  value: {
-  dps: 1324.0539426983564
-  tps: 940.078299315833
+  dps: 2005.4348783407688
+  tps: 1459.8441526973602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1323.8285303854457
-  tps: 939.9182565736659
+  dps: 1931.098574597582
+  tps: 1407.1571118648446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofSpellfire"
  value: {
-  dps: 1312.3696262372407
-  tps: 931.7824346284413
+  dps: 1959.3163746586592
+  tps: 1426.95941252293
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1512.9447463955587
-  tps: 1074.1907699408468
+  dps: 2202.071062802775
+  tps: 1599.5788440226856
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 1541.3225056195727
-  tps: 1094.3389789898977
+  dps: 2231.201535925037
+  tps: 1620.161757403574
  }
 }
 dps_results: {
  key: "TestFeral-SelfDrums-DPS"
  value: {
-  dps: 1545.3281566914075
-  tps: 1097.1829912508992
+  dps: 2235.6899003183835
+  tps: 1623.1332096514734
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 2316.9667890244887
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1545.320944603331
-  tps: 1097.1778706683647
+  dps: 2246.1957751692726
+  tps: 1630.9073898028996
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1763.0297493267876
-  tps: 1251.7511220220185
+  dps: 2463.1706254054275
+  tps: 1789.098871895837
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 686.9362939487264
-  tps: 487.7247687035954
+  dps: 787.8954885506093
+  tps: 559.4057968709324
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 686.9362939487264
-  tps: 487.7247687035954
+  dps: 787.8954885506093
+  tps: 559.4057968709324
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 699.972285184886
-  tps: 496.9803224812691
+  dps: 940.5229832670417
+  tps: 667.7713181196
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1243.6322563407207
-  tps: 882.9789020019118
+  dps: 2055.8936498626554
+  tps: 1495.9028031671467
  }
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -39,6 +39,7 @@ func NewFeralDruid(character core.Character, options proto.Player) *FeralDruid {
 	cat := &FeralDruid{
 		Druid:    druid.New(character, druid.Cat, selfBuffs, *feralOptions.Talents),
 		Rotation: *feralOptions.Rotation,
+		latency:  time.Duration(feralOptions.Options.LatencyMs) * time.Millisecond,
 	}
 
 	// Passive Cat Form threat reduction
@@ -48,7 +49,6 @@ func NewFeralDruid(character core.Character, options proto.Player) *FeralDruid {
 	cat.HasMHWeaponImbue = true
 
 	cat.EnableEnergyBar(100.0, func(sim *core.Simulation) {
-		cat.TryUseCooldowns(sim)
 		if cat.GCD.IsReady(sim) {
 			cat.doRotation(sim)
 		}
@@ -93,8 +93,10 @@ type FeralDruid struct {
 
 	Rotation proto.FeralDruid_Rotation
 
+	// currently unused
 	readyToShift   bool
 	waitingForTick bool
+	latency        time.Duration
 }
 
 func (cat *FeralDruid) GetDruid() *druid.Druid {

--- a/sim/druid/feral/presets.go
+++ b/sim/druid/feral/presets.go
@@ -69,6 +69,7 @@ var FullIndividualBuffs = &proto.IndividualBuffs{
 
 var FullConsumes = &proto.Consumes{
 	BattleElixir:     proto.BattleElixir_ElixirOfMajorAgility,
+	GuardianElixir:   proto.GuardianElixir_ElixirOfMajorMageblood,
 	Food:             proto.Food_FoodGrilledMudfish,
 	DefaultPotion:    proto.Potions_HastePotion,
 	MainHandImbue:    proto.WeaponImbue_WeaponImbueAdamantiteWeightstone,
@@ -85,6 +86,7 @@ var FullDebuffs = &proto.Debuffs{
 	ExposeArmor:                 proto.TristateEffect_TristateEffectImproved,
 	FaerieFire:                  proto.TristateEffect_TristateEffectImproved,
 	SunderArmor:                 true,
+	Mangle:                      true,
 	CurseOfRecklessness:         true,
 	HuntersMark:                 proto.TristateEffect_TristateEffectImproved,
 	ExposeWeaknessUptime:        1.0,

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/wowsims/tbc/sim/core"
+	"github.com/wowsims/tbc/sim/core/items"
 	"github.com/wowsims/tbc/sim/core/proto"
 	"github.com/wowsims/tbc/sim/druid"
 )
@@ -12,50 +13,249 @@ func (cat *FeralDruid) OnGCDReady(sim *core.Simulation) {
 	cat.doRotation(sim)
 }
 
-func (cat *FeralDruid) doRotation(sim *core.Simulation) {
-	if !cat.Form.Matches(druid.Cat) {
-		cat.Powershift.Cast(sim, nil)
-		return
+func (cat *FeralDruid) doRotation(sim *core.Simulation) bool {
+
+	// On gcd do nothing
+	if !cat.GCD.IsReady(sim) {
+		return false
 	}
 
-	if cat.readyToShift {
-		cat.innervateOrShift(sim)
-		return
+	// If we're out of form always shift back in
+	if !cat.InForm(druid.Cat) {
+		return cat.CatForm.Cast(sim, nil)
 	}
+
+	// Ported from https://github.com/NerdEgghead/TBC_cat_sim
+
+	// If we previously decided to shift, then execute the shift now once
+	// the input delay is over.
+	// if cat.readyToShift {
+	// 	cat.PowerShiftCat(sim)
+	// }
+
+	//strategy = {
+
+	min_combos_for_rip := cat.Rotation.RipMinComboPoints
+	use_mangle_trick := cat.Rotation.MangleTrick
+
+	bite_trick_cp := int32(2)
+	bite_trick_max := 39.0
+	use_bite := (cat.Rotation.Biteweave && cat.Rotation.FinishingMove == proto.FeralDruid_Rotation_Rip) || cat.Rotation.FinishingMove == proto.FeralDruid_Rotation_Bite
+	bite_time := time.Second * 0.0
+	min_combos_for_bite := cat.Rotation.BiteMinComboPoints
+
+	use_rip_trick := cat.Rotation.Ripweave
+	use_bite_trick := cat.Rotation.RakeTrick
+	use_rake_trick := cat.Rotation.RakeTrick
+
+	rip_trick_cp := int32(4)
+	rip_trick_min := 52.0
+	max_wait_time := time.Second * 1.0
+
+	bite_over_rip := use_bite && cat.Rotation.FinishingMove != proto.FeralDruid_Rotation_Rip
+	no_finisher := false
+
+	// }
 
 	energy := cat.CurrentEnergy()
-	comboPoints := cat.ComboPoints()
+	cp := cat.ComboPoints()
+	rip_cp := min_combos_for_rip
+	bite_cp := min_combos_for_bite
+	cur_time := sim.CurrentTime
+	rip_debuff := cat.RipDot.IsActive()
+	rip_end := cat.RipDot.ExpiresAt()
+	mangle_debuff := cat.MangleAura.IsActive()
+	mangle_end := cat.MangleAura.ExpiresAt()
+	next_tick := cat.NextEnergyTickAt()
+	fight_length := sim.Duration
+	wolfshead := cat.Equip[items.ItemSlotHead].ID == 8345
+	shift_cost := cat.CatForm.DefaultCast.Cost
+	omen_proc := cat.PseudoStats.NoCost
+	latency := cat.latency
 
-	if cat.shouldRip(sim, energy, comboPoints) {
-		cat.Rip.Cast(sim, cat.CurrentTarget)
-	} else if !cat.MangleAura.IsActive() && cat.CanMangleCat() {
-		cat.Mangle.Cast(sim, cat.CurrentTarget)
-	} else if cat.CanShred() {
-		cat.Shred.Cast(sim, cat.CurrentTarget)
-	} else if cat.PseudoStats.InFrontOfTarget && cat.CanMangleCat() {
-		cat.Mangle.Cast(sim, cat.CurrentTarget)
+	// 10/6/21 - Added logic to not cast Rip if we're near the end of the
+	// fight.
+	end_thresh := time.Second * 10
+	rip_now := cp >= rip_cp && !rip_debuff
+	ripweave_now := (use_rip_trick &&
+		cp >= rip_trick_cp &&
+		!rip_debuff &&
+		energy >= rip_trick_min &&
+		!cat.PseudoStats.NoCost)
+
+	rip_now = (rip_now || ripweave_now) && (fight_length-cur_time >= end_thresh)
+
+	bite_at_end := (cp >= bite_cp &&
+		!no_finisher && ((fight_length-cur_time < end_thresh) ||
+		(rip_debuff && (fight_length-rip_end < end_thresh))))
+
+	mangle_now := !rip_now && !mangle_debuff
+	mangle_cost := cat.Mangle.DefaultCast.Cost
+
+	bite_before_rip := (rip_debuff && use_bite &&
+		(rip_end-cur_time >= bite_time))
+
+	bite_now := ((bite_before_rip || bite_over_rip) &&
+		cp >= bite_cp)
+
+	rip_next := ((rip_now || ((cp >= rip_cp) && (rip_end <= next_tick))) &&
+		(fight_length-next_tick >= end_thresh))
+
+	mangle_next := (!rip_next && (mangle_now || mangle_end <= next_tick))
+
+	// 12/2/21 - Added wait_to_mangle parameter that tells us whether we
+	// should wait for the next Energy tick and cast Mangle, assuming we
+	// are less than a tick's worth of Energy from being able to cast it. In
+	// a standard Wolfshead rotation, wait_for_mangle is identical to
+	// mangle_next, i.e. we only wait for the tick if Mangle will have
+	// fallen off before the next tick. In a no-Wolfshead rotation, however,
+	// it is preferable to Mangle rather than Shred as the second special in
+	// a standard cycle, provided a bonus like 2pT6 is present to bring the
+	// Mangle Energy cost down to 38 or below so that it can be fit in
+	// alongside a Shred.
+	wait_to_mangle := (mangle_next || ((!wolfshead) && (mangle_cost <= 38)))
+
+	bite_before_rip_next := (bite_before_rip &&
+		(rip_end-next_tick >= bite_time))
+
+	prio_bite_over_mangle := (bite_over_rip || (!mangle_now))
+
+	time_to_next_tick := next_tick - cur_time
+	cat.waitingForTick = true
+
+	if cat.CurrentMana() < shift_cost {
+		// If this is the first time we're oom, log it
+		//if self.time_to_oom is None:
+		//    self.time_to_oom = time //TODO
+
+		// No-shift rotation
+		if rip_now && ((energy >= 30) || omen_proc) {
+			cat.Rip.Cast(sim, cat.CurrentTarget)
+		} else if mangle_now &&
+			((energy >= mangle_cost) || omen_proc) {
+			return cat.Mangle.Cast(sim, cat.CurrentTarget)
+		} else if bite_now && ((energy >= 35) || omen_proc) {
+			return cat.FerociousBite.Cast(sim, cat.CurrentTarget)
+		} else if (energy >= 42) || omen_proc {
+			return cat.Shred.Cast(sim, cat.CurrentTarget)
+		}
+	} else if energy < 10 {
+		cat.PowerShiftCat(sim)
+	} else if rip_now {
+		if (energy >= 30) || omen_proc {
+			cat.Rip.Cast(sim, cat.CurrentTarget)
+		} else if time_to_next_tick > max_wait_time {
+			cat.PowerShiftCat(sim)
+		}
+	} else if (bite_now || bite_at_end) && prio_bite_over_mangle {
+		// Decision tree for Bite usage is more complicated, so there is
+		// some duplicated logic with the main tree.
+
+		// Shred versus Bite decision is the same as vanilla criteria.
+
+		// Bite immediately if we'd have to wait for the following cast.
+		cutoff_mod := 20.0
+		if time_to_next_tick <= 1.0 {
+			cutoff_mod = 0.0
+		}
+		if (energy >= 57.0+cutoff_mod) ||
+			((energy >= 15+cutoff_mod) && omen_proc) {
+			return cat.Shred.Cast(sim, cat.CurrentTarget)
+		}
+		if energy >= 35 {
+			return cat.FerociousBite.Cast(sim, cat.CurrentTarget)
+		}
+		// If we are doing the Rip rotation with Bite filler, then there is
+		// a case where we would Bite now if we had enough energy, but once
+		// we gain enough energy to do so, it's too late to Bite relative to
+		// Rip falling off. In this case, we wait for the tick only if we
+		// can Shred or Mangle afterward, and otherwise shift and won't Bite
+		// at all this cycle. Returning 0.0 is the same thing as waiting for
+		// the next tick, so this logic could be written differently if
+		// desired to match the rest of the rotation code, where waiting for
+		// tick is handled implicitly instead.
+		wait := false
+		if (energy >= 22) && bite_before_rip &&
+			(!bite_before_rip_next) {
+			wait = true
+		} else if (energy >= 15) &&
+			((!bite_before_rip) ||
+				bite_before_rip_next || bite_at_end) {
+			wait = true
+		} else if (!rip_next) && ((energy < 20) || (!mangle_next)) {
+			wait = false
+			cat.PowerShiftCat(sim)
+		} else {
+			wait = true
+		}
+		if wait && (time_to_next_tick > max_wait_time) {
+			cat.PowerShiftCat(sim)
+		}
+	} else if energy >= 35 && energy <= bite_trick_max &&
+		use_bite_trick &&
+		(time_to_next_tick > latency) &&
+		!omen_proc &&
+		cp >= bite_trick_cp {
+		return cat.FerociousBite.Cast(sim, cat.CurrentTarget)
+		// no rake implemented yet
+		//    } else if (energy >= 35 && energy < mangle_cost &&
+		//          use_rake_trick &&
+		//          (time_to_next_tick > 1 + self.latency) &&
+		//          !self.rake_debuff &&
+		//          !omen_proc) {
+		//        return self.rake(time)
+	} else if mangle_now {
+		if (energy < mangle_cost-20) && (!rip_next) {
+			cat.PowerShiftCat(sim)
+		} else if (energy >= mangle_cost) || omen_proc {
+			return cat.Mangle.Cast(sim, cat.CurrentTarget)
+		} else if time_to_next_tick > max_wait_time {
+			cat.PowerShiftCat(sim)
+		}
+	} else if energy >= 22 {
+		if omen_proc {
+			return cat.Shred.Cast(sim, cat.CurrentTarget)
+		}
+		// If our energy value is between 50-56 with 2pT6, or 60-61 without,
+		// and we are within 1 second of an Energy tick, then Shredding now
+		// forces us to shift afterwards, whereas we can instead cast two
+		// Mangles instead for higher cpm. This scenario is most relevant
+		// when using a no-Wolfshead rotation with 2pT6, and it will
+		// occur whenever the initial Shred on a cycle misses.
+		if (energy >= 2*mangle_cost-20) && (energy < 22+mangle_cost) &&
+			(time_to_next_tick <= 1.0*time.Second) &&
+			use_mangle_trick &&
+			((!use_rake_trick && !use_bite_trick) || mangle_cost == 35) {
+			return cat.Mangle.Cast(sim, cat.CurrentTarget)
+		}
+		if energy >= 42 {
+			return cat.Shred.Cast(sim, cat.CurrentTarget)
+		}
+		if (energy >= mangle_cost) &&
+			(time_to_next_tick > latency) {
+			return cat.Mangle.Cast(sim, cat.CurrentTarget)
+		}
+		if time_to_next_tick > max_wait_time {
+			cat.PowerShiftCat(sim)
+		}
+	} else if (!rip_next) && ((energy < mangle_cost-20) || (!wait_to_mangle)) {
+		cat.PowerShiftCat(sim)
+	} else if time_to_next_tick > max_wait_time {
+		cat.PowerShiftCat(sim)
 	}
-}
+	// Model two types of input latency: (1) When waiting for an energy tick
+	// to execute the next special ability, the special will in practice be
+	// slightly delayed after the tick arrives. (2) When executing a
+	// powershift without clipping the GCD, the shift will in practice be
+	// slightly delayed after the GCD ends.
 
-func (cat *FeralDruid) innervateOrShift(sim *core.Simulation) {
-	cat.waitingForTick = false
+	// TODO: Model latency
+	//    if self.waiting_for_tick {
+	//        self.player.gcd = time_to_next_tick + self.latency
+	//    }
+	//    if self.player.ready_to_shift  {
+	//        self.player.gcd = self.latency
+	//    }
 
-	// If we have just now decided to shift, then we do not execute the shift immediately, but instead trigger an input delay for realism.
-	if !cat.readyToShift {
-		cat.readyToShift = true
-		return
-	}
-
-	cat.readyToShift = false
-
-	// Logic for Innervate and Haste Pot usage will go here. For now we just execute simple powershifts without bundling any caster form CDs.
-	cat.Powershift.Cast(sim, nil)
-}
-
-func (cat *FeralDruid) shouldRip(sim *core.Simulation, energy float64, comboPoints int32) bool {
-	canPrimaryRip := cat.Rotation.FinishingMove == proto.FeralDruid_Rotation_Rip && energy > cat.Rip.DefaultCast.Cost
-	canWeaveRip := cat.Rotation.FinishingMove == proto.FeralDruid_Rotation_Bite && cat.Rotation.Ripweave && (energy >= 52) && !cat.PseudoStats.NoCost
-	nearFightEnd := sim.GetRemainingDuration() < time.Second*10
-
-	return (canPrimaryRip || canWeaveRip) && (comboPoints >= cat.Rotation.RipMinComboPoints) && !cat.RipDot.IsActive() && !nearFightEnd
+	return false
 }

--- a/sim/druid/ferocious_bite.go
+++ b/sim/druid/ferocious_bite.go
@@ -43,7 +43,12 @@ func (druid *Druid) registerFerociousBiteSpell() {
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
 					comboPoints := float64(druid.ComboPoints())
-					excessEnergy := druid.CurrentEnergy() - spell.DefaultCast.Cost
+
+					// Base amount already spent, remove the rest (listed twice in logs, better way to do this?)
+					excessEnergy := druid.CurrentEnergy()
+					druid.SpendEnergy(sim, druid.CurrentEnergy(), actionID)
+					//
+
 					base := 57.0 + dmgPerComboPoint*comboPoints + 4.1*excessEnergy
 					roll := sim.RandomFloat("Ferocious Bite") * 66.0
 					return base + roll + hitEffect.MeleeAttackPower(spell.Unit)*0.05*comboPoints

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -1,6 +1,8 @@
 package druid
 
 import (
+	"time"
+
 	"github.com/wowsims/tbc/sim/core"
 	"github.com/wowsims/tbc/sim/core/items"
 	"github.com/wowsims/tbc/sim/core/stats"
@@ -19,17 +21,56 @@ func (form DruidForm) Matches(other DruidForm) bool {
 	return (form & other) != 0
 }
 
-func (druid *Druid) registerPowershiftSpell() {
+func (druid *Druid) setForm(form DruidForm, sim *core.Simulation) {
+	if form == druid.form {
+		return
+	}
+
+	druid.form = form
+
+	druid.manageCooldownsEnabled(sim)
+}
+
+func (druid *Druid) GetForm() DruidForm {
+	return druid.form
+}
+
+func (druid *Druid) InForm(form DruidForm) bool {
+	return druid.form.Matches(form)
+}
+
+func (druid *Druid) PowerShiftCat(sim *core.Simulation) {
+
+	if !druid.GCD.IsReady(sim) {
+		panic("Trying to powershift during gcd")
+	}
+	// Go out of form
+	druid.setForm(Humanoid, sim)
+
+	druid.energyBeforeShift = druid.CurrentEnergy()
+
+	// Try use cds
+	druid.TryUseCooldowns(sim)
+
+	// If cds did not trigger gcd (innervate), powershift
+	if druid.GCD.IsReady(sim) {
+		druid.CatForm.Cast(sim, nil)
+	} else {
+		druid.AutoAttacks.CancelAutoSwing(sim)
+	}
+}
+
+func (druid *Druid) registerCatFormSpell() {
 	actionID := core.ActionID{SpellID: 768}
 	baseCost := druid.BaseMana() * 0.35
 
-	// Assumes 5/5 Furor.
-	finalEnergy := 40.0
+	finalEnergy := 0.0
+	furorProcChance := 0.2 * float64(druid.Talents.Furor)
 	if druid.Equip[items.ItemSlotHead].ID == 8345 { // Wolfshead Helm
 		finalEnergy += 20.0
 	}
 
-	druid.Powershift = druid.RegisterSpell(core.SpellConfig{
+	druid.CatForm = druid.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID,
 		SpellExtras: core.SpellExtrasNoOnCastComplete,
 
@@ -45,8 +86,115 @@ func (druid *Druid) registerPowershiftSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			druid.AddEnergy(sim, finalEnergy-druid.CurrentEnergy(), spell.ActionID)
-			druid.Form = Cat
+			energyDelta := finalEnergy - druid.energyBeforeShift
+			if furorProcChance == 1 || (furorProcChance > 0 && sim.RandomFloat("Furor") < furorProcChance) {
+				energyDelta += 40.0
+			}
+			if energyDelta > 0 {
+				druid.AddEnergy(sim, energyDelta, spell.ActionID)
+			} else if energyDelta < 0 {
+				druid.SpendEnergy(sim, -energyDelta, spell.ActionID)
+			}
+			druid.setForm(Cat, sim)
+			druid.AutoAttacks.EnableAutoSwing(sim)
 		},
 	})
+}
+
+func (druid *Druid) PowerShiftBear(sim *core.Simulation) {
+
+	if !druid.GCD.IsReady(sim) {
+		panic("Trying to powershift during gcd")
+	}
+	// Go out of form
+	druid.setForm(Humanoid, sim)
+
+	// Try use cds
+	druid.TryUseCooldowns(sim)
+
+	// If cds did not trigger gcd (innervate), powershift
+	if druid.GCD.IsReady(sim) {
+		druid.BearForm.Cast(sim, nil)
+	} else {
+		druid.AutoAttacks.CancelAutoSwing(sim)
+	}
+}
+
+func (druid *Druid) registerBearFormSpell() {
+	actionID := core.ActionID{SpellID: 9634}
+	baseCost := druid.BaseMana() * 0.35
+
+	furorProcChance := 0.2 * float64(druid.Talents.Furor)
+	finalRage := 0.0
+	if druid.Equip[items.ItemSlotHead].ID == 8345 { // Wolfshead Helm
+		finalRage += 5.0
+	}
+
+	druid.BearForm = druid.RegisterSpell(core.SpellConfig{
+		ActionID:    actionID,
+		SpellExtras: core.SpellExtrasNoOnCastComplete,
+
+		ResourceType: stats.Mana,
+		BaseCost:     baseCost,
+
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				Cost: baseCost * (1 - 0.1*float64(druid.Talents.NaturalShapeshifter)),
+				GCD:  core.GCDDefault,
+			},
+			IgnoreHaste: true,
+		},
+
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			dRage := finalRage - druid.CurrentEnergy()
+			if furorProcChance == 1 || (furorProcChance > 0 && sim.RandomFloat("Furor") < furorProcChance) {
+				finalRage += 10.0
+			}
+			if dRage > 0 {
+				druid.AddRage(sim, dRage, spell.ActionID)
+			} else if dRage < 0 {
+				druid.SpendRage(sim, -dRage, spell.ActionID)
+			}
+			druid.setForm(Bear, sim)
+			druid.AutoAttacks.EnableAutoSwing(sim)
+		},
+	})
+}
+
+const cooldownDelayThresHold = time.Second * 10
+
+// Disable cooldowns not usable in form and/or delay others
+func (druid *Druid) manageCooldownsEnabled(sim *core.Simulation) {
+
+	if druid.StartingForm.Matches(Cat | Bear) {
+
+		druid.EnableAllCooldowns(druid.disabledMCDs)
+		druid.disabledMCDs = nil
+
+		if druid.InForm(Cat | Bear) {
+			// Check if any dps cooldown that requires shifting is ready soon
+			// disable all cooldowns if that is the case
+			nonUsableDpsMCDReadySoon := false
+			for _, cd := range druid.GetMajorCooldowns() {
+				if cd.TimeToReady(sim) < cooldownDelayThresHold && cd.IsEnabled() && !cd.Type.Matches(core.CooldownTypeUsableShapeShifted) && cd.Type.Matches(core.CooldownTypeDPS) {
+					nonUsableDpsMCDReadySoon = true
+					break
+				}
+			}
+			for _, cd := range druid.GetMajorCooldowns() {
+				if cd.IsEnabled() && (nonUsableDpsMCDReadySoon || !cd.Type.Matches(core.CooldownTypeUsableShapeShifted)) {
+					druid.DisableMajorCooldown(cd.Spell.ActionID)
+					druid.disabledMCDs = append(druid.disabledMCDs, cd)
+				}
+			}
+		} else {
+			// Disable cooldown that can be used in form, but incurs a gcd, so we dont get stuck out of form when we dont need to (Greater Drums)
+			for _, cd := range druid.GetMajorCooldowns() {
+				if cd.Type.Matches(core.CooldownTypeUsableShapeShifted) && cd.Spell.DefaultCast.GCD > 0 {
+					druid.DisableMajorCooldown(cd.Spell.ActionID)
+					druid.disabledMCDs = append(druid.disabledMCDs, cd)
+				}
+			}
+		}
+	}
 }

--- a/sim/druid/innervate.go
+++ b/sim/druid/innervate.go
@@ -31,8 +31,14 @@ func (druid *Druid) registerInnervateCD() {
 	druid.RegisterResetEffect(func(sim *core.Simulation) {
 		expectedManaPerInnervate = innervateTarget.SpiritManaRegenPerSecond() * 5 * 20
 		if innervateTarget == druid.GetCharacter() {
-			// Threshold can be lower when casting on self because its never mid-cast.
-			innervateManaThreshold = 500
+			if druid.StartingForm.Matches(Cat) {
+				// double shift + innervate cost.
+				// Prevents not having enough mana to shift back into form if more powershift are executed
+				innervateManaThreshold = druid.CatForm.DefaultCast.Cost*2 + baseCost
+			} else {
+				// Threshold can be lower when casting on self because its never mid-cast.
+				innervateManaThreshold = 500
+			}
 		} else {
 			innervateManaThreshold = core.InnervateManaThreshold(innervateTarget)
 		}
@@ -76,7 +82,9 @@ func (druid *Druid) registerInnervateCD() {
 			if character.CurrentMana() < baseCost {
 				return false
 			}
-
+			if druid.InForm(Bear) || druid.InForm(Cat) {
+				return false
+			}
 			// If target already has another innervate, don't cast.
 			if innervateTarget.HasActiveAuraWithTag(core.InnervateAuraTag) {
 				return false

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -70,9 +70,9 @@ var ItemSetMalorneHarness = core.ItemSet{
 				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 					if spellEffect.Landed() && spellEffect.ProcMask.Matches(core.ProcMaskMelee) {
 						if sim.RandomFloat("Malorne 2pc") < procChance {
-							if druid.Form.Matches(Bear) {
+							if druid.InForm(Bear) {
 								druid.AddRage(sim, 10, core.ActionID{SpellID: 37306})
-							} else if druid.Form.Matches(Cat) {
+							} else if druid.InForm(Cat) {
 								druid.AddEnergy(sim, 20, core.ActionID{SpellID: 37311})
 							}
 						}
@@ -82,9 +82,9 @@ var ItemSetMalorneHarness = core.ItemSet{
 		},
 		4: func(agent core.Agent) {
 			druid := agent.(DruidAgent).GetDruid()
-			if druid.Form.Matches(Bear) {
+			if druid.InForm(Bear) {
 				druid.AddStat(stats.Armor, 1400)
-			} else if druid.Form.Matches(Cat) {
+			} else if druid.InForm(Cat) {
 				druid.AddStat(stats.Strength, 30)
 			}
 		},
@@ -137,11 +137,11 @@ func ApplyLivingRootoftheWildheart(agent core.Agent) {
 	druid := agent.(DruidAgent).GetDruid()
 
 	var procAura *core.Aura
-	if druid.Form.Matches(Moonkin) {
+	if druid.InForm(Moonkin) {
 		procAura = druid.NewTemporaryStatsAura("Living Root Moonkin Proc", core.ActionID{SpellID: 37343}, stats.Stats{stats.SpellPower: 209}, time.Second*15)
-	} else if druid.Form.Matches(Bear) {
+	} else if druid.InForm(Bear) {
 		procAura = druid.NewTemporaryStatsAura("Living Root Bear Proc", core.ActionID{SpellID: 37340}, stats.Stats{stats.Armor: 4070}, time.Second*15)
-	} else if druid.Form.Matches(Cat) {
+	} else if druid.InForm(Cat) {
 		procAura = druid.NewTemporaryStatsAura("Living Root Cat Proc", core.ActionID{SpellID: 37341}, stats.Stats{stats.Strength: 64}, time.Second*15)
 	} else {
 		return
@@ -154,7 +154,7 @@ func ApplyLivingRootoftheWildheart(agent core.Agent) {
 			aura.Activate(sim)
 		},
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			if druid.Form.Matches(Moonkin) && sim.RandomFloat("Living Root of the Wildheart") < 0.03 {
+			if druid.InForm(Moonkin) && sim.RandomFloat("Living Root of the Wildheart") < 0.03 {
 				procAura.Activate(sim)
 			}
 		},
@@ -180,9 +180,9 @@ func ApplyAshtongueTalisman(agent core.Agent) {
 	actionID := core.ActionID{ItemID: 32486}
 
 	var procAura *core.Aura
-	if druid.Form.Matches(Moonkin) {
+	if druid.InForm(Moonkin) {
 		procAura = druid.NewTemporaryStatsAura("Ashtongue Talisman Proc", actionID, stats.Stats{stats.SpellPower: 150}, time.Second*8)
-	} else if druid.Form.Matches(Bear | Cat) {
+	} else if druid.InForm(Bear | Cat) {
 		procAura = druid.NewTemporaryStatsAura("Ashtongue Talisman Proc", actionID, stats.Stats{stats.Strength: 140}, time.Second*8)
 	} else {
 		return

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -43,7 +43,7 @@ func (druid *Druid) registerMangleBearSpell() {
 
 			DamageMultiplier: 1,
 			ThreatMultiplier: (1.5 / 1.15) *
-				core.TernaryFloat64(druid.Form.Matches(Bear) && ItemSetThunderheartHarness.CharacterHasSetBonus(&druid.Character, 2), 1.15, 1),
+				core.TernaryFloat64(druid.InForm(Bear) && ItemSetThunderheartHarness.CharacterHasSetBonus(&druid.Character, 2), 1.15, 1),
 
 			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 155/1.15, 1.15, true),
 			OutcomeApplier: druid.OutcomeFuncMeleeSpecialHitAndCrit(druid.MeleeCritMultiplier()),

--- a/sim/druid/swipe.go
+++ b/sim/druid/swipe.go
@@ -17,7 +17,7 @@ func (druid *Druid) registerSwipeSpell() {
 	baseEffect := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: 1 + core.TernaryFloat64(druid.Form.Matches(Bear) && ItemSetThunderheartHarness.CharacterHasSetBonus(&druid.Character, 4), 0.15, 0),
+		DamageMultiplier: 1 + core.TernaryFloat64(druid.InForm(Bear) && ItemSetThunderheartHarness.CharacterHasSetBonus(&druid.Character, 4), 0.15, 0),
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{

--- a/sim/warlock/rotations.go
+++ b/sim/warlock/rotations.go
@@ -98,7 +98,7 @@ func (warlock *Warlock) tryUseGCD(sim *core.Simulation) {
 			continue // not on cooldown right now.
 		}
 		cdReadyAt := cd.Spell.CD.ReadyAt()
-		if cd.Type == core.CooldownTypeDPS && cdReadyAt < nextBigCD {
+		if cd.Type.Matches(core.CooldownTypeDPS) && cdReadyAt < nextBigCD {
 			nextBigCD = cdReadyAt
 		}
 	}

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -182,6 +182,7 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 				IconInputs.ExposeArmor,
 				IconInputs.SunderArmor,
 				IconInputs.GiftOfArthas,
+				IconInputs.Mangle,
 			],
 			// Which options are selectable in the 'Consumes' section.
 			consumeOptions: {


### PR DESCRIPTION
**(Feral) Druid changes.**

- Cat and Bear forms implemented as spells.
- Furor talent properly implemented.
- Disable abilities not usable while shapeshifted
- Time cooldowns to align with powershifting
- Cat uses mageblood potion by default.
- Option to add mangle debuff from external source.
- Cat rotation ported from https://github.com/NerdEgghead/TBC_cat_sim 
   _*Work in progress needs some cleaning up, formatting, etc._

**Core changes**
- `MajorCooldown.Type` is now a bitflag.
- Added `CooldownTypeUsableShapeShifted` flag and applied in relevant places.

**To do**
- Fix minor issue where excess energy used by Ferocious Bite is logged separately.