### PR TITLE
Iterate through all mcds even one is not ready.

### DIFF
--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -418,9 +418,6 @@ func registerDrumsCD(agent Agent, partyBuffs proto.PartyBuffs, consumes proto.Co
 				for _, aura := range auras {
 					aura.Activate(sim)
 				}
-
-				// All MCDs that use the GCD and have a non-zero cast time must call this.
-				character.UpdateMajorCooldowns()
 			},
 		})
 	} else {

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -350,9 +350,9 @@ func (mcdm *majorCooldownManager) EnableAllCooldowns(mcdsToEnable []*MajorCooldo
 
 func (mcdm *majorCooldownManager) TryUseCooldowns(sim *Simulation) {
 	anyCooldownsUsed := false
-	for curIdx := 0; curIdx < len(mcdm.majorCooldowns) && mcdm.majorCooldowns[curIdx].IsReady(sim); curIdx++ {
+	for curIdx := 0; curIdx < len(mcdm.majorCooldowns); curIdx++ {
 		mcd := mcdm.majorCooldowns[curIdx]
-		if mcd.tryActivateInternal(sim, mcdm.character) {
+		if mcd.IsReady(sim) && mcd.tryActivateInternal(sim, mcdm.character) {
 			anyCooldownsUsed = true
 
 			if mcd.Spell.DefaultCast.GCD > 0 {

--- a/sim/core/test_suite.go
+++ b/sim/core/test_suite.go
@@ -54,7 +54,9 @@ func (testSuite *IndividualTestSuite) TestDPS(testName string, rsr *proto.RaidSi
 	testSuite.testNames = append(testSuite.testNames, testName)
 
 	result := RunRaidSim(rsr)
-
+	if result.ErrorResult != "" {
+		panic("simulation failed to run: " + result.ErrorResult)
+	}
 	testSuite.testResults.DpsResults[testName] = &proto.DpsTestResult{
 		Dps:  result.RaidMetrics.Dps.Avg,
 		Tps:  result.RaidMetrics.Parties[0].Players[0].Threat.Avg,

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -76,15 +76,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1263.3306336905728
+  tps: 1261.9491190306137
  }
 }
 dps_results: {
@@ -111,8 +111,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -132,8 +132,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -153,8 +153,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -209,15 +209,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.286411741684
+  tps: 1257.0016148540358
  }
 }
 dps_results: {
@@ -230,8 +230,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1314.2633059583125
-  tps: 1313.8663439507552
+  dps: 1298.6333231582562
+  tps: 1296.7186922907263
  }
 }
 dps_results: {
@@ -300,8 +300,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -342,15 +342,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1275.8556384510039
-  tps: 1276.2321631269258
+  dps: 1276.3426034466254
+  tps: 1274.7024493915453
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -384,8 +384,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1327.7448397295761
-  tps: 1327.0782470465927
+  dps: 1309.4982750185193
+  tps: 1307.3663451137838
  }
 }
 dps_results: {
@@ -398,8 +398,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -433,15 +433,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1287.0492237703502
-  tps: 1289.4561434065515
+  dps: 1282.5095459430906
+  tps: 1284.9584550750594
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
@@ -461,15 +461,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-MalorneHarness"
  value: {
-  dps: 885.6833813688872
-  tps: 892.279017853118
+  dps: 883.7734543706906
+  tps: 890.3580853341075
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MalorneRegalia"
  value: {
-  dps: 1087.683212061399
-  tps: 1091.6678852651125
+  dps: 1089.191165861909
+  tps: 1093.101409262168
  }
 }
 dps_results: {
@@ -524,8 +524,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-NordrassilRegalia"
  value: {
-  dps: 1232.093347763703
-  tps: 1232.270151586703
+  dps: 1227.5246992959728
+  tps: 1227.6937422793135
  }
 }
 dps_results: {
@@ -643,15 +643,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1267.2635783718279
-  tps: 1267.806610916
+  dps: 1258.9447768727434
+  tps: 1257.8239169309238
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1302.673771315875
-  tps: 1305.7654652716951
+  dps: 1302.7112082428823
+  tps: 1305.8021534601623
  }
 }
 dps_results: {
@@ -664,8 +664,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1052.847035212016
-  tps: 1057.4223319527168
+  dps: 1039.9247398766895
+  tps: 1044.5529942555697
  }
 }
 dps_results: {
@@ -720,15 +720,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1309.1703479881742
-  tps: 1308.8752451400192
+  dps: 1294.701901434074
+  tps: 1292.8658990010285
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1355.599891346074
-  tps: 1354.6873309640935
+  dps: 1343.2378111472506
+  tps: 1340.6496430031957
  }
 }
 dps_results: {
@@ -741,15 +741,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 781.2078494521784
-  tps: 789.778296574743
+  dps: 780.3479346623797
+  tps: 788.7791026915895
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1355.157335254488
-  tps: 1353.2477926610063
+  dps: 1356.2814505910533
+  tps: 1352.5323571748668
  }
 }
 dps_results: {
@@ -776,15 +776,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-WastewalkerArmor"
  value: {
-  dps: 807.6718206075525
-  tps: 815.4243883070094
+  dps: 781.4602685007558
+  tps: 787.5332278112593
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WindhawkArmor"
  value: {
-  dps: 1226.6264815899629
-  tps: 1228.0396560697723
+  dps: 1224.357645816808
+  tps: 1225.8161970120802
  }
 }
 dps_results: {
@@ -825,15 +825,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2098.3205643182687
-  tps: 2481.0065445974005
+  dps: 2095.9621059691776
+  tps: 2476.541955234999
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1105.6873967795286
-  tps: 1108.0751956222127
+  dps: 1103.6897212705755
+  tps: 1106.0016158144244
  }
 }
 dps_results: {
@@ -951,15 +951,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1053.6951687149806
-  tps: 1563.7753475728439
+  dps: 1021.3594565778355
+  tps: 1483.991561056656
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Wrath-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1053.6951687149806
-  tps: 1059.1789694522895
+  dps: 1021.3594565778355
+  tps: 1025.085232126798
  }
 }
 dps_results: {
@@ -1119,15 +1119,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1268.594351560201
-  tps: 1752.5712134278258
+  dps: 1235.9352646425211
+  tps: 1674.441186293381
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Wrath-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1268.594351560201
-  tps: 1268.6899019739383
+  dps: 1235.9352646425211
+  tps: 1234.3777906968564
  }
 }
 dps_results: {

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -76,8 +76,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -111,8 +111,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -132,8 +132,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -153,8 +153,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -209,15 +209,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -230,8 +230,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1315.2075380924514
-  tps: 1314.7916914422108
+  dps: 1314.2633059583125
+  tps: 1313.8663439507552
  }
 }
 dps_results: {
@@ -300,8 +300,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -342,22 +342,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1276.4785817909228
-  tps: 1276.8426476000463
+  dps: 1275.8556384510039
+  tps: 1276.2321631269258
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1269.127717900209
-  tps: 1269.6334676538133
+  dps: 1268.141453819267
+  tps: 1268.6669288544906
  }
 }
 dps_results: {
@@ -384,8 +384,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1328.6792015667784
-  tps: 1327.993921647051
+  dps: 1327.7448397295761
+  tps: 1327.0782470465927
  }
 }
 dps_results: {
@@ -398,8 +398,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -440,8 +440,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -587,8 +587,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1309.5673003920554
-  tps: 1309.454358495823
+  dps: 1309.2219665770756
+  tps: 1309.1159313571425
  }
 }
 dps_results: {
@@ -636,15 +636,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1340.4909659846046
-  tps: 1339.8058507765209
+  dps: 1339.6073620979944
+  tps: 1338.9399189676428
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1268.2330097211327
-  tps: 1268.756653638319
+  dps: 1267.2635783718279
+  tps: 1267.806610916
  }
 }
 dps_results: {
@@ -720,15 +720,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1310.119189149688
-  tps: 1309.8051094783023
+  dps: 1309.1703479881742
+  tps: 1308.8752451400192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1356.0034567775738
-  tps: 1355.0828250869638
+  dps: 1355.599891346074
+  tps: 1354.6873309640935
  }
 }
 dps_results: {
@@ -804,8 +804,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1302.3039060913225
-  tps: 1302.176532081104
+  dps: 1301.7214092933618
+  tps: 1301.6056852191032
  }
 }
 dps_results: {

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -1056,43 +1056,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1747.7869557746799
-  tps: 2276.2234132594226
+  dps: 1751.9313702953868
+  tps: 2277.668202014901
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1602.3040050919183
-  tps: 1379.3595821320375
+  dps: 1609.7258030783623
+  tps: 1386.522830953064
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1957.2807982485476
-  tps: 1686.6020080727287
+  dps: 2023.0685961871163
+  tps: 1755.8661066795116
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 681.0455439072929
-  tps: 782.7883940074047
+  dps: 686.3228500776786
+  tps: 788.6847783960993
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 656.9766253357477
-  tps: 552.3008833073997
+  dps: 661.7125661809109
+  tps: 557.2069673360209
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 986.9614469406488
-  tps: 854.9662647395936
+  dps: 1023.3123533290391
+  tps: 891.238178998343
  }
 }
 dps_results: {
@@ -1224,43 +1224,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1779.674783477507
-  tps: 2288.838229257063
+  dps: 1788.94006463625
+  tps: 2301.4698027841164
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1632.9316724095743
-  tps: 1396.2168514202922
+  dps: 1641.188485712631
+  tps: 1403.609523154464
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2003.2389245801269
-  tps: 1721.576762545487
+  dps: 2074.336235393578
+  tps: 1784.2172732300617
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 695.7492211524711
-  tps: 789.0156586811953
+  dps: 700.538330569606
+  tps: 793.9184440469057
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 672.6809737194702
-  tps: 560.870383754842
+  dps: 678.2771562202713
+  tps: 566.2200278794328
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1007.5313503168815
-  tps: 869.357902701178
+  dps: 1042.0972849885868
+  tps: 900.2133313821743
  }
 }
 dps_results: {

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -48,897 +48,897 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1601.363311236234
-  tps: 1170.2017786309073
+  dps: 1599.9909292011732
+  tps: 1168.6052776703543
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 1607.2335758686852
-  tps: 1174.4195138268387
+  dps: 1609.4417072054075
+  tps: 1178.0033358647563
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1598.018627316369
-  tps: 1171.3176417972982
+  dps: 1601.1762806311197
+  tps: 1171.7886195750243
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1593.1654533754884
-  tps: 1166.6842871225883
+  dps: 1591.0224354088987
+  tps: 1163.129756304078
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1628.4716895895194
-  tps: 1191.6713200334982
+  dps: 1623.100360296225
+  tps: 1189.808295616963
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1587.4706975109254
-  tps: 1157.1592948854252
+  dps: 1587.3670646407566
+  tps: 1159.9405332332412
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1594.0386916824593
-  tps: 1162.4375556131993
+  dps: 1593.811092235145
+  tps: 1165.1424735658425
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1594.3670511394732
-  tps: 1138.5458784292243
+  dps: 1595.3148229484839
+  tps: 1141.8566114361763
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 1456.1708077513206
-  tps: 1037.0705154030586
+  dps: 1459.1354618039547
+  tps: 1041.1243919158753
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1627.6579655831874
-  tps: 1192.882377426302
+  dps: 1625.7055904044828
+  tps: 1189.560253527099
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 1647.1017980863255
-  tps: 1213.700556086482
+  dps: 1647.5746367374095
+  tps: 1214.4358577981334
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1631.2789709378374
-  tps: 1197.270062147013
+  dps: 1630.4724284137376
+  tps: 1197.8884445992799
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1605.1607178838153
-  tps: 1173.7317577363765
+  dps: 1602.441167726477
+  tps: 1171.9626503756976
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1622.7527188915442
-  tps: 1188.8532769459532
+  dps: 1620.8324071414418
+  tps: 1185.551393360008
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1590.8851583160458
-  tps: 1160.7173749763906
+  dps: 1589.343951392261
+  tps: 1158.8398643535784
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1609.9679640479962
-  tps: 1181.498855286656
+  dps: 1611.9927100442906
+  tps: 1184.5027336787389
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1592.9628969884836
-  tps: 1158.981211777273
+  dps: 1592.459336340864
+  tps: 1161.524901417965
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 1542.2093241729108
-  tps: 1117.7098302768527
+  dps: 1540.3697879368324
+  tps: 1114.500465973819
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1610.5101804303517
-  tps: 1176.062273715017
+  dps: 1609.5073313522623
+  tps: 1177.250900407739
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1575.8782048473315
-  tps: 1145.1294252325579
+  dps: 1581.9375016916931
+  tps: 1153.0889556569368
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1605.5929432090852
-  tps: 1174.4210595809404
+  dps: 1603.7235223826822
+  tps: 1171.1631396121954
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1593.1681361166277
-  tps: 1164.7134238009912
+  dps: 1591.261925663248
+  tps: 1161.425313683477
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1606.6261232489726
-  tps: 1173.9294485130679
+  dps: 1608.4443508191462
+  tps: 1177.1719510912303
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1575.0205137263963
-  tps: 1147.1278346215756
+  dps: 1576.7842382877652
+  tps: 1150.3030720348643
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1593.0301410548868
-  tps: 1163.4692473849955
+  dps: 1589.0015927977129
+  tps: 1159.951571270976
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 1494.22672172456
-  tps: 1065.1134683729056
+  dps: 1492.7525037376583
+  tps: 1063.0763794010816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DesolationBattlegear"
  value: {
-  dps: 1429.3404030455467
-  tps: 1016.0896806136393
+  dps: 1432.4831923425081
+  tps: 1017.2472756591961
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 1542.2093241729108
-  tps: 1117.7098302768527
+  dps: 1540.3697879368324
+  tps: 1114.500465973819
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1590.820677301222
-  tps: 1156.372770585887
+  dps: 1589.7480081638796
+  tps: 1157.4915772193553
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Devastation-30316"
  value: {
-  dps: 1610.739651294511
-  tps: 1179.8710125227074
+  dps: 1611.4839113233236
+  tps: 1176.376758355506
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1591.873069505171
-  tps: 1158.7026505425722
+  dps: 1591.737693472861
+  tps: 1158.6691235408493
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1593.385498040362
-  tps: 1159.4154577851184
+  dps: 1594.6114956632912
+  tps: 1161.6596211061849
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1575.0205137263963
-  tps: 1147.1278346215756
+  dps: 1576.7842382877652
+  tps: 1150.3030720348643
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelstalkerArmor"
  value: {
-  dps: 1549.3651764046724
-  tps: 1118.0752702721895
+  dps: 1545.4062824388259
+  tps: 1117.0634785444695
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1586.4296305694984
-  tps: 1157.6905957778408
+  dps: 1587.370498784218
+  tps: 1157.8071839989245
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1601.4965328195779
-  tps: 1171.3039554115228
+  dps: 1599.731382679903
+  tps: 1168.1435259340064
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1617.907007412043
-  tps: 1185.6504971660088
+  dps: 1616.112373777499
+  tps: 1182.4552349773917
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 1542.2093241729108
-  tps: 1117.7098302768527
+  dps: 1540.3697879368324
+  tps: 1114.500465973819
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 1685.9625647286416
-  tps: 1246.2083499628782
+  dps: 1684.5063284001153
+  tps: 1243.210615706096
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 1580.4668409665496
-  tps: 1151.7452239415302
+  dps: 1582.2394691930551
+  tps: 1154.9312508765247
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 1632.463341221043
-  tps: 1196.7497660583933
+  dps: 1628.2947648005659
+  tps: 1193.7807810641484
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1606.513876652099
-  tps: 1177.9153657770814
+  dps: 1607.454272291755
+  tps: 1177.6882039886432
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1593.1084830644604
-  tps: 1162.940712202385
+  dps: 1590.5858476702167
+  tps: 1161.132907853563
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1615.8056838663424
-  tps: 1180.8205217920713
+  dps: 1618.9490475751873
+  tps: 1183.0679752875515
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1544.650051398018
-  tps: 1120.7552623029253
+  dps: 1541.97104116977
+  tps: 1116.8322020627702
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1592.7785107203706
-  tps: 1165.8215688903008
+  dps: 1592.2801136709802
+  tps: 1167.6215709269973
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1564.3650264946775
-  tps: 1136.6366840915528
+  dps: 1568.8759845606069
+  tps: 1139.924034218062
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1564.3650264946775
-  tps: 1136.6366840915528
+  dps: 1568.8759845606069
+  tps: 1139.924034218062
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1611.01155581637
-  tps: 1178.058485574991
+  dps: 1613.5938892394397
+  tps: 1179.930084737345
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1307.6305108134081
-  tps: 910.0456813226831
+  dps: 1309.0907007724934
+  tps: 908.4079435055406
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1728.3132198342992
-  tps: 1300.3555181779745
+  dps: 1731.4434115854463
+  tps: 1302.6855676980888
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1609.650933626057
-  tps: 1181.7582545212363
+  dps: 1611.4955796002164
+  tps: 1185.014413347316
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1575.0205137263963
-  tps: 1147.1278346215756
+  dps: 1576.7842382877652
+  tps: 1150.3030720348643
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 1562.080949637329
-  tps: 1130.4305613411418
+  dps: 1565.2893708327827
+  tps: 1134.3004847683487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1488.8807782273557
-  tps: 1064.2196281405804
+  dps: 1488.0608088968604
+  tps: 1064.0881586951434
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1597.5547334325224
-  tps: 1162.5761314759607
+  dps: 1597.0510638750245
+  tps: 1165.1276149771988
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 1569.9703061542573
-  tps: 1136.9859894747399
+  dps: 1566.2024150493248
+  tps: 1134.7508772517442
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1575.0205137263963
-  tps: 1147.1278346215756
+  dps: 1576.7842382877652
+  tps: 1150.3030720348643
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 1555.845479934921
-  tps: 1121.6553718435646
+  dps: 1553.4951302198783
+  tps: 1120.7828155311988
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1544.718604060267
-  tps: 1117.3132521064542
+  dps: 1542.7439133081164
+  tps: 1112.659614725819
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1630.9355652494808
-  tps: 1195.7955452084434
+  dps: 1629.0018980016737
+  tps: 1192.4774773399402
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1596.335858338584
-  tps: 1170.2770521612883
+  dps: 1597.3665868324463
+  tps: 1167.553375266854
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1563.6805367103918
-  tps: 1139.0946050620435
+  dps: 1561.9870853210346
+  tps: 1135.9719758868987
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1577.630397285391
-  tps: 1150.488657687189
+  dps: 1575.8741782803852
+  tps: 1148.326861742971
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1575.052578038396
-  tps: 1147.1598989335753
+  dps: 1576.6021269725652
+  tps: 1148.1166711484655
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
- value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-ShardofContempt-34472"
- value: {
-  dps: 1599.8341600318474
-  tps: 1168.0427878626347
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-ShatteredSunPendantofAcumen-34678"
- value: {
-  dps: 1591.3997450089655
-  tps: 1159.4502186731715
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-ShatteredSunPendantofMight-34679"
- value: {
-  dps: 1611.7927861397932
-  tps: 1176.0450602215817
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
- value: {
-  dps: 1575.0458445328761
-  tps: 1147.1531654280554
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
- value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-SingingCrystalAxe-31318"
- value: {
-  dps: 1542.2093241729108
-  tps: 1117.7098302768527
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-Slayer'sCrest-23041"
- value: {
-  dps: 1613.2536131225272
-  tps: 1180.8233836532645
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
   dps: 1575.0205137263963
   tps: 1147.1278346215756
  }
 }
 dps_results: {
- key: "TestHunter-AllItems-SpellstrikeInfusion"
+ key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1418.7765615843073
-  tps: 1003.4579182551457
+  dps: 1601.847817485659
+  tps: 1171.3747894305095
  }
 }
 dps_results: {
- key: "TestHunter-AllItems-StormGauntlets-12632"
+ key: "TestHunter-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1537.1906859934004
-  tps: 1107.7582491617982
+  dps: 1586.6784353796068
+  tps: 1155.6407440229325
  }
 }
 dps_results: {
- key: "TestHunter-AllItems-StrengthoftheClefthoof"
+ key: "TestHunter-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1383.1951612927542
-  tps: 973.3830600867633
+  dps: 1605.8617998020197
+  tps: 1174.0315031475338
  }
 }
 dps_results: {
- key: "TestHunter-AllItems-SwiftSkyfireDiamond"
- value: {
-  dps: 1597.5547334325224
-  tps: 1162.5761314759607
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-SwiftStarfireDiamond"
- value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-SwiftWindfireDiamond"
- value: {
-  dps: 1596.4826423057132
-  tps: 1161.6701931400437
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-SyphonoftheNathrezim-32262"
- value: {
-  dps: 1630.3900421589517
-  tps: 1195.3327273242771
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TalonofAl'ar-30448"
- value: {
-  dps: 1597.7760830455754
-  tps: 1169.8834039407552
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TenaciousEarthstormDiamond"
- value: {
-  dps: 1591.1221866716671
-  tps: 1157.1405014604572
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheBladefist-29348"
- value: {
-  dps: 1542.2093241729108
-  tps: 1117.7098302768527
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheDecapitator-28767"
- value: {
-  dps: 1634.020349144478
-  tps: 1200.9254493143242
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheFistsofFury"
- value: {
-  dps: 1587.9893450167165
-  tps: 1157.0392930041598
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheLightningCapacitor-28785"
- value: {
-  dps: 1580.507401731127
-  tps: 1151.2683759745996
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheNightBlade-31331"
- value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
- value: {
-  dps: 1576.7842382877652
-  tps: 1150.3030720348643
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
- value: {
-  dps: 1575.5301632696617
-  tps: 1148.2241654353884
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TheTwinStars"
- value: {
-  dps: 1561.3761203806257
-  tps: 1133.9090023594122
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-ThunderingSkyfireDiamond"
- value: {
-  dps: 1599.2326481946182
-  tps: 1166.6120270158938
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-Timbal'sFocusingCrystal-34470"
- value: {
-  dps: 1587.853545552707
-  tps: 1161.496015889457
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-TsunamiTalisman-30627"
- value: {
-  dps: 1614.8655713838361
-  tps: 1183.4128246940538
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-WarpSlicer-30311"
- value: {
-  dps: 1652.5828623251155
-  tps: 1213.6885523457966
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-WastewalkerArmor"
- value: {
-  dps: 1380.2041705304964
-  tps: 968.7145870448126
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-WindhawkArmor"
- value: {
-  dps: 1480.888514752777
-  tps: 1061.390280389631
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-WorldBreaker-30090"
- value: {
-  dps: 1542.2093241729108
-  tps: 1117.7098302768527
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-WrathofSpellfire"
- value: {
-  dps: 1468.544120201389
-  tps: 1047.4147334569864
- }
-}
-dps_results: {
- key: "TestHunter-AllItems-Xi'ri'sGift-29179"
+ key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
   dps: 1576.5958343513353
   tps: 1148.1103785272355
  }
 }
 dps_results: {
+ key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
+ value: {
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-SingingCrystalAxe-31318"
+ value: {
+  dps: 1540.3697879368324
+  tps: 1114.500465973819
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-Slayer'sCrest-23041"
+ value: {
+  dps: 1611.3540860763394
+  tps: 1177.5426010317894
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-Sorcerer'sAlchemistStone-35749"
+ value: {
+  dps: 1576.7842382877652
+  tps: 1150.3030720348643
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-SpellstrikeInfusion"
+ value: {
+  dps: 1416.8652743692955
+  tps: 1000.1339688532039
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-StormGauntlets-12632"
+ value: {
+  dps: 1540.0532771014136
+  tps: 1111.153691192444
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-StrengthoftheClefthoof"
+ value: {
+  dps: 1393.1174351764878
+  tps: 979.8336382838518
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-SwiftSkyfireDiamond"
+ value: {
+  dps: 1597.0510638750245
+  tps: 1165.1276149771988
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-SwiftStarfireDiamond"
+ value: {
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-SwiftWindfireDiamond"
+ value: {
+  dps: 1595.9777356607347
+  tps: 1164.2191224253975
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-SyphonoftheNathrezim-32262"
+ value: {
+  dps: 1628.457265277658
+  tps: 1192.0157384079446
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TalonofAl'ar-30448"
+ value: {
+  dps: 1599.5122354361445
+  tps: 1173.0310691832447
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TenaciousEarthstormDiamond"
+ value: {
+  dps: 1590.6110945892856
+  tps: 1159.676659666386
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheBladefist-29348"
+ value: {
+  dps: 1540.3697879368324
+  tps: 1114.500465973819
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheDecapitator-28767"
+ value: {
+  dps: 1631.147160666757
+  tps: 1197.7066876339024
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheFistsofFury"
+ value: {
+  dps: 1583.8159488641168
+  tps: 1152.9247966540738
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheLightningCapacitor-28785"
+ value: {
+  dps: 1575.6887886228544
+  tps: 1152.5912190494626
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheNightBlade-31331"
+ value: {
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
+ value: {
+  dps: 1575.0205137263963
+  tps: 1147.1278346215756
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
+ value: {
+  dps: 1575.3296181228975
+  tps: 1148.8334194799156
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TheTwinStars"
+ value: {
+  dps: 1558.445713684148
+  tps: 1131.2872491922067
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-ThunderingSkyfireDiamond"
+ value: {
+  dps: 1596.3348393247068
+  tps: 1164.7899295275759
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-Timbal'sFocusingCrystal-34470"
+ value: {
+  dps: 1579.0706788476316
+  tps: 1151.9600583756471
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-TsunamiTalisman-30627"
+ value: {
+  dps: 1609.6163259086843
+  tps: 1180.9167604072527
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-WarpSlicer-30311"
+ value: {
+  dps: 1649.943436754765
+  tps: 1211.9988225151906
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-WastewalkerArmor"
+ value: {
+  dps: 1380.353373483709
+  tps: 968.299118376994
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-WindhawkArmor"
+ value: {
+  dps: 1480.1984728320065
+  tps: 1062.1967020631746
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-WorldBreaker-30090"
+ value: {
+  dps: 1540.3697879368324
+  tps: 1114.500465973819
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-WrathofSpellfire"
+ value: {
+  dps: 1459.014525812142
+  tps: 1041.293238194008
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-Xi'ri'sGift-29179"
+ value: {
+  dps: 1575.0458445328761
+  tps: 1147.1531654280554
+ }
+}
+dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 1613.3475802005598
-  tps: 1182.0587049330181
+  dps: 1613.5016221246094
+  tps: 1181.9827121513902
  }
 }
 dps_results: {
  key: "TestHunter-SelfDrums-DPS"
  value: {
-  dps: 1600.0962312633253
-  tps: 1167.3165916577175
+  dps: 1605.7420555507813
+  tps: 1171.7847078700702
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1750.0015700539327
-  tps: 1853.7954394753588
+  dps: 1751.2866425082775
+  tps: 1851.750866172187
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1583.886020350239
-  tps: 1173.4893721497217
+  dps: 1581.0821526696773
+  tps: 1171.6121681519237
  }
 }
 dps_results: {
@@ -972,15 +972,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1672.0244121867859
-  tps: 1823.8358882654438
+  dps: 1671.2612498535811
+  tps: 1821.7129089226332
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1570.361629025969
-  tps: 1155.6448755869287
+  dps: 1570.6747828703444
+  tps: 1157.5081957976145
  }
 }
 dps_results: {
@@ -1014,15 +1014,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1954.6067467090988
-  tps: 2183.69083552061
+  dps: 1963.9826817471155
+  tps: 2190.30497856504
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1843.225949472568
-  tps: 1424.9260826541563
+  dps: 1850.0406638479008
+  tps: 1433.738934658494
  }
 }
 dps_results: {
@@ -1056,57 +1056,57 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1757.496001999762
-  tps: 2285.988198431255
+  dps: 1747.7869557746799
+  tps: 2276.2234132594226
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1612.5965551698237
-  tps: 1389.0672301995455
+  dps: 1602.3040050919183
+  tps: 1379.3595821320375
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2037.174492426999
-  tps: 1772.5734332424333
+  dps: 1957.2807982485476
+  tps: 1686.6020080727287
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 686.3228500776786
-  tps: 788.6847783960993
+  dps: 681.0455439072929
+  tps: 782.7883940074047
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 661.7125661809109
-  tps: 557.2069673360209
+  dps: 656.9766253357477
+  tps: 552.3008833073997
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1023.3123533290391
-  tps: 891.238178998343
+  dps: 986.9614469406488
+  tps: 854.9662647395936
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1792.0737820415159
-  tps: 1871.1291964078423
+  dps: 1787.8259788113685
+  tps: 1867.2849341538913
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1616.7519648957252
-  tps: 1183.7622802201267
+  dps: 1614.8414471772714
+  tps: 1180.4722651080574
  }
 }
 dps_results: {
@@ -1140,15 +1140,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1712.0486721630152
-  tps: 1836.2954215982886
+  dps: 1708.8099170365197
+  tps: 1833.03305922202
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1608.346102970329
-  tps: 1169.7737904883925
+  dps: 1603.6884948189495
+  tps: 1166.4935645777778
  }
 }
 dps_results: {
@@ -1182,15 +1182,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2001.8629306503517
-  tps: 2204.3796635594376
+  dps: 2005.274878338705
+  tps: 2207.4793966119173
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1892.8220286580163
-  tps: 1451.887203223392
+  dps: 1889.8842339775376
+  tps: 1446.0462734966163
  }
 }
 dps_results: {
@@ -1224,49 +1224,49 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1786.9841262566197
-  tps: 2301.6079659764127
+  dps: 1779.674783477507
+  tps: 2288.838229257063
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1647.5254703805551
-  tps: 1409.3229836578446
+  dps: 1632.9316724095743
+  tps: 1396.2168514202922
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2079.561672190182
-  tps: 1794.4526413284416
+  dps: 2003.2389245801269
+  tps: 1721.576762545487
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 700.538330569606
-  tps: 793.9184440469057
+  dps: 695.7492211524711
+  tps: 789.0156586811953
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 678.2771562202713
-  tps: 566.2200278794328
+  dps: 672.6809737194702
+  tps: 560.870383754842
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1042.0972849885868
-  tps: 900.2133313821743
+  dps: 1007.5313503168815
+  tps: 869.357902701178
  }
 }
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1541.871640664667
-  tps: 1178.0292030245103
+  dps: 1544.7841245239172
+  tps: 1180.830803708698
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -48,784 +48,784 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1321.119088486837
-  tps: 1330.5177023559181
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AldorRegalia"
  value: {
-  dps: 1250.2763152446394
-  tps: 1263.7987282083639
+  dps: 1252.9351722821411
+  tps: 1266.6512275108923
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1321.119088486837
-  tps: 1330.5177023559181
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1340.255719357559
-  tps: 1348.711930014211
+  dps: 1335.5670158230705
+  tps: 1345.073401844094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1321.8435300112908
-  tps: 1330.508500575303
+  dps: 1321.682111540747
+  tps: 1331.220572037743
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1332.08974096361
-  tps: 1341.0947617838674
+  dps: 1339.2366494590815
+  tps: 1348.272796529497
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1332.08974096361
-  tps: 1341.0947617838674
+  dps: 1339.2366494590815
+  tps: 1348.272796529497
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1393.4090961771979
-  tps: 1401.6123440349793
+  dps: 1390.6210905021817
+  tps: 1399.3330418451274
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1323.1527707526727
-  tps: 1332.5355056504748
+  dps: 1306.7449015785687
+  tps: 1316.9201398007112
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1324.4474055546111
-  tps: 1333.802846387311
+  dps: 1332.0007881979016
+  tps: 1341.3185340682417
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1323.1527707526727
-  tps: 1332.5355056504748
+  dps: 1306.7449015785687
+  tps: 1316.9201398007112
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1318.9317805512067
-  tps: 1328.4290844054767
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1307.781864079491
-  tps: 1342.9623896505454
+  dps: 1304.160023706688
+  tps: 1339.7465353165544
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1321.119088486837
-  tps: 1330.5177023559181
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1322.4193817642338
-  tps: 1331.6425176243129
+  dps: 1323.5801727110772
+  tps: 1332.671228605577
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1320.245583261073
-  tps: 1329.9016870787993
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1372.9099427327753
-  tps: 1380.8112177107369
+  dps: 1369.409398056775
+  tps: 1376.9556057569528
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1366.706640845934
-  tps: 1374.0900825732886
+  dps: 1356.9040240879133
+  tps: 1365.3916516899692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Despair-28573"
  value: {
-  dps: 1178.5964469918326
-  tps: 1192.2950924594609
+  dps: 1184.010705557504
+  tps: 1197.7282345126646
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1324.9587763134107
-  tps: 1334.2210368281317
+  dps: 1331.4339475478141
+  tps: 1340.7474116094768
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1336.5311545870125
-  tps: 1345.9541843815086
+  dps: 1329.7806648508674
+  tps: 1340.0330056933426
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1351.7612267448908
-  tps: 1360.21920493856
+  dps: 1357.5066317613862
+  tps: 1366.0406032697679
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1363.3237629050925
-  tps: 1370.8565398253195
+  dps: 1353.4542004327186
+  tps: 1362.0985407870542
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1350.34734126679
-  tps: 1359.5653798075807
+  dps: 1352.891612123853
+  tps: 1362.4597119551888
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1320.245583261073
-  tps: 1329.9016870787993
+  dps: 1322.6587422648663
+  tps: 1332.3239590291655
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1330.2990727902497
-  tps: 1339.1542804952205
+  dps: 1330.0138507982867
+  tps: 1339.417448205018
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1321.119088486837
-  tps: 1330.5177023559181
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HandofJustice-11815"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartrazor-29962"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1385.7989223325856
-  tps: 1393.3107723549244
+  dps: 1382.0150428977313
+  tps: 1389.169465180054
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1327.2165091366246
-  tps: 1336.4783402735807
+  dps: 1334.7830161199975
+  tps: 1344.0069148387413
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1338.744968444445
-  tps: 1350.3947656776093
+  dps: 1334.1445511582456
+  tps: 1346.5196204348115
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1178.5964469918326
-  tps: 1192.2950924594609
+  dps: 1184.010705557504
+  tps: 1197.7282345126646
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1178.5964469918326
-  tps: 1192.2950924594609
+  dps: 1184.010705557504
+  tps: 1197.7282345126646
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1178.5964469918326
-  tps: 1192.2950924594609
+  dps: 1184.010705557504
+  tps: 1197.7282345126646
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1120.7400161782805
-  tps: 1136.4647728906136
+  dps: 1124.866890651277
+  tps: 1140.667216746515
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1375.09632559388
-  tps: 1382.2286071093392
+  dps: 1365.5094115170373
+  tps: 1373.748099263474
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1326.8827965228222
-  tps: 1335.8718803436145
+  dps: 1326.9735739805076
+  tps: 1335.9791718809865
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1321.119088486837
-  tps: 1330.5177023559181
+  dps: 1326.383160698034
+  tps: 1335.862775809198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1321.7248828350268
-  tps: 1331.501041865698
+  dps: 1319.3783557780032
+  tps: 1329.5274580844853
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1347.2593535056758
-  tps: 1355.8305005171383
+  dps: 1354.9612547129595
+  tps: 1363.4799857129549
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1337.545358397001
-  tps: 1346.52422697374
+  dps: 1343.1852501211283
+  tps: 1351.858554515416
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1321.8435300112908
-  tps: 1330.508500575303
+  dps: 1315.363137425367
+  tps: 1324.9038468911751
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1343.088687380956
-  tps: 1351.5399016921062
+  dps: 1342.3643636002557
+  tps: 1351.3560817182681
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1372.0508117108818
-  tps: 1383.1212114434486
+  dps: 1371.0610219962668
+  tps: 1382.9887431983495
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1369.4382573534242
-  tps: 1376.8010107534794
+  dps: 1358.657329237862
+  tps: 1367.1876917841616
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1321.8435300112908
-  tps: 1330.508500575303
+  dps: 1315.363137425367
+  tps: 1324.9038468911751
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1369.4854500969575
-  tps: 1377.4573966461392
+  dps: 1372.417787925685
+  tps: 1380.4848815712821
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1323.1527707526727
-  tps: 1332.5355056504748
+  dps: 1306.7449015785687
+  tps: 1316.9201398007112
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1360.9963441113498
-  tps: 1368.5414825672485
+  dps: 1350.6723959960773
+  tps: 1359.4326871117694
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1363.2294302064581
-  tps: 1370.813497465904
+  dps: 1363.6802477410806
+  tps: 1371.853894141121
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1328.5628107769217
-  tps: 1337.8341732748127
+  dps: 1325.8523328594392
+  tps: 1334.7789830052113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1390.3321019857506
-  tps: 1402.704541874953
+  dps: 1393.6822449125095
+  tps: 1406.0986141109706
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1242.6908915468553
-  tps: 1254.4437484882737
+  dps: 1241.8539323571913
+  tps: 1253.6446637510924
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1326.1088677038197
-  tps: 1335.4081427190727
+  dps: 1333.6701249511586
+  tps: 1342.931562530542
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 1473.3153781141677
-  tps: 1485.2495587792446
+  dps: 1487.7183385332091
+  tps: 1500.038106316526
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1377.6937531254036
-  tps: 1385.4858328511555
+  dps: 1383.7334547710564
+  tps: 1391.9873058271885
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1367.9847530643558
-  tps: 1376.031951173199
+  dps: 1364.610139307589
+  tps: 1372.3029586911614
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1358.9697882811472
-  tps: 1367.5633917064413
+  dps: 1353.936488628001
+  tps: 1363.2127273035812
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinStars"
  value: {
-  dps: 1398.7898348671847
-  tps: 1406.4018393243086
+  dps: 1393.0130424458323
+  tps: 1401.4478359198692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1319.4630191069868
-  tps: 1328.9869573920269
+  dps: 1326.992777938128
+  tps: 1336.479448681342
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1351.8800464611827
-  tps: 1359.8065656702126
+  dps: 1342.501962117009
+  tps: 1351.5100620647386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirisfalRegalia"
  value: {
-  dps: 1479.897647319035
-  tps: 1487.642660858554
+  dps: 1485.4097177158112
+  tps: 1493.2844766622604
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1326.9650151968253
-  tps: 1335.7438870526125
+  dps: 1317.811040809663
+  tps: 1327.6448514124359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofSpellfire"
  value: {
-  dps: 1317.0187001274242
-  tps: 1326.291500993334
+  dps: 1312.6127834632146
+  tps: 1322.5717735285098
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1354.9377791327488
-  tps: 1362.8876545377848
+  dps: 1353.7590404982882
+  tps: 1362.3938578399145
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 1340.5997027527465
-  tps: 1349.2014616693523
+  dps: 1336.4052181905959
+  tps: 1345.4028511065405
  }
 }
 dps_results: {
  key: "TestArcane-SelfDrums-DPS"
  value: {
-  dps: 1337.5254499626178
-  tps: 1347.1642107431287
+  dps: 1333.5231731851873
+  tps: 1343.173147302441
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6911.809701236671
-  tps: 7737.726600611444
+  dps: 6925.204492999349
+  tps: 7751.248163205537
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 481.76112238451884
-  tps: 520.3532879401374
+  dps: 484.1369227405355
+  tps: 522.7087056223669
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 872.556184091676
-  tps: 936.8511050203487
+  dps: 856.5482645870738
+  tps: 916.0320673309565
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2608.0540671927315
-  tps: 2743.807985848876
+  dps: 2615.7982884127837
+  tps: 2751.397322644528
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 150.44678845059397
-  tps: 156.83360268158202
+  dps: 151.05402674911525
+  tps: 157.42869621413288
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 510.96773347839064
-  tps: 547.7271288088228
+  dps: 491.98823465868117
+  tps: 529.1272199655074
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1351.9588166215854
-  tps: 2320.530016979893
+  dps: 1359.1904736626414
+  tps: 2329.8378118262767
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2174.846576561095
-  tps: 2242.2745521494517
+  dps: 2146.456501052726
+  tps: 2211.923424658338
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 450.960339975718
-  tps: 627.8000904993336
+  dps: 458.13881605097134
+  tps: 634.6092151536752
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 450.960339975718
-  tps: 449.28084049933415
+  dps: 458.13881605097134
+  tps: 456.0899651536757
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1164.5513149294827
-  tps: 1184.8004403480722
+  dps: 1164.050860308274
+  tps: 1184.505479121267
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1351.9588166215854
-  tps: 1360.2888858491417
+  dps: 1359.1904736626414
+  tps: 1367.5512882943074
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -48,784 +48,784 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AldorRegalia"
  value: {
-  dps: 1252.9351722821411
-  tps: 1266.6512275108923
+  dps: 1248.7565574104676
+  tps: 1262.0292613632698
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1335.5670158230705
-  tps: 1345.073401844094
+  dps: 1349.9009868709459
+  tps: 1357.5639897351084
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1321.682111540747
-  tps: 1331.220572037743
+  dps: 1327.1495351250865
+  tps: 1336.0178714566705
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1339.2366494590815
-  tps: 1348.272796529497
+  dps: 1332.6779780240624
+  tps: 1341.6712341031116
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1339.2366494590815
-  tps: 1348.272796529497
+  dps: 1332.6779780240624
+  tps: 1341.6712341031116
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1390.6210905021817
-  tps: 1399.3330418451274
+  dps: 1390.578111513054
+  tps: 1398.9140812762012
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1306.7449015785687
-  tps: 1316.9201398007112
+  dps: 1324.659612718402
+  tps: 1333.9044419100028
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1332.0007881979016
-  tps: 1341.3185340682417
+  dps: 1325.0230086624238
+  tps: 1334.3669374329672
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1306.7449015785687
-  tps: 1316.9201398007112
+  dps: 1324.659612718402
+  tps: 1333.9044419100028
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1304.160023706688
-  tps: 1339.7465353165544
+  dps: 1308.322778784538
+  tps: 1343.5033043555925
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1323.5801727110772
-  tps: 1332.671228605577
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1369.409398056775
-  tps: 1376.9556057569528
+  dps: 1370.7139293510484
+  tps: 1377.995999778896
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1356.9040240879133
-  tps: 1365.3916516899692
+  dps: 1363.2440000890458
+  tps: 1371.017428771425
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Despair-28573"
  value: {
-  dps: 1184.010705557504
-  tps: 1197.7282345126646
+  dps: 1179.133263132145
+  tps: 1192.8211722769674
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1331.4339475478141
-  tps: 1340.7474116094768
+  dps: 1325.5343794212233
+  tps: 1334.7851278737878
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1329.7806648508674
-  tps: 1340.0330056933426
+  dps: 1337.0407972995122
+  tps: 1346.453634239759
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1357.5066317613862
-  tps: 1366.0406032697679
+  dps: 1353.0945891962695
+  tps: 1361.6656963799003
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1353.4542004327186
-  tps: 1362.0985407870542
+  dps: 1359.2697970404924
+  tps: 1367.1879640574834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1352.891612123853
-  tps: 1362.4597119551888
+  dps: 1352.2239952050152
+  tps: 1361.4358344184
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1322.6587422648663
-  tps: 1332.3239590291655
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1330.0138507982867
-  tps: 1339.417448205018
+  dps: 1320.315194875902
+  tps: 1329.902111931806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HandofJustice-11815"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartrazor-29962"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1382.0150428977313
-  tps: 1389.169465180054
+  dps: 1383.6358462951719
+  tps: 1390.519950506232
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1334.7830161199975
-  tps: 1344.0069148387413
+  dps: 1327.7921122444372
+  tps: 1337.0424313192366
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1334.1445511582456
-  tps: 1346.5196204348115
+  dps: 1339.2653226741324
+  tps: 1350.9047128227032
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1184.010705557504
-  tps: 1197.7282345126646
+  dps: 1179.133263132145
+  tps: 1192.8211722769674
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1184.010705557504
-  tps: 1197.7282345126646
+  dps: 1179.133263132145
+  tps: 1192.8211722769674
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1184.010705557504
-  tps: 1197.7282345126646
+  dps: 1179.133263132145
+  tps: 1192.8211722769674
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1124.866890651277
-  tps: 1140.667216746515
+  dps: 1130.547268910368
+  tps: 1145.756225784213
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1365.5094115170373
-  tps: 1373.748099263474
+  dps: 1371.7380006860624
+  tps: 1379.2568549923762
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1326.9735739805076
-  tps: 1335.9791718809865
+  dps: 1332.8586061540504
+  tps: 1342.0588179097626
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1326.383160698034
-  tps: 1335.862775809198
+  dps: 1322.3784104488168
+  tps: 1331.8825512978094
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1319.3783557780032
-  tps: 1329.5274580844853
+  dps: 1322.2925932459643
+  tps: 1332.0573980684164
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1354.9612547129595
-  tps: 1363.4799857129549
+  dps: 1347.8475905661285
+  tps: 1356.4069728363822
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1343.1852501211283
-  tps: 1351.858554515416
+  dps: 1338.1233405891576
+  tps: 1347.0906495220531
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1315.363137425367
-  tps: 1324.9038468911751
+  dps: 1321.7313564444216
+  tps: 1331.2711444729791
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1342.3643636002557
-  tps: 1351.3560817182681
+  dps: 1332.7467692392206
+  tps: 1341.964249186434
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1371.0610219962668
-  tps: 1382.9887431983495
+  dps: 1372.5837096909602
+  tps: 1383.6434514639252
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1358.657329237862
-  tps: 1367.1876917841616
+  dps: 1365.5145911871991
+  tps: 1373.2705392943521
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1315.363137425367
-  tps: 1324.9038468911751
+  dps: 1321.7313564444216
+  tps: 1331.2711444729791
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1372.417787925685
-  tps: 1380.4848815712821
+  dps: 1370.0232866502233
+  tps: 1377.9844764683394
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1306.7449015785687
-  tps: 1316.9201398007112
+  dps: 1324.659612718402
+  tps: 1333.9044419100028
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1350.6723959960773
-  tps: 1359.4326871117694
+  dps: 1356.7249756613821
+  tps: 1364.691240450973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1363.6802477410806
-  tps: 1371.853894141121
+  dps: 1368.1784395555942
+  tps: 1375.8658391830968
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1325.8523328594392
-  tps: 1334.7789830052113
+  dps: 1326.2806554794508
+  tps: 1334.9611827396502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1393.6822449125095
-  tps: 1406.0986141109706
+  dps: 1390.9186928551408
+  tps: 1403.2794009269562
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1241.8539323571913
-  tps: 1253.6446637510924
+  dps: 1243.2191384734178
+  tps: 1254.961430476305
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1333.6701249511586
-  tps: 1342.931562530542
+  dps: 1326.684470811632
+  tps: 1335.9722337647293
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 1487.7183385332091
-  tps: 1500.038106316526
+  dps: 1473.8706857157306
+  tps: 1485.7937602287757
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1383.7334547710564
-  tps: 1391.9873058271885
+  dps: 1378.213763459013
+  tps: 1385.9954429780926
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1364.610139307589
-  tps: 1372.3029586911614
+  dps: 1365.773555366848
+  tps: 1373.2049100977101
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1353.936488628001
-  tps: 1363.2127273035812
+  dps: 1364.5092297521855
+  tps: 1372.8965466701204
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinStars"
  value: {
-  dps: 1393.0130424458323
-  tps: 1401.4478359198692
+  dps: 1396.3580698635687
+  tps: 1404.3791769579684
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1326.992777938128
-  tps: 1336.479448681342
+  dps: 1320.0386222147988
+  tps: 1329.5510484376834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1342.501962117009
-  tps: 1351.5100620647386
+  dps: 1348.5967428969386
+  tps: 1356.9009317721618
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirisfalRegalia"
  value: {
-  dps: 1485.4097177158112
-  tps: 1493.2844766622604
+  dps: 1477.5694823890908
+  tps: 1485.5334162255322
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1317.811040809663
-  tps: 1327.6448514124359
+  dps: 1323.7622223427566
+  tps: 1332.9092092919318
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofSpellfire"
  value: {
-  dps: 1312.6127834632146
-  tps: 1322.5717735285098
+  dps: 1315.479169719733
+  tps: 1325.2744256235144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1353.7590404982882
-  tps: 1362.3938578399145
+  dps: 1344.8256691781637
+  tps: 1353.635837290303
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 1336.4052181905959
-  tps: 1345.4028511065405
+  dps: 1340.9787316112645
+  tps: 1349.5924836289953
  }
 }
 dps_results: {
  key: "TestArcane-SelfDrums-DPS"
  value: {
-  dps: 1333.5231731851873
-  tps: 1343.173147302441
+  dps: 1339.026671399646
+  tps: 1348.5500246591255
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6925.204492999349
-  tps: 7751.248163205537
+  dps: 6910.544849214683
+  tps: 7736.487045629898
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 484.1369227405355
-  tps: 522.7087056223669
+  dps: 482.61213650103
+  tps: 521.1950340059612
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 856.5482645870738
-  tps: 916.0320673309565
+  dps: 875.1633955633166
+  tps: 939.4061722625563
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2615.7982884127837
-  tps: 2751.397322644528
+  dps: 2608.611504648832
+  tps: 2744.354274555855
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 151.05402674911525
-  tps: 157.42869621413288
+  dps: 151.04372122604036
+  tps: 157.4185968015195
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 491.98823465868117
-  tps: 529.1272199655074
+  dps: 513.8390506071108
+  tps: 550.5410195949684
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1359.1904736626414
-  tps: 2329.8378118262767
+  dps: 1352.547053682038
+  tps: 2321.106489299137
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2146.456501052726
-  tps: 2211.923424658338
+  dps: 2223.2918494587548
+  tps: 2291.76949129011
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 458.13881605097134
-  tps: 634.6092151536752
+  dps: 454.5921190633387
+  tps: 631.2677978903723
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 458.13881605097134
-  tps: 456.0899651536757
+  dps: 454.5921190633387
+  tps: 452.748547890373
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll10-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1164.050860308274
-  tps: 1184.505479121267
+  dps: 1167.3069380745721
+  tps: 1187.5009510302602
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1359.1904736626414
-  tps: 1367.5512882943074
+  dps: 1352.547053682038
+  tps: 1360.865358168386
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -83,8 +83,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -118,8 +118,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -132,8 +132,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -160,8 +160,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -216,15 +216,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1322.4193817642338
+  tps: 1331.6425176243129
  }
 }
 dps_results: {
@@ -237,8 +237,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1365.7355229379682
-  tps: 1373.6425631028364
+  dps: 1372.9099427327753
+  tps: 1380.8112177107369
  }
 }
 dps_results: {
@@ -293,8 +293,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -328,22 +328,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1352.1450162487247
-  tps: 1361.5919372075589
+  dps: 1350.34734126679
+  tps: 1359.5653798075807
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1320.245583261073
+  tps: 1329.9016870787993
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1323.7859740086778
-  tps: 1333.058672230366
+  dps: 1330.2990727902497
+  tps: 1339.1542804952205
  }
 }
 dps_results: {
@@ -370,8 +370,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1378.5855768435833
-  tps: 1386.1039883565652
+  dps: 1385.7989223325856
+  tps: 1393.3107723549244
  }
 }
 dps_results: {
@@ -384,8 +384,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -412,8 +412,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -461,8 +461,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1328.383626379195
-  tps: 1337.3498808831878
+  dps: 1326.8827965228222
+  tps: 1335.8718803436145
  }
 }
 dps_results: {
@@ -524,8 +524,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1336.2406926689835
-  tps: 1345.108398398399
+  dps: 1343.088687380956
+  tps: 1351.5399016921062
  }
 }
 dps_results: {
@@ -580,15 +580,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1352.7211915304163
-  tps: 1361.3643869715138
+  dps: 1363.2294302064581
+  tps: 1370.813497465904
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1321.5376964577652
-  tps: 1330.8125438968939
+  dps: 1328.5628107769217
+  tps: 1337.8341732748127
  }
 }
 dps_results: {
@@ -657,15 +657,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1360.8237384262577
-  tps: 1368.8763535108935
+  dps: 1367.9847530643558
+  tps: 1376.031951173199
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1353.7295389459923
-  tps: 1362.0567586876964
+  dps: 1358.9697882811472
+  tps: 1367.5633917064413
  }
 }
 dps_results: {
@@ -720,8 +720,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1347.1136225960581
-  tps: 1355.6142274802742
+  dps: 1354.9377791327488
+  tps: 1362.8876545377848
  }
 }
 dps_results: {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -398,8 +398,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1592.9824099190937
-  tps: 1344.5841821600088
+  dps: 1593.3229297962278
+  tps: 1345.0772290617329
  }
 }
 dps_results: {
@@ -804,15 +804,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll10-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 483.40553721881895
-  tps: 642.7571222540029
+  dps: 482.6422166606228
+  tps: 641.9674605666049
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll10-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 483.40553721881895
-  tps: 419.3598722540035
+  dps: 482.6422166606228
+  tps: 418.6946605666055
  }
 }
 dps_results: {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -83,8 +83,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -118,8 +118,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -132,8 +132,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -160,8 +160,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -216,15 +216,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -237,8 +237,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1602.3083391411274
-  tps: 1341.7409452827246
+  dps: 1597.6906079267344
+  tps: 1338.3051485124752
  }
 }
 dps_results: {
@@ -293,8 +293,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -328,22 +328,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1586.4561144847473
-  tps: 1328.224231871612
+  dps: 1588.9006163507418
+  tps: 1329.7884297848266
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1546.8884402346257
-  tps: 1296.296895340145
+  dps: 1541.2334690068776
+  tps: 1292.2965037868441
  }
 }
 dps_results: {
@@ -370,8 +370,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1619.0682260496574
-  tps: 1355.4729015777048
+  dps: 1614.6595398310656
+  tps: 1352.135594313836
  }
 }
 dps_results: {
@@ -384,8 +384,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -412,8 +412,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -461,8 +461,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1529.3601332774226
-  tps: 1284.176545900638
+  dps: 1538.9841034171309
+  tps: 1291.5777130206227
  }
 }
 dps_results: {
@@ -524,8 +524,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1563.0585201155575
-  tps: 1309.7260955341171
+  dps: 1557.466771210612
+  tps: 1305.6935841225416
  }
 }
 dps_results: {
@@ -580,15 +580,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1572.4237788765374
-  tps: 1317.901102230215
+  dps: 1570.439310963577
+  tps: 1316.461538399004
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1544.948025319024
-  tps: 1294.8177878332872
+  dps: 1539.7942944435317
+  tps: 1291.1389708073705
  }
 }
 dps_results: {
@@ -657,15 +657,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1595.8747898628158
-  tps: 1336.4626300973127
+  dps: 1591.15966298965
+  tps: 1332.9800373621124
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1577.0389250234684
-  tps: 1323.4160942991073
+  dps: 1582.5518715079609
+  tps: 1326.3555573489762
  }
 }
 dps_results: {
@@ -720,8 +720,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1589.1353794529207
-  tps: 1323.3634682771662
+  dps: 1576.9892036097187
+  tps: 1316.0315336231804
  }
 }
 dps_results: {

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -48,784 +48,784 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AldorRegalia"
  value: {
-  dps: 1416.5184309543533
-  tps: 1183.5688413139983
+  dps: 1472.6472875315892
+  tps: 1196.080365552612
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1562.8775927670765
-  tps: 1316.6989166767953
+  dps: 1622.5137348929784
+  tps: 1331.5371578357383
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850415
+  dps: 1558.4886063648748
+  tps: 1271.6058135729081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1541.0907523081373
-  tps: 1295.6995059563933
+  dps: 1600.312056687058
+  tps: 1308.6146057951403
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1541.0907523081373
-  tps: 1295.6995059563933
+  dps: 1600.312056687058
+  tps: 1308.6146057951403
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1599.1878345681712
-  tps: 1344.9147481549837
+  dps: 1659.1895361049903
+  tps: 1358.1525671181842
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1542.9062228283365
-  tps: 1297.1815573724552
+  dps: 1603.0793821972156
+  tps: 1310.5331827954005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1533.5631209656483
-  tps: 1287.7276786909292
+  dps: 1595.3947262330091
+  tps: 1302.1240175708515
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1542.9062228283365
-  tps: 1297.1815573724552
+  dps: 1603.0793821972156
+  tps: 1310.5331827954005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1541.4836439083822
-  tps: 1322.1468022989925
+  dps: 1600.4589987602342
+  tps: 1334.7235752779127
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1513.389572277007
-  tps: 1261.485791846319
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1611.0327465899225
-  tps: 1319.9192155997378
+  dps: 1623.9621509374113
+  tps: 1326.1200117612523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1556.5186869533488
-  tps: 1305.8363431824364
+  dps: 1624.4922540785315
+  tps: 1326.7197071702049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Despair-28573"
  value: {
-  dps: 1376.8652599020234
-  tps: 1156.326981118537
+  dps: 1434.0342359159847
+  tps: 1169.2164709743565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1532.4204539095915
-  tps: 1286.9923942518624
+  dps: 1593.5798473750908
+  tps: 1300.918159563861
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1539.221659325664
-  tps: 1292.38762430804
+  dps: 1601.3297454091062
+  tps: 1307.1077645750458
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1535.5398726732146
-  tps: 1287.3054540911571
+  dps: 1601.8115506773488
+  tps: 1307.3008589565068
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1543.815474231927
-  tps: 1294.9623163305366
+  dps: 1611.0765225214234
+  tps: 1315.416117479078
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1568.2298812987333
-  tps: 1282.6373873676673
+  dps: 1574.7237732240467
+  tps: 1284.668756708193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1495.1805035773502
-  tps: 1255.0307826167627
+  dps: 1558.674691224585
+  tps: 1271.9254066265808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HandofJustice-11815"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartrazor-29962"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1629.6459960078957
-  tps: 1335.3386609873287
+  dps: 1642.846467900627
+  tps: 1341.791825851019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1537.737532302898
-  tps: 1291.2580939879533
+  dps: 1599.6921242277585
+  tps: 1305.6949530768354
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1528.1676681503536
-  tps: 1283.831491499316
+  dps: 1589.7804594723618
+  tps: 1298.7496708352978
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1376.8652599020234
-  tps: 1156.326981118537
+  dps: 1434.0342359159847
+  tps: 1169.2164709743565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1376.8652599020234
-  tps: 1156.326981118537
+  dps: 1434.0342359159847
+  tps: 1169.2164709743565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1376.8652599020234
-  tps: 1156.326981118537
+  dps: 1434.0342359159847
+  tps: 1169.2164709743565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1384.996383977391
-  tps: 1161.700268473276
+  dps: 1438.1019179737145
+  tps: 1170.3633971296656
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1560.5931275058686
-  tps: 1311.6431801351778
+  dps: 1627.5470539891953
+  tps: 1332.6731455022327
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1581.6738843915082
-  tps: 1294.225344215378
+  dps: 1594.7610665150894
+  tps: 1304.2746979446556
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1556.0270256356516
-  tps: 1310.9087495298504
+  dps: 1623.70909809461
+  tps: 1330.3182312603508
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1565.3737192171861
-  tps: 1316.057174253161
+  dps: 1627.5178377374825
+  tps: 1330.8514670634922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1579.5575240335154
-  tps: 1327.3501342965155
+  dps: 1640.2591975418054
+  tps: 1341.263004886497
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1502.143059231186
-  tps: 1263.0934691938983
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1514.3582556373506
-  tps: 1270.9718011871632
+  dps: 1580.8425484772856
+  tps: 1290.6687291755472
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1523.6099738055336
-  tps: 1277.9605846123159
+  dps: 1592.9787662480946
+  tps: 1301.4349813280937
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1542.7930660540944
-  tps: 1294.5001127907149
+  dps: 1612.0862387038214
+  tps: 1317.0617086193079
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1502.143059231186
-  tps: 1263.0934691938983
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1595.213331683347
-  tps: 1341.1012876465682
+  dps: 1657.1342808057657
+  tps: 1355.4320052266514
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1542.9062228283365
-  tps: 1297.1815573724552
+  dps: 1603.0793821972156
+  tps: 1310.5331827954005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1531.7419060852085
-  tps: 1284.8449765449816
+  dps: 1599.1048362735692
+  tps: 1305.909167833315
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1594.5909492383828
-  tps: 1340.5545425590174
+  dps: 1658.4879254393177
+  tps: 1359.2761306797513
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1546.3949983505363
-  tps: 1266.308411637872
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1545.1859123951554
-  tps: 1296.8650838031301
+  dps: 1612.7838395887718
+  tps: 1318.2762776302593
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1483.083419651036
-  tps: 1245.1413760975756
+  dps: 1542.6416941557059
+  tps: 1258.4199111333066
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1536.0677677679985
-  tps: 1289.8459278691437
+  dps: 1597.973165029859
+  tps: 1304.2665788744423
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TempestRegalia"
  value: {
-  dps: 1703.8596700208652
-  tps: 1430.451996228798
+  dps: 1761.3342654211156
+  tps: 1443.2026516148233
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1538.0866616517876
-  tps: 1298.843088247367
+  dps: 1607.2767871960834
+  tps: 1321.8824242305036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1603.9770510312571
-  tps: 1314.0803161107426
+  dps: 1616.7936163306354
+  tps: 1320.1729483631907
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1629.3192023401286
-  tps: 1336.583342945083
+  dps: 1639.8081727656108
+  tps: 1341.42218726584
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 1577.0080762714001
-  tps: 1324.7150791086724
+  dps: 1632.7135638265047
+  tps: 1333.7723408004326
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1526.0491805585982
-  tps: 1281.3729311562863
+  dps: 1587.659409842459
+  tps: 1295.6963336600804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1529.345951690277
-  tps: 1282.7437051745235
+  dps: 1596.4090867117234
+  tps: 1303.2932445258718
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirisfalRegalia"
  value: {
-  dps: 1513.3392868552132
-  tps: 1264.5456648550787
+  dps: 1567.7576248951837
+  tps: 1273.2071194838538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1492.6639374263486
-  tps: 1251.7296344850413
+  dps: 1558.4886063648748
+  tps: 1271.7635946975818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 1527.324133976976
-  tps: 1284.3492219956197
+  dps: 1585.5471290394592
+  tps: 1296.2692017966353
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1529.677106033501
-  tps: 1284.4830272365673
+  dps: 1595.5961198720165
+  tps: 1303.6813791456996
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 1560.6963181751746
-  tps: 1314.479472175158
+  dps: 1621.2001376396588
+  tps: 1327.9173984267193
  }
 }
 dps_results: {
  key: "TestFrost-SelfDrums-DPS"
  value: {
-  dps: 1546.7781777578657
-  tps: 1299.057724227253
+  dps: 1603.804310538413
+  tps: 1308.6096956367285
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3307.942703447727
-  tps: 3503.347868243736
+  dps: 3292.921326209827
+  tps: 3450.322350736189
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 455.1673781793907
-  tps: 349.7926975001263
+  dps: 492.9104461464902
+  tps: 343.54529688116594
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 826.2033054877356
-  tps: 539.380207489251
+  dps: 888.3881963688644
+  tps: 561.8884947313804
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1577.5417252860902
+  dps: 1610.678914569473
   tps: 1530.7983999999997
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 165.61368438872097
-  tps: 125.2717743201934
+  dps: 198.88018929266423
+  tps: 125.41502820113548
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 469.3192224123067
-  tps: 309.62226479740167
+  dps: 522.572053643577
+  tps: 319.4645672012952
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1571.201760674808
-  tps: 1850.238970548928
+  dps: 1633.1517172686365
+  tps: 1874.3980774039103
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2091.6641120723007
-  tps: 1626.6436627527685
+  dps: 2215.8869037819777
+  tps: 1684.8892895826223
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 657.5981589542894
-  tps: 685.9363420236108
+  dps: 653.7331872549844
+  tps: 682.4288840777059
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 657.5981589542894
-  tps: 525.8423420236114
+  dps: 653.7331872549844
+  tps: 522.3348840777062
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1130.7010389504096
-  tps: 845.4052844152543
+  dps: 1194.6703342484961
+  tps: 856.9907209178465
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1571.201760674808
-  tps: 1321.1975068187833
+  dps: 1633.1517172686365
+  tps: 1335.820548809969
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -48,784 +48,784 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1558.6468147359153
-  tps: 1272.2241363416556
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AldorRegalia"
  value: {
-  dps: 1472.6472875315892
-  tps: 1196.080365552612
+  dps: 1416.5184309543533
+  tps: 1183.5688413139983
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1622.5137348929784
-  tps: 1331.5371578357383
+  dps: 1562.8775927670765
+  tps: 1316.6989166767953
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.6058135729081
+  dps: 1492.6639374263486
+  tps: 1251.7296344850415
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1600.312056687058
-  tps: 1308.6146057951403
+  dps: 1541.0907523081373
+  tps: 1295.6995059563933
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1600.312056687058
-  tps: 1308.6146057951403
+  dps: 1541.0907523081373
+  tps: 1295.6995059563933
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1659.1895361049903
-  tps: 1358.1525671181842
+  dps: 1599.1878345681712
+  tps: 1344.9147481549837
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1557.18774081468
-  tps: 1271.2424164026284
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1603.0793821972156
-  tps: 1310.5331827954005
+  dps: 1542.9062228283365
+  tps: 1297.1815573724552
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1595.3947262330091
-  tps: 1302.1240175708515
+  dps: 1533.5631209656483
+  tps: 1287.7276786909292
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1603.0793821972156
-  tps: 1310.5331827954005
+  dps: 1542.9062228283365
+  tps: 1297.1815573724552
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1600.4589987602342
-  tps: 1334.7235752779127
+  dps: 1541.4836439083822
+  tps: 1322.1468022989925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1558.6468147359153
-  tps: 1272.2241363416556
+  dps: 1513.389572277007
+  tps: 1261.485791846319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1623.9621509374113
-  tps: 1326.1200117612523
+  dps: 1611.0327465899225
+  tps: 1319.9192155997378
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1624.4922540785315
-  tps: 1326.7197071702049
+  dps: 1556.5186869533488
+  tps: 1305.8363431824364
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Despair-28573"
  value: {
-  dps: 1434.0342359159847
-  tps: 1169.2164709743565
+  dps: 1376.8652599020234
+  tps: 1156.326981118537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1593.5798473750908
-  tps: 1300.918159563861
+  dps: 1532.4204539095915
+  tps: 1286.9923942518624
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1601.3297454091062
-  tps: 1307.1077645750458
+  dps: 1539.221659325664
+  tps: 1292.38762430804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1601.8115506773488
-  tps: 1307.3008589565068
+  dps: 1535.5398726732146
+  tps: 1287.3054540911571
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1611.0765225214234
-  tps: 1315.416117479078
+  dps: 1543.815474231927
+  tps: 1294.9623163305366
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1574.2790223350717
-  tps: 1284.7587484086378
+  dps: 1568.2298812987333
+  tps: 1282.6373873676673
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1558.82584085796
-  tps: 1272.236583413117
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1557.4827276039612
-  tps: 1271.3544400457813
+  dps: 1495.1805035773502
+  tps: 1255.0307826167627
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HandofJustice-11815"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartrazor-29962"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1643.4363697495
-  tps: 1342.0382122968904
+  dps: 1629.6459960078957
+  tps: 1335.3386609873287
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1599.6921242277585
-  tps: 1305.6949530768354
+  dps: 1537.737532302898
+  tps: 1291.2580939879533
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1589.7804594723618
-  tps: 1298.7496708352978
+  dps: 1528.1676681503536
+  tps: 1283.831491499316
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1434.0342359159847
-  tps: 1169.2164709743565
+  dps: 1376.8652599020234
+  tps: 1156.326981118537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1557.18774081468
-  tps: 1271.2424164026284
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1434.0342359159847
-  tps: 1169.2164709743565
+  dps: 1376.8652599020234
+  tps: 1156.326981118537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1434.0342359159847
-  tps: 1169.2164709743565
+  dps: 1376.8652599020234
+  tps: 1156.326981118537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1438.1019179737145
-  tps: 1170.3633971296656
+  dps: 1384.996383977391
+  tps: 1161.700268473276
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1627.5470539891953
-  tps: 1332.6731455022327
+  dps: 1560.5931275058686
+  tps: 1311.6431801351778
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1592.9197940702943
-  tps: 1302.418088271209
+  dps: 1581.6738843915082
+  tps: 1294.225344215378
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1623.70909809461
-  tps: 1330.3182312603508
+  dps: 1556.0270256356516
+  tps: 1310.9087495298504
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1627.5178377374825
-  tps: 1330.8514670634922
+  dps: 1565.3737192171861
+  tps: 1316.057174253161
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1640.2591975418054
-  tps: 1341.263004886497
+  dps: 1579.5575240335154
+  tps: 1327.3501342965155
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1502.143059231186
+  tps: 1263.0934691938983
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1582.1813078949606
-  tps: 1292.3335940520528
+  dps: 1514.3582556373506
+  tps: 1270.9718011871632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1592.9787662480946
-  tps: 1301.4349813280937
+  dps: 1523.6099738055336
+  tps: 1277.9605846123159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1612.0862387038214
-  tps: 1317.0617086193079
+  dps: 1542.7930660540944
+  tps: 1294.5001127907149
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1502.143059231186
+  tps: 1263.0934691938983
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1657.1342808057657
-  tps: 1355.4320052266514
+  dps: 1595.213331683347
+  tps: 1341.1012876465682
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1603.0793821972156
-  tps: 1310.5331827954005
+  dps: 1542.9062228283365
+  tps: 1297.1815573724552
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1599.1048362735692
-  tps: 1305.909167833315
+  dps: 1531.7419060852085
+  tps: 1284.8449765449816
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1663.1756039132172
-  tps: 1363.114702165916
+  dps: 1594.5909492383828
+  tps: 1340.5545425590174
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1556.8558423188906
-  tps: 1271.0816322134744
+  dps: 1546.3949983505363
+  tps: 1266.308411637872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1612.7838395887718
-  tps: 1318.2762776302593
+  dps: 1545.1859123951554
+  tps: 1296.8650838031301
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1542.6416941557059
-  tps: 1258.4199111333066
+  dps: 1483.083419651036
+  tps: 1245.1413760975756
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1597.973165029859
-  tps: 1304.2665788744423
+  dps: 1536.0677677679985
+  tps: 1289.8459278691437
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TempestRegalia"
  value: {
-  dps: 1761.3342654211156
-  tps: 1443.2026516148233
+  dps: 1703.8596700208652
+  tps: 1430.451996228798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1607.2767871960834
-  tps: 1321.8824242305036
+  dps: 1538.0866616517876
+  tps: 1298.843088247367
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1616.5302672909609
-  tps: 1320.062954414141
+  dps: 1603.9770510312571
+  tps: 1314.0803161107426
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1635.4111924931879
-  tps: 1337.4724296589309
+  dps: 1629.3192023401286
+  tps: 1336.583342945083
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 1632.7135638265047
-  tps: 1333.7723408004326
+  dps: 1577.0080762714001
+  tps: 1324.7150791086724
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1587.659409842459
-  tps: 1295.6963336600804
+  dps: 1526.0491805585982
+  tps: 1281.3729311562863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1596.4090867117234
-  tps: 1303.2932445258718
+  dps: 1529.345951690277
+  tps: 1282.7437051745235
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirisfalRegalia"
  value: {
-  dps: 1567.7576248951837
-  tps: 1273.2071194838538
+  dps: 1513.3392868552132
+  tps: 1264.5456648550787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1558.4886063648748
-  tps: 1271.7635946975818
+  dps: 1492.6639374263486
+  tps: 1251.7296344850413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 1585.5471290394592
-  tps: 1296.2692017966353
+  dps: 1527.324133976976
+  tps: 1284.3492219956197
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1596.9371554712914
-  tps: 1305.348251614376
+  dps: 1529.677106033501
+  tps: 1284.4830272365673
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 1621.2001376396588
-  tps: 1327.9173984267193
+  dps: 1560.6963181751746
+  tps: 1314.479472175158
  }
 }
 dps_results: {
  key: "TestFrost-SelfDrums-DPS"
  value: {
-  dps: 1603.804310538413
-  tps: 1308.6096956367285
+  dps: 1546.7781777578657
+  tps: 1299.057724227253
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3292.921326209827
-  tps: 3450.322350736189
+  dps: 3307.942703447727
+  tps: 3503.347868243736
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 492.9104461464902
-  tps: 343.54529688116594
+  dps: 455.1673781793907
+  tps: 349.7926975001263
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 888.3881963688644
-  tps: 561.8884947313804
+  dps: 826.2033054877356
+  tps: 539.380207489251
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1610.678914569473
+  dps: 1577.5417252860902
   tps: 1530.7983999999997
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 198.88018929266423
-  tps: 125.41502820113548
+  dps: 165.61368438872097
+  tps: 125.2717743201934
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 522.572053643577
-  tps: 319.4645672012952
+  dps: 469.3192224123067
+  tps: 309.62226479740167
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1633.1517172686365
-  tps: 1874.3980774039103
+  dps: 1571.201760674808
+  tps: 1850.238970548928
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2215.8869037819777
-  tps: 1684.8892895826223
+  dps: 2091.6641120723007
+  tps: 1626.6436627527685
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 653.7331872549844
-  tps: 682.4288840777059
+  dps: 657.5981589542894
+  tps: 685.9363420236108
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 653.7331872549844
-  tps: 522.3348840777062
+  dps: 657.5981589542894
+  tps: 525.8423420236114
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll10-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1194.6703342484961
-  tps: 856.9907209178465
+  dps: 1130.7010389504096
+  tps: 845.4052844152543
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1633.1517172686365
-  tps: 1335.820548809969
+  dps: 1571.201760674808
+  tps: 1321.1975068187833
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1559.1045729565992
-  tps: 1273.142746266691
+  dps: 1558.6468147359153
+  tps: 1272.2241363416556
  }
 }
 dps_results: {
@@ -83,8 +83,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
@@ -118,8 +118,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
@@ -132,8 +132,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1557.670400215955
-  tps: 1272.1745011389703
+  dps: 1557.18774081468
+  tps: 1271.2424164026284
  }
 }
 dps_results: {
@@ -160,8 +160,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
@@ -216,15 +216,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1558.9664571630194
-  tps: 1273.1551933381527
+  dps: 1558.6468147359153
+  tps: 1272.2241363416556
  }
 }
 dps_results: {
@@ -237,8 +237,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1624.8991003574752
-  tps: 1327.4957257431788
+  dps: 1623.9621509374113
+  tps: 1326.1200117612523
  }
 }
 dps_results: {
@@ -293,8 +293,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
@@ -328,22 +328,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1575.3308548701848
-  tps: 1286.3113979110944
+  dps: 1574.2790223350717
+  tps: 1284.7587484086378
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1559.2321048735537
-  tps: 1273.1074605319977
+  dps: 1558.82584085796
+  tps: 1272.236583413117
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1557.8361888863299
-  tps: 1272.1745011389705
+  dps: 1557.4827276039612
+  tps: 1271.3544400457813
  }
 }
 dps_results: {
@@ -370,8 +370,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1644.5263095536145
-  tps: 1343.5566399282368
+  dps: 1643.4363697495
+  tps: 1342.0382122968904
  }
 }
 dps_results: {
@@ -384,8 +384,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
@@ -412,8 +412,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1557.670400215955
-  tps: 1272.1745011389703
+  dps: 1557.18774081468
+  tps: 1271.2424164026284
  }
 }
 dps_results: {
@@ -461,8 +461,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1588.3389690765332
-  tps: 1298.7243101665342
+  dps: 1592.9197940702943
+  tps: 1302.418088271209
  }
 }
 dps_results: {
@@ -524,8 +524,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1584.6770819655803
-  tps: 1295.0577366008263
+  dps: 1582.1813078949606
+  tps: 1292.3335940520528
  }
 }
 dps_results: {
@@ -580,15 +580,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1656.7521849930479
-  tps: 1358.2230551969978
+  dps: 1663.1756039132172
+  tps: 1363.114702165916
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1557.3605695167196
-  tps: 1272.052085904047
+  dps: 1556.8558423188906
+  tps: 1271.0816322134744
  }
 }
 dps_results: {
@@ -657,15 +657,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1617.3997552750695
-  tps: 1321.3759364820182
+  dps: 1616.5302672909609
+  tps: 1320.062954414141
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1638.484849670642
-  tps: 1342.1634564505925
+  dps: 1635.4111924931879
+  tps: 1337.4724296589309
  }
 }
 dps_results: {
@@ -720,8 +720,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1600.0955446156245
-  tps: 1308.6568206581658
+  dps: 1596.9371554712914
+  tps: 1305.348251614376
  }
 }
 dps_results: {

--- a/sim/mage/evocation.go
+++ b/sim/mage/evocation.go
@@ -50,9 +50,6 @@ func (mage *Mage) registerEvocationCD() {
 					mage.AddMana(sim, manaPerTick, actionID, true)
 				},
 			})
-
-			// All MCDs that use the GCD and have a non-zero cast time must call this.
-			mage.UpdateMajorCooldowns()
 		},
 	})
 

--- a/sim/mage/water_elemental.go
+++ b/sim/mage/water_elemental.go
@@ -36,9 +36,6 @@ func (mage *Mage) registerSummonWaterElementalCD() {
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
 			mage.waterElemental.EnableWithTimeout(sim, mage.waterElemental, time.Second*45)
-
-			// All MCDs that use the GCD and have a non-zero cast time must call this.
-			mage.UpdateMajorCooldowns()
 		},
 	})
 

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 2073.53938501748
-  tps: 1503.575452476711
+  dps: 2094.899554837773
+  tps: 1518.7517813635998
  }
 }
 dps_results: {
@@ -76,8 +76,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 2055.040990626226
-  tps: 1489.944068298525
+  dps: 2062.389332359004
+  tps: 1495.164413262673
  }
 }
 dps_results: {
@@ -125,8 +125,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 2065.144477583839
-  tps: 1496.971570784799
+  dps: 2074.358284655872
+  tps: 1503.5911143478259
  }
 }
 dps_results: {
@@ -146,8 +146,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 2082.254998387534
-  tps: 1508.9676281270758
+  dps: 2089.898818187179
+  tps: 1514.4839526294422
  }
 }
 dps_results: {
@@ -223,8 +223,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 2069.105663497814
-  tps: 1499.7467584948404
+  dps: 2076.8160377106155
+  tps: 1505.3073848589527
  }
 }
 dps_results: {
@@ -244,8 +244,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 2053.8286817029593
-  tps: 1489.0241367939393
+  dps: 2061.6511411718566
+  tps: 1494.6953629839813
  }
 }
 dps_results: {
@@ -258,8 +258,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 2045.9601510371692
-  tps: 1483.6154763939296
+  dps: 2053.596725991542
+  tps: 1489.0940701485326
  }
 }
 dps_results: {
@@ -349,8 +349,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 2082.254998387534
-  tps: 1508.9676281270758
+  dps: 2089.898818187179
+  tps: 1514.4839526294422
  }
 }
 dps_results: {
@@ -405,22 +405,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 2036.6895095152372
-  tps: 1477.0235135724174
+  dps: 2044.575886950756
+  tps: 1482.710825488677
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 2065.556715657559
-  tps: 1497.2577184063173
+  dps: 2073.2672868403133
+  tps: 1502.8187293847993
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 2083.1263454289447
-  tps: 1509.5777894421806
+  dps: 2090.93888674126
+  tps: 1515.1787714456937
  }
 }
 dps_results: {
@@ -454,8 +454,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 2049.0574687714443
-  tps: 1485.8155791368865
+  dps: 2056.6137971770136
+  tps: 1491.2375398985998
  }
 }
 dps_results: {
@@ -468,15 +468,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 2045.8630015779263
-  tps: 1483.5062415353727
+  dps: 2053.690133723957
+  tps: 1489.1066279820755
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 2045.9601510371692
-  tps: 1483.6154763939296
+  dps: 2053.596725991542
+  tps: 1489.0940701485326
  }
 }
 dps_results: {
@@ -517,8 +517,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 2077.6172184410425
-  tps: 1506.3460658855759
+  dps: 2073.8002251853522
+  tps: 1503.7072714175551
  }
 }
 dps_results: {
@@ -678,8 +678,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 2037.986335375703
-  tps: 1477.946165694977
+  dps: 2045.4957694424163
+  tps: 1483.39900752423
  }
 }
 dps_results: {
@@ -727,8 +727,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 2048.0526921414075
-  tps: 1485.4024384375027
+  dps: 2046.390148356589
+  tps: 1484.040316316985
  }
 }
 dps_results: {
@@ -741,8 +741,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 2077.959549943815
-  tps: 1505.955475204863
+  dps: 2085.613415561948
+  tps: 1511.4764242549704
  }
 }
 dps_results: {
@@ -825,15 +825,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 2044.793915180584
-  tps: 1482.7871082207564
+  dps: 2052.4642870763414
+  tps: 1488.2894658426258
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 2049.4944361883013
-  tps: 1486.2153407095477
+  dps: 2045.760123695777
+  tps: 1483.8518721260234
  }
 }
 dps_results: {
@@ -916,8 +916,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 2038.1230577083106
-  tps: 1478.0418713278027
+  dps: 2045.4957694424163
+  tps: 1483.39900752423
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -181,7 +181,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 2081.7012453317416
+  dps: 2081.701245331741
   tps: 1509.753643046014
  }
 }
@@ -811,8 +811,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TheDecapitator-28767"
  value: {
-  dps: 2149.668066141275
-  tps: 1557.51803363732
+  dps: 2147.782807524031
+  tps: 1556.1978466695562
  }
 }
 dps_results: {
@@ -930,8 +930,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SelfDrums-DPS"
  value: {
-  dps: 2121.25731239662
-  tps: 1536.9271300774699
+  dps: 2119.4346317218456
+  tps: 1535.6512536051287
  }
 }
 dps_results: {

--- a/sim/raid_test.go
+++ b/sim/raid_test.go
@@ -144,7 +144,7 @@ func TestBasicRaid(t *testing.T) {
 		SimOptions: SimOptions,
 	}
 
-	core.RaidSimTest("P1 ST", t, rsr, 6260.88)
+	core.RaidSimTest("P1 ST", t, rsr, 6207.01)
 }
 
 func testRaidString(t *testing.T, raidString string) {

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -48,22 +48,22 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1197.9566822717686
-  tps: 838.5529010405619
+  dps: 1197.9661322717686
+  tps: 838.5596105405618
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
@@ -83,50 +83,50 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1185.1131080035268
-  tps: 829.3817795796554
+  dps: 1185.1068080035268
+  tps: 829.3773065796554
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1184.683943349846
-  tps: 829.1005305327448
+  dps: 1184.5003132216975
+  tps: 828.9701531417592
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1232.9609451151307
-  tps: 863.4180511943811
+  dps: 1232.9672451151307
+  tps: 863.4225241943811
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1197.3226736602403
-  tps: 838.1542760619241
+  dps: 1197.3289736602403
+  tps: 838.158749061924
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1197.417752033449
-  tps: 838.2217817069024
+  dps: 1197.424052033449
+  tps: 838.2262547069024
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1206.6728354041934
-  tps: 844.7126438913317
+  dps: 1206.6791354041934
+  tps: 844.7171168913317
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1236.8769341352945
-  tps: 866.1435328967555
+  dps: 1236.8745716352944
+  tps: 866.1418555217555
  }
 }
 dps_results: {
@@ -139,113 +139,113 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1225.3326758840956
-  tps: 857.947955637675
+  dps: 1225.3484258840958
+  tps: 857.959138137675
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1205.734399861628
-  tps: 844.1349839405657
+  dps: 1205.6357296509268
+  tps: 844.0689408334679
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1227.7561697715828
-  tps: 859.672329665805
+  dps: 1227.753019771583
+  tps: 859.670093165805
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1205.0822966269939
-  tps: 843.5701863651327
+  dps: 1205.0980466269941
+  tps: 843.5813688651327
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1218.9513834002855
-  tps: 853.4172379741699
+  dps: 1218.9671334002858
+  tps: 853.4284204741698
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1206.4046462236577
-  tps: 844.5329696794247
+  dps: 1206.407796223658
+  tps: 844.5352061794247
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1189.4619133253063
-  tps: 832.492889215322
+  dps: 1189.4682133253064
+  tps: 832.4973622153219
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1189.4213527651714
-  tps: 832.4640912176259
+  dps: 1189.4276527651714
+  tps: 832.4685642176258
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1195.7675466833512
-  tps: 836.9698888995334
+  dps: 1195.7738466833514
+  tps: 836.9743618995334
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1185.9117482610127
-  tps: 829.9339998579724
+  dps: 1185.8328499769532
+  tps: 829.8777532654345
  }
 }
 dps_results: {
@@ -258,99 +258,99 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1198.2124737090985
-  tps: 838.705787087814
+  dps: 1198.2187737090985
+  tps: 838.7102600878139
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1203.1895831547167
-  tps: 842.2515589113923
+  dps: 1203.1990331547167
+  tps: 842.2582684113924
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1186.4067029201176
-  tps: 830.3236898276376
+  dps: 1186.4130029201176
+  tps: 830.3281628276376
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1197.9273836068473
-  tps: 838.5033731152157
+  dps: 1197.9336836068474
+  tps: 838.5078461152157
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HandofJustice-11815"
  value: {
-  dps: 1191.5773016014045
-  tps: 833.9623018848278
+  dps: 1193.9698582005383
+  tps: 835.7167364319777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Heartrazor-29962"
  value: {
-  dps: 1225.3326758840956
-  tps: 857.947955637675
+  dps: 1225.3484258840958
+  tps: 857.959138137675
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
@@ -370,22 +370,22 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
@@ -405,99 +405,99 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 892.0574713818547
-  tps: 621.2779797213033
+  dps: 892.0566838818545
+  tps: 621.2774205963033
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1203.4833923427389
-  tps: 842.4481393176989
+  dps: 1203.489692342739
+  tps: 842.4526123176988
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1102.0463196075273
-  tps: 770.4452996637092
+  dps: 1102.0526196075273
+  tps: 770.4497726637092
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1204.9128271881425
-  tps: 843.4498630635484
+  dps: 1204.9285771881423
+  tps: 843.4610455635484
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1179.6485704868085
-  tps: 825.5132118704552
+  dps: 1179.6525079868084
+  tps: 825.5160074954551
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1225.3326758840956
-  tps: 857.947955637675
+  dps: 1225.3484258840958
+  tps: 857.959138137675
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1135.0253814185699
-  tps: 793.843276481195
+  dps: 1135.0222314185698
+  tps: 793.841039981195
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1188.658626088269
-  tps: 831.9802205900564
+  dps: 1188.657717792483
+  tps: 831.9795757000481
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1157.3878939850379
-  tps: 809.7203354837307
+  dps: 1157.3941939850379
+  tps: 809.7248084837306
  }
 }
 dps_results: {
@@ -510,15 +510,15 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1166.919188231808
-  tps: 816.4875543989378
+  dps: 1166.925488231808
+  tps: 816.4920273989378
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
@@ -531,29 +531,29 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1196.8179722540333
-  tps: 837.7959380635173
+  dps: 1196.8242722540335
+  tps: 837.8004110635172
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1232.7335073713111
-  tps: 863.2619508378702
+  dps: 1232.7398073713111
+  tps: 863.2664238378702
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1166.919188231808
-  tps: 816.4875543989378
+  dps: 1166.925488231808
+  tps: 816.4920273989378
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1166.3093407564004
-  tps: 816.054562691398
+  dps: 1166.3156407564002
+  tps: 816.059035691398
  }
 }
 dps_results: {
@@ -566,22 +566,22 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1195.366496760311
-  tps: 836.6851434541751
+  dps: 1195.3727967603108
+  tps: 836.6896164541752
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1035.8025785179402
-  tps: 723.3883552582555
+  dps: 1035.8120285179402
+  tps: 723.3950647582556
  }
 }
 dps_results: {
@@ -594,85 +594,85 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1204.9128271881425
-  tps: 843.4498630635484
+  dps: 1204.9285771881423
+  tps: 843.4610455635484
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1203.9117268935909
-  tps: 842.7390818544164
+  dps: 1203.927476893591
+  tps: 842.7502643544166
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1198.906225420831
-  tps: 839.1851758087571
+  dps: 1198.9219754208311
+  tps: 839.196358308757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1225.3326758840956
-  tps: 857.947955637675
+  dps: 1225.3484258840958
+  tps: 857.959138137675
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1166.8492360375415
-  tps: 816.4378883410086
+  dps: 1166.8555360375415
+  tps: 816.4423613410087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1166.390137497752
-  tps: 816.0724714556653
+  dps: 1166.322865021027
+  tps: 816.023640121882
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1166.032726043993
-  tps: 815.8482349408058
+  dps: 1165.8600035720074
+  tps: 815.7195499937121
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1209.9407055320708
-  tps: 847.0159591055489
+  dps: 1209.9509430320707
+  tps: 847.0232277305488
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1177.6014394400952
-  tps: 824.0961957932568
+  dps: 1177.5034425418262
+  tps: 824.0288591962403
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1203.8787209168747
-  tps: 842.6934376014145
+  dps: 1203.6752878944735
+  tps: 842.5375111517584
  }
 }
 dps_results: {
@@ -699,50 +699,50 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1044.9134107911493
-  tps: 729.8774333864733
+  dps: 1044.9165607911493
+  tps: 729.8796698864733
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1166.379292950667
-  tps: 816.1042287493273
+  dps: 1166.385592950667
+  tps: 816.1087017493273
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1215.8582620945033
-  tps: 851.3255882306214
+  dps: 1215.6000596157762
+  tps: 851.1495507826096
  }
 }
 dps_results: {
  key: "TestMutilate-SelfDrums-DPS"
  value: {
-  dps: 1224.2636196663284
-  tps: 857.2579240457324
+  dps: 1224.444122102576
+  tps: 857.3874443863722
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1299.2652100964988
-  tps: 910.4167979970454
+  dps: 1299.26353532051
+  tps: 910.4156089060931
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1225.1495703525718
-  tps: 857.843149821869
+  dps: 1225.159020352572
+  tps: 857.849859321869
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1443.0108591799226
-  tps: 1024.5377100177457
+  dps: 1443.0266091799226
+  tps: 1024.5488925177456
  }
 }
 dps_results: {
@@ -769,22 +769,22 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1299.2081926167302
-  tps: 910.3763155864099
+  dps: 1299.2065178407415
+  tps: 910.3751264954578
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1225.3326758840956
-  tps: 857.947955637675
+  dps: 1225.3484258840958
+  tps: 857.959138137675
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1442.7202917538586
-  tps: 1024.3314071452394
+  dps: 1442.7360417538584
+  tps: 1024.3425896452393
  }
 }
 dps_results: {
@@ -811,7 +811,7 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1086.8537635436726
-  tps: 759.6110767744956
+  dps: 1086.8529760436725
+  tps: 759.6105176494956
  }
 }

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -48,8 +48,8 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1197.933343896269
-  tps: 838.5170425406286
+  dps: 1197.9566822717686
+  tps: 838.5529010405619
  }
 }
 dps_results: {
@@ -83,8 +83,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1187.3416019922306
-  tps: 831.0311898090065
+  dps: 1185.1131080035268
+  tps: 829.3817795796554
  }
 }
 dps_results: {
@@ -118,8 +118,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1210.1820330657551
-  tps: 847.1691871030052
+  dps: 1206.6728354041934
+  tps: 844.7126438913317
  }
 }
 dps_results: {
@@ -132,8 +132,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1189.9845035265805
-  tps: 832.8792563516884
+  dps: 1183.9651579220726
+  tps: 828.5363739383059
  }
 }
 dps_results: {
@@ -202,15 +202,15 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1192.8860481230713
-  tps: 834.8890377936993
+  dps: 1189.4619133253063
+  tps: 832.492889215322
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1192.8373272634265
-  tps: 834.8544459833522
+  dps: 1189.4213527651714
+  tps: 832.4640912176259
  }
 }
 dps_results: {
@@ -223,8 +223,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1170.1639310235373
-  tps: 818.7563346530306
+  dps: 1166.8492360375415
+  tps: 816.4378883410086
  }
 }
 dps_results: {
@@ -272,8 +272,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1201.6790964456827
-  tps: 841.1321021027537
+  dps: 1198.2124737090985
+  tps: 838.705787087814
  }
 }
 dps_results: {
@@ -307,22 +307,22 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1170.1639310235373
-  tps: 818.7563346530306
+  dps: 1166.8492360375415
+  tps: 816.4378883410086
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1190.001300557853
-  tps: 832.8408670223948
+  dps: 1186.4067029201176
+  tps: 830.3236898276376
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1201.5385959316147
-  tps: 841.0323467377652
+  dps: 1197.9273836068473
+  tps: 838.5033731152157
  }
 }
 dps_results: {
@@ -349,8 +349,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1170.1639310235373
-  tps: 818.7563346530306
+  dps: 1166.8492360375415
+  tps: 816.4378883410086
  }
 }
 dps_results: {
@@ -363,15 +363,15 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1184.7940248157483
-  tps: 829.1772017223301
+  dps: 1183.9285403586105
+  tps: 828.5146788218694
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1170.1639310235373
-  tps: 818.7563346530306
+  dps: 1166.8492360375415
+  tps: 816.4378883410086
  }
 }
 dps_results: {
@@ -391,8 +391,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1194.757669205419
-  tps: 836.283617448264
+  dps: 1193.0529745515669
+  tps: 835.0540666492105
  }
 }
 dps_results: {
@@ -503,8 +503,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1168.762638699648
-  tps: 817.7902117606824
+  dps: 1167.0613533802868
+  tps: 816.5634993898941
  }
 }
 dps_results: {
@@ -552,8 +552,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1169.7016529060709
-  tps: 818.4281171896288
+  dps: 1166.3093407564004
+  tps: 816.054562691398
  }
 }
 dps_results: {
@@ -566,8 +566,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1198.820974515989
-  tps: 839.1028355326708
+  dps: 1195.366496760311
+  tps: 836.6851434541751
  }
 }
 dps_results: {
@@ -636,15 +636,15 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1170.1639310235373
-  tps: 818.7563346530306
+  dps: 1166.8492360375415
+  tps: 816.4378883410086
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1167.2293258718898
-  tps: 816.6620372395932
+  dps: 1166.390137497752
+  tps: 816.0724714556653
  }
 }
 dps_results: {
@@ -706,8 +706,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1170.0946754739955
-  tps: 818.7071632128552
+  dps: 1166.379292950667
+  tps: 816.1042287493273
  }
 }
 dps_results: {
@@ -720,8 +720,8 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-SelfDrums-DPS"
  value: {
-  dps: 1224.3741614457545
-  tps: 857.337772320029
+  dps: 1224.2636196663284
+  tps: 857.2579240457324
  }
 }
 dps_results: {

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -48,1015 +48,1015 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1387.6858323310898
-  tps: 973.2615926557122
+  dps: 1387.111506305662
+  tps: 972.8174129798925
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1405.4390549903808
-  tps: 985.7986571644266
+  dps: 1402.234811238264
+  tps: 983.5776085403148
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1194.0484189980139
-  tps: 835.7015059775326
+  dps: 1194.3821108042246
+  tps: 835.9365682044859
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1368.3297791034329
-  tps: 959.4510712846942
+  dps: 1365.4522498362983
+  tps: 957.4619899449194
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1373.3535960348352
-  tps: 963.0179813059897
+  dps: 1369.5081589874549
+  tps: 960.3416854422401
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1428.8927467830833
-  tps: 1002.4708536174958
+  dps: 1426.4001707151363
+  tps: 1000.6534710915569
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1384.3246783811953
-  tps: 970.8275250521557
+  dps: 1382.5186355270955
+  tps: 969.4975811080467
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1384.394630575462
-  tps: 970.8771911100849
+  dps: 1382.58874829417
+  tps: 969.5473611726698
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1397.0504115826898
-  tps: 979.8427203449661
+  dps: 1393.6835619310168
+  tps: 977.5062215321699
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1430.8821295583236
-  tps: 1003.8644761047882
+  dps: 1432.205040897373
+  tps: 1004.8658155361715
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1371.5635743945206
-  tps: 961.7470659413661
+  dps: 1367.8076079561777
+  tps: 959.1342942100335
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1395.941631189954
-  tps: 979.2271860869146
+  dps: 1393.5093210952919
+  tps: 977.4159984636846
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1429.7480236569243
-  tps: 1003.0874227464567
+  dps: 1427.749898186356
+  tps: 1001.6591908649693
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1403.0992968540224
-  tps: 984.1560302309064
+  dps: 1397.4632953005423
+  tps: 980.1146885119392
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 830.1880224625294
-  tps: 577.4341750964498
+  dps: 828.9128257345072
+  tps: 576.5257136368647
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1416.2669496037759
-  tps: 993.505063683231
+  dps: 1410.5170916727036
+  tps: 989.3828839361735
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1395.342784031283
-  tps: 978.5837005026799
+  dps: 1393.5933577736723
+  tps: 977.4031190636471
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1376.5855142789233
-  tps: 965.3126432592917
+  dps: 1373.228913465938
+  tps: 962.983421121964
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1378.8014012783055
-  tps: 966.8859230288534
+  dps: 1375.4768087813834
+  tps: 964.5794267959299
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1384.497785703858
-  tps: 970.9303559709956
+  dps: 1381.114090405117
+  tps: 968.5818967487805
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1364.6760355751053
-  tps: 956.8569133795811
+  dps: 1361.4376063548207
+  tps: 954.6115930730701
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1324.0799517798866
-  tps: 928.0628862521396
+  dps: 1324.429510601391
+  tps: 928.2836349903098
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Despair-28573"
  value: {
-  dps: 968.1089823141264
-  tps: 675.3621073829536
+  dps: 966.9225055741892
+  tps: 674.512586323039
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Devastation-30316"
  value: {
-  dps: 1202.6114543064534
-  tps: 841.8530670012167
+  dps: 1205.044704769798
+  tps: 843.5793477519214
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1386.9966051503952
-  tps: 972.7045177780373
+  dps: 1383.6346068519667
+  tps: 970.3714634260441
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1400.6694860215262
-  tps: 982.4308645398337
+  dps: 1395.5852013904948
+  tps: 978.7812418358053
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1373.362372772046
-  tps: 963.0242127894094
+  dps: 1369.7313264810914
+  tps: 960.5001343627227
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1386.7653788021487
-  tps: 972.540347070782
+  dps: 1383.2139796586487
+  tps: 970.072818118788
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 919.2630007169812
-  tps: 640.6708745741773
+  dps: 915.8660466713072
+  tps: 638.2311086187239
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HandofJustice-11815"
  value: {
-  dps: 1380.6723192337463
-  tps: 968.2465472371899
+  dps: 1382.2165758166975
+  tps: 969.3378610985758
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Heartrazor-29962"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1380.6355139306302
-  tps: 968.1881430120036
+  dps: 1376.5704077264018
+  tps: 965.3558820468928
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1377.6265218672154
-  tps: 966.0397200770619
+  dps: 1377.6587300203007
+  tps: 966.1037340732204
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 939.6680674721495
-  tps: 655.1712735493185
+  dps: 936.5950863596695
+  tps: 652.9801186807302
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1384.3567184659594
-  tps: 970.8604484939331
+  dps: 1382.5858717692838
+  tps: 969.5973101776036
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartChampion-28429"
  value: {
-  dps: 998.824387221365
-  tps: 697.1629222925336
+  dps: 994.1958264722282
+  tps: 693.8766441606465
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1023.9516548748212
-  tps: 715.0032823264872
+  dps: 1019.4153808230594
+  tps: 711.7825277497369
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1403.432375962178
-  tps: 984.3964950460846
+  dps: 1405.459762993826
+  tps: 985.8207216942114
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1023.7217738368873
-  tps: 714.8206811027798
+  dps: 1026.8706929502787
+  tps: 717.0825582800012
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 761.904054172126
-  tps: 528.954678777876
+  dps: 759.0543936463467
+  tps: 526.9262268542705
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1393.8606468332634
-  tps: 977.5779873728735
+  dps: 1390.4772833785253
+  tps: 975.2297637599003
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1269.1699987067263
-  tps: 889.0807750660726
+  dps: 1268.3674637144513
+  tps: 888.5331853877635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1401.975469368167
-  tps: 983.3581127159483
+  dps: 1396.3324383478873
+  tps: 979.3117800755542
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1390.5419156083633
-  tps: 975.2320681081151
+  dps: 1387.8211737818224
+  tps: 973.4002496485847
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1334.1356966159533
-  tps: 935.2611992678898
+  dps: 1328.1583453500207
+  tps: 930.9271694912734
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1381.769391057259
-  tps: 969.0336601335835
+  dps: 1384.1491952442989
+  tps: 970.7423898412195
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1336.5142760202816
-  tps: 936.8620640956563
+  dps: 1333.0776157775413
+  tps: 934.4759997632026
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1346.255142122578
-  tps: 943.7586017381435
+  dps: 1348.1652832427428
+  tps: 945.089255388667
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.4392268944448
+  tps: 943.9627436562034
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1400.4243523707783
-  tps: 982.325030051375
+  dps: 1400.9699177134762
+  tps: 982.6760681962597
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1383.7164630324796
-  tps: 970.3956921545675
+  dps: 1381.9101686666586
+  tps: 969.0655696371374
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1428.1182325084728
-  tps: 1001.9209484825224
+  dps: 1425.8908321580745
+  tps: 1000.2918407160423
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.4392268944448
+  tps: 943.9627436562034
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1348.6839907574765
-  tps: 945.5025615590644
+  dps: 1345.5676483497696
+  tps: 943.3439228894839
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 902.0490959769086
-  tps: 628.4626607334202
+  dps: 904.1562023367317
+  tps: 629.9485110244436
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1531.7491996197639
-  tps: 1075.4814229845413
+  dps: 1531.6525997498643
+  tps: 1075.39397987075
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1383.5971251876701
-  tps: 970.2908870045021
+  dps: 1380.237293024457
+  tps: 967.959370608512
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1207.1212640458298
-  tps: 844.9854076072525
+  dps: 1208.6581542039003
+  tps: 846.0975281882567
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1190.217649617165
-  tps: 833.0500090636108
+  dps: 1190.4212444666218
+  tps: 833.2405854384647
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1401.975469368167
-  tps: 983.3581127159483
+  dps: 1396.3324383478873
+  tps: 979.3117800755542
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1400.7618687094061
-  tps: 982.496456248229
+  dps: 1395.1239596984315
+  tps: 978.4537602344403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1394.693865415604
-  tps: 978.1881739096291
+  dps: 1389.0815664511538
+  tps: 974.1636610288728
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheBladefist-29348"
  value: {
-  dps: 1322.11493466177
-  tps: 926.6512022711466
+  dps: 1324.1586106942038
+  tps: 928.1193135686619
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1305.093615346602
-  tps: 914.6327638274036
+  dps: 1305.9184496861612
+  tps: 915.1655604360155
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1349.6789414888838
-  tps: 946.2089765783641
+  dps: 1346.3363756528179
+  tps: 943.8897192746484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1352.2492226176882
-  tps: 948.0660573719923
+  dps: 1348.4857522400496
+  tps: 945.3003133191854
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1598.3715714176685
-  tps: 1122.8077364965109
+  dps: 1596.7608312937662
+  tps: 1121.623106664196
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1344.3890943910396
-  tps: 942.5442966190196
+  dps: 1341.9872552288664
+  tps: 940.7453771420339
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1412.5319926525515
-  tps: 990.8648175692247
+  dps: 1416.0781230951718
+  tps: 993.3942725249491
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1356.080823534709
-  tps: 950.7574992535659
+  dps: 1356.9494648172235
+  tps: 951.39882475259
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1395.5764890342502
-  tps: 978.8304002082816
+  dps: 1392.331514985222
+  tps: 976.4618328756518
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1398.864893393831
-  tps: 981.1770402550115
+  dps: 1402.0804003957892
+  tps: 983.4862055809078
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1222.6799259029042
-  tps: 856.0354240212542
+  dps: 1220.746173071627
+  tps: 854.6629252248416
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1251.9179846610255
-  tps: 876.8135335261991
+  dps: 1251.3585805744642
+  tps: 876.4358990106526
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WorldBreaker-30090"
  value: {
-  dps: 960.6260873827009
-  tps: 670.0523542742743
+  dps: 961.6950841564009
+  tps: 670.8011171164088
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1215.8535297152746
-  tps: 851.2112963798348
+  dps: 1212.3252778268422
+  tps: 848.7734259713085
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1348.6839907574765
-  tps: 945.5025615590644
+  dps: 1345.6704995913963
+  tps: 943.4169472710389
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1417.6682952906215
-  tps: 994.6341055208543
+  dps: 1417.4153210081265
+  tps: 994.4511144554604
  }
 }
 dps_results: {
  key: "TestRogue-SelfDrums-DPS"
  value: {
-  dps: 1421.360534684696
-  tps: 997.1290193601063
+  dps: 1417.1554399358615
+  tps: 994.1768797734275
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1714.1908564118246
-  tps: 1205.0470157751824
+  dps: 1717.4613814063705
+  tps: 1207.4255917998537
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1410.6235237441779
-  tps: 989.5036406339664
+  dps: 1409.5534607955808
+  tps: 988.7100347372095
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1775.114035891134
-  tps: 1260.3309654827053
+  dps: 1763.9413764061637
+  tps: 1252.3983772483762
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 773.312901089799
-  tps: 549.0521597737572
+  dps: 773.3456315919714
+  tps: 549.0753984302996
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 666.5487591512679
-  tps: 473.24961899740026
+  dps: 666.5583850896826
+  tps: 473.2564534136747
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 731.3760081609004
-  tps: 519.2769657942391
+  dps: 731.4909024080496
+  tps: 519.358540709715
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1797.861878071719
-  tps: 1264.485635097883
+  dps: 1800.9516634837535
+  tps: 1266.6874247846267
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1484.4151443119483
-  tps: 1041.8226926607497
+  dps: 1481.392395931163
+  tps: 1039.7613187603017
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1814.2687775070956
-  tps: 1288.1308320300375
+  dps: 1816.0206533123987
+  tps: 1289.3746638518032
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 756.147458494333
-  tps: 536.8646955309762
+  dps: 756.1929413404587
+  tps: 536.8969883517253
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 651.9420467502339
-  tps: 462.87885319266604
+  dps: 651.9908825618418
+  tps: 462.9135266189075
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 715.5462082544549
-  tps: 508.037807860663
+  dps: 715.7346422733747
+  tps: 508.17159601409594
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1737.992457812125
-  tps: 1221.9880291527447
+  dps: 1743.4837546786823
+  tps: 1225.8476821564277
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1424.2249976543492
-  tps: 999.1552777991379
+  dps: 1418.8898134077765
+  tps: 995.3275163680751
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1792.732136106029
-  tps: 1272.8398166352808
+  dps: 1793.0641919724208
+  tps: 1273.0755763004179
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 779.0470370667109
-  tps: 553.1233963173648
+  dps: 779.0721586976225
+  tps: 553.1412326753122
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 675.7865567219314
-  tps: 479.8084552725714
+  dps: 675.8276608637782
+  tps: 479.83763921328233
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 741.7084954816371
-  tps: 526.6130317919624
+  dps: 741.800844757454
+  tps: 526.6785997777922
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1810.2746902103893
-  tps: 1273.2764598497185
+  dps: 1817.4762981007175
+  tps: 1278.3733561003846
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1501.6364860516364
-  tps: 1054.150122620478
+  dps: 1496.2419133897379
+  tps: 1050.264877132385
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1827.0234891196371
-  tps: 1297.1866772749418
+  dps: 1837.468555114171
+  tps: 1304.602674131062
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 767.4077814757173
-  tps: 544.8595248477591
+  dps: 767.4521412040344
+  tps: 544.8910202548643
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 660.6694277261107
-  tps: 469.07529368553844
+  dps: 660.6991296019895
+  tps: 469.09638201741257
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 732.8839861900364
-  tps: 520.3476301949256
+  dps: 733.0027738681208
+  tps: 520.431969446366
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1289.9873070691401
-  tps: 903.8741021735914
+  dps: 1290.0180739152356
+  tps: 903.8993064176408
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -48,1015 +48,1015 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1383.6441146019351
-  tps: 970.311076482099
+  dps: 1387.6858323310898
+  tps: 973.2615926557122
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1410.9977794805336
-  tps: 989.7458484879892
+  dps: 1405.4390549903808
+  tps: 985.7986571644266
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1195.3734790055266
-  tps: 836.6778364574579
+  dps: 1194.0484189980139
+  tps: 835.7015059775326
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1368.91660420191
-  tps: 959.94983769406
+  dps: 1368.3297791034329
+  tps: 959.4510712846942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1372.7011441058278
-  tps: 962.5552373719484
+  dps: 1373.3535960348352
+  tps: 963.0179813059897
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1429.4369464845615
-  tps: 1002.866858045269
+  dps: 1428.8927467830833
+  tps: 1002.4708536174958
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1384.7409830345716
-  tps: 971.1327239957761
+  dps: 1384.3246783811953
+  tps: 970.8275250521557
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1384.8158153981399
-  tps: 971.1858549739095
+  dps: 1384.394630575462
+  tps: 970.8771911100849
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1397.5523116826846
-  tps: 980.2811900054096
+  dps: 1397.0504115826898
+  tps: 979.8427203449661
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1433.8330838328347
-  tps: 1005.9325156538142
+  dps: 1430.8821295583236
+  tps: 1003.8644761047882
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1373.2427487787954
-  tps: 963.0214003436485
+  dps: 1371.5635743945206
+  tps: 961.7470659413661
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1395.3368477123604
-  tps: 978.7132665598077
+  dps: 1395.941631189954
+  tps: 979.2271860869146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1430.8250015136093
-  tps: 1003.8940929741444
+  dps: 1429.7480236569243
+  tps: 1003.0874227464567
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1409.3014789780218
-  tps: 988.6044218315068
+  dps: 1403.0992968540224
+  tps: 984.1560302309064
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 828.7424440125126
-  tps: 576.4047426142483
+  dps: 830.1880224625294
+  tps: 577.4341750964498
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1422.747009939227
-  tps: 998.1507488139631
+  dps: 1416.2669496037759
+  tps: 993.505063683231
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1393.586007267858
-  tps: 977.3620667298106
+  dps: 1395.342784031283
+  tps: 978.5837005026799
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1377.0479943506898
-  tps: 965.7231246996936
+  dps: 1376.5855142789233
+  tps: 965.3126432592917
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1379.1763329980452
-  tps: 967.234245139316
+  dps: 1378.8014012783055
+  tps: 966.8859230288534
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1350.0912879954535
-  tps: 946.5838631874761
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1384.4998148324323
-  tps: 970.9322935878372
+  dps: 1384.497785703858
+  tps: 970.9303559709956
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1366.9358428957255
-  tps: 958.4618735127755
+  dps: 1364.6760355751053
+  tps: 956.8569133795811
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1333.7327013323127
-  tps: 934.9398934307575
+  dps: 1324.0799517798866
+  tps: 928.0628862521396
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Despair-28573"
  value: {
-  dps: 965.917603054153
-  tps: 673.7991055338131
+  dps: 968.1089823141264
+  tps: 675.3621073829536
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1400.9716532497475
-  tps: 982.6902455644325
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Devastation-30316"
  value: {
-  dps: 1204.0745457613878
-  tps: 842.8937679503618
+  dps: 1202.6114543064534
+  tps: 841.8530670012167
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1387.4785838929497
-  tps: 973.1288432746984
+  dps: 1386.9966051503952
+  tps: 972.7045177780373
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1407.0514260403152
-  tps: 987.0068842457356
+  dps: 1400.6694860215262
+  tps: 982.4308645398337
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1350.0912879954535
-  tps: 946.5838631874761
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1373.6742592646654
-  tps: 963.3277727886161
+  dps: 1373.362372772046
+  tps: 963.0242127894094
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1387.433042306865
-  tps: 973.0965087485783
+  dps: 1386.7653788021487
+  tps: 972.540347070782
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 916.9803113297015
-  tps: 639.0185441851781
+  dps: 919.2630007169812
+  tps: 640.6708745741773
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HandofJustice-11815"
  value: {
-  dps: 1379.689917302461
-  tps: 967.557162019205
+  dps: 1380.6723192337463
+  tps: 968.2465472371899
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Heartrazor-29962"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1350.0912879954535
-  tps: 946.5838631874761
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1381.0285101778732
-  tps: 968.4676672831006
+  dps: 1380.6355139306302
+  tps: 968.1881430120036
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1377.3042821269075
-  tps: 965.8048030417092
+  dps: 1377.6265218672154
+  tps: 966.0397200770619
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1350.0912879954535
-  tps: 946.5838631874761
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 937.8024231017496
-  tps: 653.8373277676068
+  dps: 939.6680674721495
+  tps: 655.1712735493185
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1380.2217927224067
-  tps: 967.922140611383
+  dps: 1384.3567184659594
+  tps: 970.8604484939331
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartChampion-28429"
  value: {
-  dps: 992.2095469393779
-  tps: 692.4663856923228
+  dps: 998.824387221365
+  tps: 697.1629222925336
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1017.4293485583469
-  tps: 710.3724448417905
+  dps: 1023.9516548748212
+  tps: 715.0032823264872
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1404.0085671197
-  tps: 984.8123458834743
+  dps: 1403.432375962178
+  tps: 984.3964950460846
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1024.3950929021019
-  tps: 715.3321313054819
+  dps: 1023.7217738368873
+  tps: 714.8206811027798
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 760.0735377859704
-  tps: 527.6498191934033
+  dps: 761.904054172126
+  tps: 528.954678777876
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1393.8632370116975
-  tps: 977.5803233351161
+  dps: 1393.8606468332634
+  tps: 977.5779873728735
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1267.9550845036517
-  tps: 888.2279285640205
+  dps: 1269.1699987067263
+  tps: 889.0807750660726
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1408.2064644422496
-  tps: 987.8269615111087
+  dps: 1401.975469368167
+  tps: 983.3581127159483
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1394.1408749203795
-  tps: 977.7783873568062
+  dps: 1390.5419156083633
+  tps: 975.2320681081151
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1335.014020621027
-  tps: 935.7419195700127
+  dps: 1334.1356966159533
+  tps: 935.2611992678898
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1384.5506631191624
-  tps: 971.0388368117584
+  dps: 1381.769391057259
+  tps: 969.0336601335835
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1336.7456974661968
-  tps: 937.0268702578102
+  dps: 1336.5142760202816
+  tps: 936.8620640956563
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1349.21634612485
-  tps: 945.8967889477074
+  dps: 1346.255142122578
+  tps: 943.7586017381435
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1401.0897691349226
-  tps: 982.7470394377455
+  dps: 1400.4243523707783
+  tps: 982.325030051375
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1384.1317425300483
-  tps: 970.7001632375647
+  dps: 1383.7164630324796
+  tps: 970.3956921545675
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1428.2915787602265
-  tps: 1002.0536469609912
+  dps: 1428.1182325084728
+  tps: 1001.9209484825224
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1349.5163521549703
-  tps: 946.1756587407326
+  dps: 1348.6839907574765
+  tps: 945.5025615590644
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 902.4512088893193
-  tps: 628.7379656767811
+  dps: 902.0490959769086
+  tps: 628.4626607334202
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1529.302769341184
-  tps: 1073.7647626388687
+  dps: 1531.7491996197639
+  tps: 1075.4814229845413
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1384.0739585050665
-  tps: 970.7115592493009
+  dps: 1383.5971251876701
+  tps: 970.2908870045021
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1205.3383932829483
-  tps: 843.748048320456
+  dps: 1207.1212640458298
+  tps: 844.9854076072525
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1184.3636929906877
-  tps: 828.8779886651544
+  dps: 1190.217649617165
+  tps: 833.0500090636108
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1408.2064644422496
-  tps: 987.8269615111087
+  dps: 1401.975469368167
+  tps: 983.3581127159483
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1406.989063688241
-  tps: 986.9626069757625
+  dps: 1400.7618687094061
+  tps: 982.496456248229
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1400.9020599181965
-  tps: 982.6408342990314
+  dps: 1394.693865415604
+  tps: 978.1881739096291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheBladefist-29348"
  value: {
-  dps: 1319.9537724357765
-  tps: 925.1652670429826
+  dps: 1322.11493466177
+  tps: 926.6512022711466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1305.7800168433187
-  tps: 915.0672524889084
+  dps: 1305.093615346602
+  tps: 914.6327638274036
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1349.661642676472
-  tps: 946.1971913571055
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1350.0912879954535
-  tps: 946.5838631874761
+  dps: 1349.6789414888838
+  tps: 946.2089765783641
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1347.7467140204378
-  tps: 944.8041275513309
+  dps: 1352.2492226176882
+  tps: 948.0660573719923
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1598.9971624890863
-  tps: 1123.1822062501085
+  dps: 1598.3715714176685
+  tps: 1122.8077364965109
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1348.0354947424316
-  tps: 945.095922735611
+  dps: 1344.3890943910396
+  tps: 942.5442966190196
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1414.5868363652176
-  tps: 992.3168827840747
+  dps: 1412.5319926525515
+  tps: 990.8648175692247
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1359.4362667462824
-  tps: 953.0772952129034
+  dps: 1356.080823534709
+  tps: 950.7574992535659
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1389.6737543952459
-  tps: 974.6333820114452
+  dps: 1395.5764890342502
+  tps: 978.8304002082816
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1400.7603690370279
-  tps: 982.4831894325054
+  dps: 1398.864893393831
+  tps: 981.1770402550115
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1216.153843737046
-  tps: 851.4136514277867
+  dps: 1222.6799259029042
+  tps: 856.0354240212542
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1252.681683743773
-  tps: 877.3692569034329
+  dps: 1251.9179846610255
+  tps: 876.8135335261991
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WorldBreaker-30090"
  value: {
-  dps: 961.4214782843004
-  tps: 670.6068569472177
+  dps: 960.6260873827009
+  tps: 670.0523542742743
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1219.023284880308
-  tps: 853.4523855548349
+  dps: 1215.8535297152746
+  tps: 851.2112963798348
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1349.7085536643706
-  tps: 946.3121218124066
+  dps: 1348.6839907574765
+  tps: 945.5025615590644
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1416.9555617541703
-  tps: 994.122529354961
+  dps: 1417.6682952906215
+  tps: 994.6341055208543
  }
 }
 dps_results: {
  key: "TestRogue-SelfDrums-DPS"
  value: {
-  dps: 1422.0115563930524
-  tps: 997.58357398945
+  dps: 1421.360534684696
+  tps: 997.1290193601063
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1719.8414136858198
-  tps: 1209.0332965425741
+  dps: 1714.1908564118246
+  tps: 1205.0470157751824
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1407.6406682695542
-  tps: 987.3800424243565
+  dps: 1410.6235237441779
+  tps: 989.5036406339664
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1750.7788447236212
-  tps: 1243.0529797537708
+  dps: 1775.114035891134
+  tps: 1260.3309654827053
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 773.3456315919714
-  tps: 549.0753984302996
+  dps: 773.312901089799
+  tps: 549.0521597737572
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 666.5583850896826
-  tps: 473.2564534136747
+  dps: 666.5487591512679
+  tps: 473.24961899740026
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 731.4909024080496
-  tps: 519.358540709715
+  dps: 731.3760081609004
+  tps: 519.2769657942391
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1801.8692313481483
-  tps: 1267.2447361009401
+  dps: 1797.861878071719
+  tps: 1264.485635097883
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1481.9685030362236
-  tps: 1040.1655218348085
+  dps: 1484.4151443119483
+  tps: 1041.8226926607497
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1807.091786657301
-  tps: 1283.035168526684
+  dps: 1814.2687775070956
+  tps: 1288.1308320300375
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 756.1929413404587
-  tps: 536.8969883517253
+  dps: 756.147458494333
+  tps: 536.8646955309762
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 651.9908825618418
-  tps: 462.9135266189075
+  dps: 651.9420467502339
+  tps: 462.87885319266604
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 715.7346422733747
-  tps: 508.17159601409594
+  dps: 715.5462082544549
+  tps: 508.037807860663
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1741.4108909770946
-  tps: 1224.3894526458487
+  dps: 1737.992457812125
+  tps: 1221.9880291527447
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1431.1241538264792
-  tps: 1004.0985209739118
+  dps: 1424.2249976543492
+  tps: 999.1552777991379
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1779.741721785005
-  tps: 1263.6166224673532
+  dps: 1792.732136106029
+  tps: 1272.8398166352808
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 779.0721586976225
-  tps: 553.1412326753122
+  dps: 779.0470370667109
+  tps: 553.1233963173648
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 675.8276608637782
-  tps: 479.83763921328233
+  dps: 675.7865567219314
+  tps: 479.8084552725714
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 741.800844757454
-  tps: 526.6785997777922
+  dps: 741.7084954816371
+  tps: 526.6130317919624
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1811.8296935947933
-  tps: 1274.3450266325478
+  dps: 1810.2746902103893
+  tps: 1273.2764598497185
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1500.4564964625665
-  tps: 1053.258074090241
+  dps: 1501.6364860516364
+  tps: 1054.150122620478
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1830.9761829760928
-  tps: 1299.9930899130254
+  dps: 1827.0234891196371
+  tps: 1297.1866772749418
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 767.4521412040344
-  tps: 544.8910202548643
+  dps: 767.4077814757173
+  tps: 544.8595248477591
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 660.6991296019895
-  tps: 469.09638201741257
+  dps: 660.6694277261107
+  tps: 469.07529368553844
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 733.0027738681208
-  tps: 520.431969446366
+  dps: 732.8839861900364
+  tps: 520.3476301949256
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1291.173979563831
-  tps: 904.6991304148479
+  dps: 1289.9873070691401
+  tps: 903.8741021735914
  }
 }

--- a/sim/shaman/bloodlust.go
+++ b/sim/shaman/bloodlust.go
@@ -45,9 +45,6 @@ func (shaman *Shaman) registerBloodlustCD() {
 			for _, blAura := range blAuras {
 				blAura.Activate(sim)
 			}
-
-			// All MCDs that use the GCD and have a non-zero cast time must call this.
-			shaman.UpdateMajorCooldowns()
 		},
 	})
 

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -51,19 +51,19 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.1795336961318958
+  weights: 0.18798991171372337
   weights: 0
-  weights: 0.6718309195263736
-  weights: 0
-  weights: 0
+  weights: 0.6729795991261927
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.6269071455220758
-  weights: 0.5684188752028695
+  weights: 0
+  weights: 0
+  weights: 1.6512823138464532
+  weights: 0.5640608856230711
   weights: 0
   weights: 0
   weights: 0
@@ -95,876 +95,876 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1493.5408045354168
-  tps: 1237.5112442068828
+  dps: 1489.4234337896237
+  tps: 1233.1997202734497
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1512.7113935650789
-  tps: 1262.6661162216708
+  dps: 1517.6171728985878
+  tps: 1265.8448649734883
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1512.7113935650789
-  tps: 1262.6661162216708
+  dps: 1517.6171728985878
+  tps: 1265.8448649734883
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1565.4075799683687
-  tps: 1306.8794683347162
+  dps: 1565.3343048899708
+  tps: 1305.0712602852511
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1492.9473425662075
-  tps: 1237.0366675501166
+  dps: 1488.931867209092
+  tps: 1232.8203053546533
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1524.7087548611626
-  tps: 1273.8086630430016
+  dps: 1524.7195733977417
+  tps: 1271.1236693269127
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1513.910746414465
-  tps: 1264.6979082753362
+  dps: 1518.5469499820442
+  tps: 1265.7559931640378
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1524.7087548611626
-  tps: 1273.8086630430016
+  dps: 1524.7195733977417
+  tps: 1271.1236693269127
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 1521.578203164115
-  tps: 1269.5215252392723
+  dps: 1526.2038831772577
+  tps: 1273.7136918684332
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CataclysmHarness"
  value: {
-  dps: 1134.6635232773804
-  tps: 956.1589247977905
+  dps: 1136.1284748577966
+  tps: 957.3475647113756
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CataclysmRegalia"
  value: {
-  dps: 1403.6945131171085
-  tps: 1172.944663189723
+  dps: 1403.5895446918328
+  tps: 1171.9452398481578
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1524.7087548611626
-  tps: 1299.287666976479
+  dps: 1524.7195733977417
+  tps: 1296.5865517346624
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1493.494181184867
-  tps: 1237.427608666565
+  dps: 1489.3937674490508
+  tps: 1233.1904037721615
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CycloneHarness"
  value: {
-  dps: 1133.854979161028
-  tps: 955.9443468808008
+  dps: 1135.9320957737189
+  tps: 958.2053586956572
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CycloneRegalia"
  value: {
-  dps: 1345.2297398947817
-  tps: 1123.1416137226877
+  dps: 1346.2249313580587
+  tps: 1124.036804207328
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1546.001580561196
-  tps: 1280.0432325745105
+  dps: 1544.1564580867282
+  tps: 1278.9202328393305
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1547.857734519329
-  tps: 1281.5271498743125
+  dps: 1550.1162173906791
+  tps: 1282.4932538401163
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DesolationBattlegear"
  value: {
-  dps: 1135.9491601155441
-  tps: 957.590509368881
+  dps: 1136.4965216131832
+  tps: 958.3602747206605
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1515.734482351234
-  tps: 1265.6207524315819
+  dps: 1519.8599414031728
+  tps: 1268.1356275740964
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Devastation-30316"
  value: {
-  dps: 1348.255388508866
-  tps: 1130.7937394193473
+  dps: 1347.0764902696371
+  tps: 1126.756538652432
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1522.2228386521558
-  tps: 1272.1451537776022
+  dps: 1522.9835271207735
+  tps: 1269.532678445346
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1530.014794474797
-  tps: 1267.1113038445144
+  dps: 1532.3310054500773
+  tps: 1268.1355676475216
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1544.8546812702066
-  tps: 1279.0860469360457
+  dps: 1546.507737892236
+  tps: 1279.5426262312537
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Fathom-BroochoftheTidewalker-30663"
  value: {
-  dps: 1495.615372676189
-  tps: 1240.3722323007887
+  dps: 1499.0613124843628
+  tps: 1243.8911847074255
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FelstalkerArmor"
  value: {
-  dps: 1403.3914767225297
-  tps: 1174.2749398044596
+  dps: 1406.5982857540557
+  tps: 1174.4647579318882
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1506.8643590378126
-  tps: 1247.9125727548846
+  dps: 1501.6299497469847
+  tps: 1242.6424352738652
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1493.4270719974636
-  tps: 1237.381501841199
+  dps: 1489.3039480249292
+  tps: 1233.1102348556678
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1492.8194164970012
-  tps: 1236.924060505036
+  dps: 1488.931867209092
+  tps: 1232.8203053546533
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HandofJustice-11815"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartrazor-29962"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1561.517137498688
-  tps: 1292.6239277571178
+  dps: 1559.3248142823347
+  tps: 1291.2689157874845
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1517.17657954009
-  tps: 1267.3448587830326
+  dps: 1521.8248529561063
+  tps: 1268.4116881857635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1512.1026801235532
-  tps: 1265.3335063244117
+  dps: 1511.911773426588
+  tps: 1262.5428845184065
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1492.9473425662075
-  tps: 1237.0366675501166
+  dps: 1488.931867209092
+  tps: 1232.8203053546533
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1305.4403374376575
-  tps: 1095.1924890081598
+  dps: 1304.5343697649516
+  tps: 1092.3146561048407
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1348.255388508866
-  tps: 1130.7937394193473
+  dps: 1347.0764902696371
+  tps: 1126.756538652432
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1553.0164732512326
-  tps: 1285.7348286694225
+  dps: 1555.2632328360169
+  tps: 1286.681086466168
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1546.4633955273996
-  tps: 1292.151505957892
+  dps: 1541.4390101759593
+  tps: 1283.7875679300143
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1508.5228377904828
-  tps: 1249.7373524934953
+  dps: 1504.3384951418118
+  tps: 1245.3551377931137
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NetherscaleArmor"
  value: {
-  dps: 1402.1604464060158
-  tps: 1173.495003828997
+  dps: 1405.9346999570669
+  tps: 1173.6363010321168
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1513.577818278725
-  tps: 1263.460350539977
+  dps: 1516.3520529421014
+  tps: 1265.3176101847666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PrimalIntent"
  value: {
-  dps: 1394.608429640572
-  tps: 1165.4137806330962
+  dps: 1397.879531487776
+  tps: 1167.5188977689802
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1554.0401539370696
-  tps: 1286.2151063635997
+  dps: 1555.266101624344
+  tps: 1284.8706606051646
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1548.9443743429217
-  tps: 1293.3272056163855
+  dps: 1553.9511168435229
+  tps: 1294.6770387006814
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1531.7502870415722
-  tps: 1280.6759084556134
+  dps: 1534.493947198778
+  tps: 1281.0723443817476
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1539.6786278389802
-  tps: 1276.0688049022208
+  dps: 1527.2560635777895
+  tps: 1263.2902107579491
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1547.260654066026
-  tps: 1282.394412658173
+  dps: 1550.2825460602764
+  tps: 1282.9302519018759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1562.3720148756006
-  tps: 1302.8599665607019
+  dps: 1567.9038449657016
+  tps: 1306.6248518681814
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1524.7087548611626
-  tps: 1273.8086630430016
+  dps: 1524.7195733977417
+  tps: 1271.1236693269127
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1537.5827502673503
-  tps: 1274.2674685560837
+  dps: 1539.0416657299304
+  tps: 1273.2067492368305
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1585.0217419076462
-  tps: 1310.914569620553
+  dps: 1568.2170669089223
+  tps: 1295.6951013590317
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1348.255388508866
-  tps: 1130.7937394193473
+  dps: 1347.0764902696371
+  tps: 1126.756538652432
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 1573.4274645146672
-  tps: 1311.1484845799093
+  dps: 1574.4589527025944
+  tps: 1312.0315700898957
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 1032.590631645456
-  tps: 872.4873927548471
+  dps: 1031.7163624626162
+  tps: 869.2513204766517
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1637.22963521984
-  tps: 1359.9893188082349
+  dps: 1635.9445360875827
+  tps: 1358.4613041859272
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1492.7100664971515
-  tps: 1236.837721902472
+  dps: 1491.8075453442384
+  tps: 1236.331414868982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1538.15971780828
-  tps: 1275.507591263682
+  dps: 1540.3903796850923
+  tps: 1277.541663522693
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1460.5546402254092
-  tps: 1221.3625154798422
+  dps: 1459.500184592976
+  tps: 1217.535518329027
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 1517.5392285833468
-  tps: 1266.2521016767862
+  dps: 1522.153564426598
+  tps: 1270.4294439187918
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1507.6251177650743
-  tps: 1258.2166124360797
+  dps: 1514.0641242668185
+  tps: 1264.4951400208472
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1320.2802774467955
-  tps: 1107.510308818029
+  dps: 1322.145864366817
+  tps: 1107.4397539185486
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1515.8702462898407
-  tps: 1266.2860785799544
+  dps: 1520.5136917664815
+  tps: 1267.3494101770737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheBladefist-29348"
  value: {
-  dps: 1381.0247387815589
-  tps: 1157.3545248088985
+  dps: 1379.875126648292
+  tps: 1153.3231157804867
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 1348.255388508866
-  tps: 1130.7937394193473
+  dps: 1347.0764902696371
+  tps: 1126.756538652432
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1540.0638351315702
-  tps: 1275.228113476278
+  dps: 1538.375471566407
+  tps: 1274.2111261670636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1588.894025461164
-  tps: 1312.3830281685762
+  dps: 1589.1377445216724
+  tps: 1314.1112880402686
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheTwinStars"
  value: {
-  dps: 1533.7372914741927
-  tps: 1278.980018345444
+  dps: 1534.6292921792806
+  tps: 1280.209958124092
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1508.0322467883398
-  tps: 1259.9333973614828
+  dps: 1512.6467246287316
+  tps: 1260.97574212493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 1246.704300705613
-  tps: 1047.4044852193647
+  dps: 1248.2585626960392
+  tps: 1047.6699650604614
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1525.3288835620942
-  tps: 1263.2994736373344
+  dps: 1527.5456428729296
+  tps: 1264.2057421401676
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofthePulsingEarth-29389"
  value: {
-  dps: 1517.5392285833468
-  tps: 1263.5267684904934
+  dps: 1521.7538991190572
+  tps: 1268.8216967461185
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1495.615372676189
-  tps: 1239.2225072614349
+  dps: 1497.7999365710796
+  tps: 1240.0858604244602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WastewalkerArmor"
  value: {
-  dps: 1111.6310491005506
-  tps: 935.1249319927929
+  dps: 1095.0202754065047
+  tps: 920.6798185970813
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WindhawkArmor"
  value: {
-  dps: 1507.2529043137786
-  tps: 1260.3377439769313
+  dps: 1509.8031938386353
+  tps: 1260.3332615489685
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1348.255388508866
-  tps: 1130.7937394193473
+  dps: 1347.0764902696371
+  tps: 1126.756538652432
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathofSpellfire"
  value: {
-  dps: 1438.4294262754186
-  tps: 1203.5859890944687
+  dps: 1437.2797240393631
+  tps: 1200.6099042761712
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1532.747350480535
-  tps: 1270.2310872857781
+  dps: 1522.133659536649
+  tps: 1259.582398911336
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 1553.282129603281
-  tps: 1297.5491691109582
+  dps: 1554.9878858009295
+  tps: 1297.1878825257324
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1979.4582037178823
-  tps: 2117.3933909614584
+  dps: 1984.312420352337
+  tps: 2083.7671480461
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1566.3075355582832
-  tps: 1308.3833192542077
+  dps: 1574.8185823193285
+  tps: 1315.2557118326356
  }
 }
 dps_results: {
@@ -998,15 +998,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-CLOnClearcast-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1911.0685112241292
-  tps: 2006.8857689533636
+  dps: 1899.5517185111798
+  tps: 1989.7346723907613
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-CLOnClearcast-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1557.287637317937
-  tps: 1297.5776399809515
+  dps: 1558.2435135398007
+  tps: 1299.1369631887944
  }
 }
 dps_results: {
@@ -1040,15 +1040,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-CLOnClearcastNoBuffs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1674.567360047865
-  tps: 1853.084204849715
+  dps: 1682.9426436461538
+  tps: 1828.6478786778596
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-CLOnClearcastNoBuffs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1383.0770860254374
-  tps: 1159.8790655282464
+  dps: 1385.1682280610828
+  tps: 1159.8853002564751
  }
 }
 dps_results: {
@@ -1082,15 +1082,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Fixed3LBCL-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1984.8179910961633
-  tps: 2121.38559383653
+  dps: 1994.874654147899
+  tps: 2092.488802437474
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Fixed3LBCL-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1572.5485248213488
-  tps: 1317.5335238171795
+  dps: 1564.3777294618674
+  tps: 1307.1957500693784
  }
 }
 dps_results: {
@@ -1166,15 +1166,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1975.5294440473613
-  tps: 2119.271538742726
+  dps: 1981.5362388185247
+  tps: 2082.651623466168
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1562.815940715592
-  tps: 1308.2008542184988
+  dps: 1569.5486505813772
+  tps: 1311.2736489229624
  }
 }
 dps_results: {
@@ -1208,15 +1208,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-CLOnClearcast-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1893.3381831587874
-  tps: 2025.219970419948
+  dps: 1901.395662046024
+  tps: 2009.0152111865082
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-CLOnClearcast-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }
 dps_results: {
@@ -1250,15 +1250,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-CLOnClearcastNoBuffs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1671.684162076332
-  tps: 1858.6149414468166
+  dps: 1681.7704732147533
+  tps: 1829.6486136677424
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-CLOnClearcastNoBuffs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1380.3915207831649
-  tps: 1157.068958711983
+  dps: 1379.8385128304342
+  tps: 1157.0980075013917
  }
 }
 dps_results: {
@@ -1292,15 +1292,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-Fixed3LBCL-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1981.1171614149353
-  tps: 2122.823299819546
+  dps: 2002.3297211512026
+  tps: 2100.3158419976926
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll10-P1-Fixed3LBCL-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1566.2751512039893
-  tps: 1311.353116419296
+  dps: 1565.6409969118217
+  tps: 1309.0770582297632
  }
 }
 dps_results: {
@@ -1376,7 +1376,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1554.563162240393
-  tps: 1296.2218176662398
+  dps: 1559.2814863076478
+  tps: 1300.5350501238365
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -102,15 +102,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1495.0963752056766
-  tps: 1238.790961454522
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1495.0963752056766
-  tps: 1238.790961454522
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
@@ -123,15 +123,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1495.021572449414
-  tps: 1238.7458286248489
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
@@ -158,8 +158,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
@@ -200,8 +200,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
@@ -221,8 +221,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1495.0963752056766
-  tps: 1238.790961454522
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
@@ -270,22 +270,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1495.0963752056766
-  tps: 1238.790961454522
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1493.5089693618984
-  tps: 1237.4224314899666
+  dps: 1493.494181184867
+  tps: 1237.427608666565
  }
 }
 dps_results: {
@@ -305,15 +305,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1495.021572449414
-  tps: 1238.7458286248489
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1545.990091680646
-  tps: 1280.0330993818652
+  dps: 1546.001580561196
+  tps: 1280.0432325745105
  }
 }
 dps_results: {
@@ -396,8 +396,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
@@ -417,8 +417,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1529.4957970042842
-  tps: 1266.679758037601
+  dps: 1530.014794474797
+  tps: 1267.1113038445144
  }
 }
 dps_results: {
@@ -459,8 +459,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1493.4335268740388
-  tps: 1237.3871950423384
+  dps: 1493.4270719974636
+  tps: 1237.381501841199
  }
 }
 dps_results: {
@@ -473,8 +473,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1495.0963752056766
-  tps: 1238.790961454522
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
@@ -494,8 +494,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1561.505648618138
-  tps: 1292.6137945644728
+  dps: 1561.517137498688
+  tps: 1292.6239277571178
  }
 }
 dps_results: {
@@ -508,8 +508,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
@@ -571,8 +571,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1495.0963752056766
-  tps: 1238.790961454522
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
@@ -662,15 +662,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1495.021572449414
-  tps: 1238.7458286248489
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1539.6835956488553
-  tps: 1276.0731865105306
+  dps: 1539.6786278389802
+  tps: 1276.0688049022208
  }
 }
 dps_results: {
@@ -683,8 +683,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1495.021572449414
-  tps: 1238.7458286248489
+  dps: 1495.615372676189
+  tps: 1239.2225072614349
  }
 }
 dps_results: {
@@ -753,8 +753,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1492.6985776166016
-  tps: 1236.8275887098266
+  dps: 1492.7100664971515
+  tps: 1236.837721902472
  }
 }
 dps_results: {
@@ -858,8 +858,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1540.0523462510203
-  tps: 1275.2179802836329
+  dps: 1540.0638351315702
+  tps: 1275.228113476278
  }
 }
 dps_results: {
@@ -942,8 +942,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1532.743145714585
-  tps: 1270.2313678116552
+  dps: 1532.747350480535
+  tps: 1270.2310872857781
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -48,945 +48,945 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1947.4122463762317
-  tps: 1440.0952071577663
+  dps: 1915.3866584371094
+  tps: 1399.447951804181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 1958.4384133704339
-  tps: 1445.3927987977506
+  dps: 1929.9292735786748
+  tps: 1410.4374869783246
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1926.741920971395
-  tps: 1422.5402337875043
+  dps: 1885.155243547036
+  tps: 1378.6778003189695
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1938.0987767704905
-  tps: 1431.0753229951383
+  dps: 1890.5192424949578
+  tps: 1382.1897692422517
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1959.9204243482195
-  tps: 1445.9385233724608
+  dps: 1905.8564104773789
+  tps: 1393.2722772096622
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1908.9389139010937
-  tps: 1410.9090210394893
+  dps: 1876.9835842901448
+  tps: 1372.3384101850565
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1923.590839799141
-  tps: 1420.0796589731567
+  dps: 1869.6987762379465
+  tps: 1368.3605436632363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1976.6192543593847
-  tps: 1459.1319231871967
+  dps: 1924.1963007875947
+  tps: 1406.2172624576044
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1996.1468943105458
-  tps: 1472.494520274061
+  dps: 1963.4879732112872
+  tps: 1431.2140891266795
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1940.8646479705158
-  tps: 1433.0766931635249
+  dps: 1896.1437740133704
+  tps: 1385.1646003085343
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1926.8508540354524
-  tps: 1423.7830520816904
+  dps: 1873.924364389159
+  tps: 1370.5990769780142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1928.2113883514621
-  tps: 1424.2541982316284
+  dps: 1877.9933134907585
+  tps: 1373.5019721173585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1967.8478458593581
-  tps: 1454.4434930404004
+  dps: 1912.3332493827425
+  tps: 1397.65319224053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1933.5378719163293
-  tps: 1427.9074404668638
+  dps: 1883.3765765471712
+  tps: 1377.1539207711085
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 1315.7614542970362
-  tps: 995.9974904996158
+  dps: 1253.79231413205
+  tps: 942.1693897537699
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmHarness"
  value: {
-  dps: 1765.9199054334013
-  tps: 1309.2315456295685
+  dps: 1715.6220224706499
+  tps: 1256.712581543542
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmRegalia"
  value: {
-  dps: 1521.1127223895141
-  tps: 1130.9952866801607
+  dps: 1472.8694703623469
+  tps: 1091.4369811873764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1954.1853267847107
-  tps: 1441.8273611054587
+  dps: 1914.9675178534455
+  tps: 1398.2052626193333
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1941.7213914478064
-  tps: 1434.8242017862096
+  dps: 1889.1946473767305
+  tps: 1381.1675640363392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1942.432735388923
-  tps: 1437.016919464134
+  dps: 1903.944644987258
+  tps: 1391.8481297146004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1944.5512673224432
-  tps: 1435.7746428186613
+  dps: 1895.6711587415984
+  tps: 1385.8300709538962
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneHarness"
  value: {
-  dps: 1677.3659671949163
-  tps: 1244.734155980517
+  dps: 1634.137570768629
+  tps: 1198.9657182912224
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneRegalia"
  value: {
-  dps: 1498.5724155472856
-  tps: 1116.0153840133937
+  dps: 1452.709429991015
+  tps: 1075.3479711858465
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1923.8632357532392
-  tps: 1421.915925754639
+  dps: 1883.8241899410662
+  tps: 1378.1514456598836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1960.4218737581045
-  tps: 1447.0071555760471
+  dps: 1928.0563198655839
+  tps: 1409.2443098240087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1923.1891684900256
-  tps: 1422.8085721257144
+  dps: 1885.6312781697209
+  tps: 1381.3808022209937
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1928.6457902660766
-  tps: 1423.6089099755077
+  dps: 1901.446983842667
+  tps: 1388.4617397406491
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DesolationBattlegear"
  value: {
-  dps: 1620.912646223157
-  tps: 1206.708402103793
+  dps: 1571.990861821673
+  tps: 1156.6919791276823
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1922.7025978131235
-  tps: 1419.8432191715922
+  dps: 1883.4806958835409
+  tps: 1376.0749629965294
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Devastation-30316"
  value: {
-  dps: 1834.0902711329359
-  tps: 1362.8453937881213
+  dps: 1757.3098216238664
+  tps: 1293.6960155825684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1925.9530859120582
-  tps: 1423.8110582434567
+  dps: 1872.2717017868856
+  tps: 1368.9335516651408
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1932.317843254799
-  tps: 1430.3058146991557
+  dps: 1883.1423029182888
+  tps: 1377.3309833480462
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1920.3917255877022
-  tps: 1419.1993695456317
+  dps: 1881.3605562029036
+  tps: 1376.1996950070409
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1926.9968944546233
-  tps: 1423.3287562436692
+  dps: 1876.8466751173023
+  tps: 1372.5829897702
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1926.0880193309347
-  tps: 1422.8676575615814
+  dps: 1888.1059294362758
+  tps: 1381.23695097799
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Fathom-BroochoftheTidewalker-30663"
  value: {
-  dps: 1912.4852015139943
-  tps: 1411.4353825102394
+  dps: 1872.1460960023303
+  tps: 1369.1064170557695
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelstalkerArmor"
  value: {
-  dps: 1782.377889529642
-  tps: 1321.479306860255
+  dps: 1735.3069187722795
+  tps: 1272.5484095003108
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1911.4447265898725
-  tps: 1410.771346516845
+  dps: 1881.9722613238514
+  tps: 1375.9172724231485
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1939.09159617376
-  tps: 1434.585951838392
+  dps: 1905.08881991644
+  tps: 1392.6717506904504
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1971.2488652612033
-  tps: 1455.8250670276725
+  dps: 1916.779396888954
+  tps: 1400.966657297762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HandofJustice-11815"
  value: {
-  dps: 1932.4532625000868
-  tps: 1425.9188643664488
+  dps: 1900.2112297767253
+  tps: 1387.216255463793
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartrazor-29962"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1926.6577819527542
-  tps: 1424.1164624300282
+  dps: 1885.6458371847161
+  tps: 1379.5885739051248
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1951.197248510845
-  tps: 1442.1328535625494
+  dps: 1909.0424235467256
+  tps: 1394.959655814675
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1935.4429045084762
-  tps: 1429.5167453984168
+  dps: 1901.4167628518665
+  tps: 1388.996643086126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1923.8632357532392
-  tps: 1421.915925754639
+  dps: 1883.8241899410662
+  tps: 1378.1514456598836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1928.8861071830388
-  tps: 1424.7683326693832
+  dps: 1878.6303348093454
+  tps: 1374.0125178657797
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1931.1510581566579
-  tps: 1421.4313823915354
+  dps: 1884.283920004844
+  tps: 1378.0355271740818
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1936.2474078923815
-  tps: 1429.2457974032086
+  dps: 1897.3232411939473
+  tps: 1386.1158293434876
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1977.0933938281273
-  tps: 1458.130473416239
+  dps: 1935.403929236873
+  tps: 1414.2260463413272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1486.1559964003193
-  tps: 1114.2335712837032
+  dps: 1438.1646118956485
+  tps: 1068.4174052371006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1210.1345836281735
-  tps: 920.8824152333691
+  dps: 1169.516818548757
+  tps: 880.1408614530575
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1963.5601490129445
-  tps: 1448.8982835648574
+  dps: 1926.0945571946859
+  tps: 1407.092489532061
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1925.5623075060753
-  tps: 1423.0162553859036
+  dps: 1887.7286709687717
+  tps: 1381.3453108184394
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1926.9968944546233
-  tps: 1423.3287562436692
+  dps: 1876.8466751173023
+  tps: 1372.5829897702
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1916.800095732356
-  tps: 1423.6361779989843
+  dps: 1882.4440319796795
+  tps: 1377.7015344117178
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherscaleArmor"
  value: {
-  dps: 1808.6890636581513
-  tps: 1337.4708805050548
+  dps: 1758.2393509220306
+  tps: 1288.371259602076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1714.7257019507658
-  tps: 1270.511311876524
+  dps: 1665.035749103489
+  tps: 1220.5447726611046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1937.9792805955765
-  tps: 1431.5279630658347
+  dps: 1886.321757208319
+  tps: 1379.317853615382
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1926.9968944546233
-  tps: 1423.3287562436692
+  dps: 1876.8466751173023
+  tps: 1372.5829897702
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrimalIntent"
  value: {
-  dps: 1844.0280853622958
-  tps: 1370.093764456913
+  dps: 1794.4423409526173
+  tps: 1315.6703139298957
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1919.063453432263
-  tps: 1418.0624678631639
+  dps: 1881.5656006214551
+  tps: 1376.4049357054723
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1831.805193524238
-  tps: 1356.6362528067277
+  dps: 1780.4072312055919
+  tps: 1305.9586577489695
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1941.2814923531475
-  tps: 1439.8451703282851
+  dps: 1906.050876141344
+  tps: 1397.6233403381825
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1899.288123576401
-  tps: 1403.8150057106157
+  dps: 1868.8797160958027
+  tps: 1366.989947020496
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1919.5593470900117
-  tps: 1418.3706281632801
+  dps: 1886.1286839406312
+  tps: 1380.128599443547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1917.6427871145563
-  tps: 1418.6782964366314
+  dps: 1887.1216916940682
+  tps: 1379.5599354870653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1914.053920083699
-  tps: 1414.2439233143855
+  dps: 1876.8149005620655
+  tps: 1372.5967298892272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofContempt-34472"
  value: {
-  dps: 2001.3116105150807
-  tps: 1476.387386581756
+  dps: 1964.2741723397987
+  tps: 1431.9129016525858
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1930.7311849670216
-  tps: 1424.4359860913669
+  dps: 1877.4934310569072
+  tps: 1373.14892098663
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1973.4959281489678
-  tps: 1456.6885282849153
+  dps: 1919.412196935404
+  tps: 1401.4659381661538
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1914.9661033894413
-  tps: 1415.7024746474278
+  dps: 1880.455738054807
+  tps: 1374.8368278935054
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1922.6089317867945
-  tps: 1420.8100317629535
+  dps: 1879.1009800462045
+  tps: 1374.3536299565333
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1423.9453553970923
-  tps: 1072.2533643149022
+  dps: 1353.752396826421
+  tps: 1009.8342305301022
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 1953.3000768405007
-  tps: 1444.9583540883614
+  dps: 1903.681381432517
+  tps: 1391.7642662068108
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 1864.2910918672394
-  tps: 1371.0077770651997
+  dps: 1809.823810698523
+  tps: 1318.7165096744973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1390.2994021435745
-  tps: 1035.6459357539063
+  dps: 1348.65994401006
+  tps: 998.8882133064569
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1958.2710158711282
-  tps: 1446.6376899717684
+  dps: 1910.631428574998
+  tps: 1396.5915625449184
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1922.5836660555774
-  tps: 1420.7457694379814
+  dps: 1884.9039303929185
+  tps: 1379.0809722249965
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1708.4704515557773
-  tps: 1273.26076127894
+  dps: 1662.3962845687738
+  tps: 1223.9380056219816
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 1978.2540436067168
-  tps: 1460.4255104779545
+  dps: 1928.054108364397
+  tps: 1408.7900015133482
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1820.277466879826
-  tps: 1344.2146043154453
+  dps: 1771.1048022582652
+  tps: 1293.6728763054548
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1647.2973887826636
-  tps: 1230.8801954017817
+  dps: 1608.3286596834266
+  tps: 1187.271994869825
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1937.9792805955765
-  tps: 1431.5279630658347
+  dps: 1886.321757208319
+  tps: 1379.317853615382
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1928.616219650408
-  tps: 1424.5626788942816
+  dps: 1878.3755262819113
+  tps: 1373.808299566411
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1936.3847042908703
-  tps: 1430.3909360121843
+  dps: 1884.7425768598155
+  tps: 1378.195376307852
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1926.9968944546233
-  tps: 1423.3287562436692
+  dps: 1876.8466751173023
+  tps: 1372.5829897702
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheBladefist-29348"
  value: {
-  dps: 1808.868807679726
-  tps: 1342.7949922124483
+  dps: 1766.5924052257242
+  tps: 1294.6732050769476
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 1684.149786448442
-  tps: 1254.3100071917486
+  dps: 1634.7839007342689
+  tps: 1207.0252585979206
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1962.6909415030418
-  tps: 1463.4396680194677
+  dps: 1925.552081211922
+  tps: 1421.0167450125175
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1922.8139242185052
-  tps: 1421.0846633165431
+  dps: 1883.198964894972
+  tps: 1377.6605813983404
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1925.4875955921048
-  tps: 1424.6754321492044
+  dps: 1898.0974585515348
+  tps: 1388.771081455962
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheTwinStars"
  value: {
-  dps: 1884.85383873373
-  tps: 1391.6491276502327
+  dps: 1822.4244133717925
+  tps: 1334.1451710552944
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1940.954706855395
-  tps: 1436.4983811824534
+  dps: 1891.1408566528362
+  tps: 1381.7211578227425
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 1468.563702613722
-  tps: 1097.1921523706415
+  dps: 1420.5693033674854
+  tps: 1050.6584829575686
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1925.2623537395018
-  tps: 1425.2337022422942
+  dps: 1880.6112962634477
+  tps: 1376.8662599809352
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofthePulsingEarth-29389"
  value: {
-  dps: 1953.3000768405007
-  tps: 1444.9583540883614
+  dps: 1903.681381432517
+  tps: 1391.7642662068108
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1961.2911885889462
-  tps: 1446.2827438049542
+  dps: 1929.3776741753975
+  tps: 1409.9691567709328
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WastewalkerArmor"
  value: {
-  dps: 1650.0185611609472
-  tps: 1232.113756600097
+  dps: 1593.7859895650552
+  tps: 1177.7854482625376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WindhawkArmor"
  value: {
-  dps: 1703.222624374277
-  tps: 1262.551840449007
+  dps: 1663.1098885678628
+  tps: 1221.80614013964
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1479.4950156850991
-  tps: 1109.7082926827757
+  dps: 1413.4499097303114
+  tps: 1053.0315826671856
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathofSpellfire"
  value: {
-  dps: 1678.2475655437527
-  tps: 1246.123228933163
+  dps: 1633.1178967841533
+  tps: 1200.5713900899336
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1918.5283522175273
-  tps: 1418.4808916528627
+  dps: 1880.9417462108445
+  tps: 1375.260505804368
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 1950.9530074714232
-  tps: 1440.296327429343
+  dps: 1900.3715291649855
+  tps: 1389.478343697269
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2812.8658680310928
-  tps: 2654.9283235989733
+  dps: 2485.2434454840286
+  tps: 1944.698064522685
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1975.6247754040044
-  tps: 1458.3271382066564
+  dps: 1915.974408042534
+  tps: 1399.4750415229169
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2189.05981108497
-  tps: 1615.5518244130194
+  dps: 2173.8525255241743
+  tps: 1553.7609388253416
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1202.4095860736331
-  tps: 1277.6642373845605
+  dps: 685.6525020218791
+  tps: 434.1675070833257
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 693.4061019403947
-  tps: 539.226421571372
+  dps: 583.3945498188558
+  tps: 433.8426232122349
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 881.0141620556101
-  tps: 680.9291580022937
+  dps: 770.6083787612282
+  tps: 556.4726601309778
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2804.057610039967
-  tps: 2675.083619392834
+  dps: 2502.098530408619
+  tps: 1953.878238969812
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1964.1115639210811
-  tps: 1452.5263950447668
+  dps: 1914.4123011110973
+  tps: 1399.2759099818174
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2181.542533545906
-  tps: 1615.0850405101635
+  dps: 2189.3245093325045
+  tps: 1568.2965805697922
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1187.1604006980963
-  tps: 1250.8094075320246
+  dps: 679.6382645775665
+  tps: 432.8532491362411
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 682.9067108044428
-  tps: 530.4578511840049
+  dps: 575.7584269510604
+  tps: 428.54467912393557
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll10-P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 871.2507043279104
-  tps: 674.4447510969003
+  dps: 746.800173389911
+  tps: 536.777325650124
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1717.4356744467764
-  tps: 1274.6730923006717
+  dps: 1677.2472425033948
+  tps: 1232.4863173653255
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -174,8 +174,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 709.0860580435952
-  tps: 601.548265053543
+  dps: 709.3748752473397
+  tps: 601.7737591323474
  }
 }
 dps_results: {
@@ -944,15 +944,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 705.6575525978462
-  tps: 598.745442036126
+  dps: 705.7381222416225
+  tps: 598.8147971343177
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1155.8638561282862
-  tps: 1090.8007683858139
+  dps: 1163.1064729210418
+  tps: 1096.8867059615247
  }
 }
 dps_results: {
@@ -993,8 +993,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1165.3654436841332
-  tps: 1097.1997646955365
+  dps: 1168.243506160362
+  tps: 1099.4923648513861
  }
 }
 dps_results: {
@@ -1014,8 +1014,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 882.5484269912317
-  tps: 858.4063562586565
+  dps: 885.9159944266338
+  tps: 860.8470555705951
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -951,8 +951,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1153.7508674419873
-  tps: 1088.4493408600865
+  dps: 1151.6208721688513
+  tps: 1086.8985476161174
  }
 }
 dps_results: {
@@ -972,8 +972,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 884.6506283882773
-  tps: 861.9957274096336
+  dps: 875.6569073243587
+  tps: 853.730610873497
  }
 }
 dps_results: {
@@ -993,8 +993,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1168.4031157249635
-  tps: 1100.7084063685986
+  dps: 1158.877269805267
+  tps: 1091.9063077999108
  }
 }
 dps_results: {
@@ -1014,8 +1014,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 882.172453934798
-  tps: 858.1906864653622
+  dps: 890.2308294439165
+  tps: 866.7230366605916
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -48,932 +48,932 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 696.210663683986
-  tps: 590.5219059514372
+  dps: 693.1499493486103
+  tps: 588.1996992002673
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 679.4984396630186
-  tps: 576.5298229031263
+  dps: 677.7408328266347
+  tps: 575.3435118515163
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 685.7858269965039
-  tps: 582.7296570751525
+  dps: 680.6373860920793
+  tps: 578.0533108536234
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 683.9648463860071
-  tps: 580.7366795353338
+  dps: 687.631094247239
+  tps: 584.0543097945379
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 713.0773981989399
-  tps: 604.4898068281914
+  dps: 716.2087299963089
+  tps: 606.9479796783444
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 696.4164643422564
-  tps: 590.1811759281876
+  dps: 696.0275591127968
+  tps: 589.9129793658033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 696.4298228135017
-  tps: 590.1998777879309
+  dps: 696.030683984042
+  tps: 589.9234943455466
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 695.6260940124995
-  tps: 589.996439800755
+  dps: 708.1650488722863
+  tps: 600.613033624741
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 715.740042381565
-  tps: 607.178363394835
+  dps: 711.1580643685232
+  tps: 603.1009922861997
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 689.1886562203813
-  tps: 584.9887696853536
+  dps: 689.9395568739477
+  tps: 586.0449733058231
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 690.2148898765128
-  tps: 586.2972347081018
+  dps: 695.717209477691
+  tps: 590.359018486869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blinkstrike-31332"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BoldArmor"
  value: {
-  dps: 540.8692753776963
-  tps: 460.0415809214704
+  dps: 543.6885854261724
+  tps: 462.27647451547483
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 709.3748752473397
-  tps: 601.7737591323474
+  dps: 716.9296908274564
+  tps: 608.0543261490716
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 686.9435010485915
-  tps: 582.6441170256165
+  dps: 692.7625335554435
+  tps: 587.7152194702128
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 703.33183436636
-  tps: 596.8748671661705
+  dps: 707.7514874258861
+  tps: 600.7476027580956
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 710.1411024871267
-  tps: 602.6918597623059
+  dps: 713.193410939876
+  tps: 605.3456265157358
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningRage"
  value: {
-  dps: 636.6164863185033
-  tps: 539.3921864319004
+  dps: 635.287639943193
+  tps: 538.2323713794092
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 703.5329642025504
-  tps: 597.1835605825925
+  dps: 704.0696905209735
+  tps: 597.0224364744699
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 700.4906058550405
-  tps: 594.7162995291752
+  dps: 701.3365302549897
+  tps: 594.8646589909526
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 689.7815973714205
-  tps: 585.9209388967918
+  dps: 691.0700268819529
+  tps: 586.1929338943913
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 686.8438659906044
-  tps: 582.8668006485294
+  dps: 686.4051916294572
+  tps: 582.5181899937736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 694.2097529365195
-  tps: 588.8529418648785
+  dps: 698.4565411193494
+  tps: 592.8766421736149
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 678.8318142222473
-  tps: 576.6384153805734
+  dps: 681.0817412916366
+  tps: 578.1032994132053
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 683.1335953250106
-  tps: 580.1812960472357
+  dps: 682.8752523894752
+  tps: 579.4011305639169
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DesolationBattlegear"
  value: {
-  dps: 572.553195907833
-  tps: 485.9031053655133
+  dps: 570.9943305962588
+  tps: 485.05928428169847
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Despair-28573"
  value: {
-  dps: 789.7231411993357
-  tps: 662.737615611573
+  dps: 789.6240053848658
+  tps: 662.5536910875754
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestroyerArmor"
  value: {
-  dps: 556.532554961035
-  tps: 472.7370091668381
+  dps: 547.4677862873493
+  tps: 464.5376646502173
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestroyerBattlegear"
  value: {
-  dps: 655.3706715994718
-  tps: 553.1344972072649
+  dps: 652.944205046923
+  tps: 551.2966692726225
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 692.4394067039418
-  tps: 587.8384407110941
+  dps: 688.6029270924321
+  tps: 584.9005003611779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Devastation-30316"
  value: {
-  dps: 1060.300779617738
-  tps: 886.9313712536191
+  dps: 1054.1357791982828
+  tps: 881.6329946523023
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DoomplateBattlegear"
  value: {
-  dps: 585.88332955589
-  tps: 497.1344114835553
+  dps: 589.9136722125656
+  tps: 500.18113221507355
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dragonstrike-28439"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 692.359484248372
-  tps: 587.8524239010093
+  dps: 698.0041267849033
+  tps: 592.3731420731913
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 689.6264349291073
-  tps: 585.3996887512592
+  dps: 692.8339849666286
+  tps: 588.2084351333751
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 672.7418677761846
-  tps: 571.7664582237235
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FaithinFelsteel"
  value: {
-  dps: 564.8679404710016
-  tps: 481.1944296927352
+  dps: 567.75707715961
+  tps: 483.07470788711595
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FelstalkerArmor"
  value: {
-  dps: 665.1445279663378
-  tps: 565.1642098278139
+  dps: 668.7563769843033
+  tps: 567.721239941832
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 690.5319402210873
-  tps: 586.1359979216659
+  dps: 691.4318700269656
+  tps: 586.9599441185017
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 695.3293386279657
-  tps: 589.6258508484116
+  dps: 695.9977919673194
+  tps: 590.5642417005332
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FlameGuard"
  value: {
-  dps: 541.929851944847
-  tps: 460.71438254126423
+  dps: 543.381783615007
+  tps: 461.5201725637
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HandofJustice-11815"
  value: {
-  dps: 686.5459449753805
-  tps: 582.6780853065984
+  dps: 690.2574466984327
+  tps: 586.0825791721556
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heartrazor-29962"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 691.3067649434422
-  tps: 586.646817826068
+  dps: 683.3479416340954
+  tps: 580.4499241858148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 687.9883874612403
-  tps: 584.0192956481653
+  dps: 688.9115020525642
+  tps: 584.8087052101382
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 754.8428070670435
-  tps: 634.7274904512803
+  dps: 755.6468843090735
+  tps: 635.4080011696165
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 691.2436457250442
-  tps: 586.9449674355931
+  dps: 691.5411131342336
+  tps: 587.3105120659235
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LionheartChampion-28429"
  value: {
-  dps: 811.4979479937329
-  tps: 681.5699832614059
+  dps: 815.1742088528001
+  tps: 684.1228748065577
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 843.521579011317
-  tps: 708.1243144044242
+  dps: 847.114272133968
+  tps: 710.7814874261495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 699.1384249867407
-  tps: 593.0600561503463
+  dps: 703.6588012716321
+  tps: 597.0137812618
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 485.68204197054115
-  tps: 413.7819991037374
+  dps: 486.65326180408164
+  tps: 414.4289324761153
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 492.7800091792362
-  tps: 423.1099178188332
+  dps: 492.8793363846271
+  tps: 423.3185085774669
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 703.9048368406548
-  tps: 597.2685510711337
+  dps: 702.5161256608073
+  tps: 596.2842367433602
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 672.7418677761846
-  tps: 571.7664582237235
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 690.4748831847345
-  tps: 585.8314947454717
+  dps: 688.513706537433
+  tps: 584.9951040774293
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherscaleArmor"
  value: {
-  dps: 678.8114805200622
-  tps: 576.3168524746714
+  dps: 679.0197575426807
+  tps: 576.576256845002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherstrikeArmor"
  value: {
-  dps: 616.6165064766225
-  tps: 524.5244817941808
+  dps: 621.3528511804224
+  tps: 528.4467289467042
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 461.40638550489564
-  tps: 394.9758220942099
+  dps: 462.2365734130554
+  tps: 395.6757361800104
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 716.8117136491558
-  tps: 606.7831768109832
+  dps: 710.6242318844675
+  tps: 602.1501914331599
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 692.0790744039481
-  tps: 587.0755953139151
+  dps: 689.7232728100894
+  tps: 585.3656194919804
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PrimalIntent"
  value: {
-  dps: 689.4030741675326
-  tps: 585.4490222362452
+  dps: 698.1136254584354
+  tps: 592.4328716011485
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 673.0001562024122
-  tps: 571.2293561853413
+  dps: 675.3013537743564
+  tps: 573.8969305446703
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 669.0320583916023
-  tps: 568.0210094204153
+  dps: 672.3336658220213
+  tps: 571.1456798485528
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 696.2501329289386
-  tps: 590.4071698735677
+  dps: 698.2751640358179
+  tps: 592.3454352678675
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 664.1621649980327
-  tps: 564.3658723159366
+  dps: 665.8317355911291
+  tps: 565.7493712852962
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 671.1011627683833
-  tps: 570.1738347028436
+  dps: 675.6056902739517
+  tps: 573.7818498500043
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 672.7641476841693
-  tps: 571.8099304149019
+  dps: 674.9610793262519
+  tps: 573.2284105643143
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofContempt-34472"
  value: {
-  dps: 699.4934186788901
-  tps: 594.8952418371331
+  dps: 701.572834763125
+  tps: 596.8191625959196
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 686.2488183903948
-  tps: 582.3530020666855
+  dps: 687.4700326692541
+  tps: 583.6267950203644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 709.1235515307262
-  tps: 601.2503062310125
+  dps: 710.4023493928574
+  tps: 602.3397928356916
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 672.7494533657996
-  tps: 571.7893583691844
+  dps: 674.9566186078821
+  tps: 573.2160253985968
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 672.013005200316
-  tps: 570.3332235720295
+  dps: 672.6406953342289
+  tps: 571.3506850363573
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 714.1849196925567
-  tps: 601.740800544715
+  dps: 717.0309180622892
+  tps: 604.1709010691036
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 692.8239741251216
-  tps: 588.294003532276
+  dps: 694.9251209904872
+  tps: 589.6193481520892
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 672.7418677761846
-  tps: 571.7664582237235
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 583.9688767598656
-  tps: 497.46364282672016
+  dps: 593.2391918438711
+  tps: 505.19291645811523
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormGauntlets-12632"
  value: {
-  dps: 676.9761011349805
-  tps: 574.9068799922646
+  dps: 676.6428128022551
+  tps: 574.8860616106507
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 606.2231545575809
-  tps: 515.7183053327881
+  dps: 605.6064074904587
+  tps: 515.5226345029002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 692.0790744039481
-  tps: 587.0755953139151
+  dps: 689.7232728100894
+  tps: 585.3656194919804
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 690.9473821865923
-  tps: 586.2303448581852
+  dps: 693.4737476883946
+  tps: 588.7946477089959
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 692.4373848257351
-  tps: 587.8294699216049
+  dps: 688.6009052142253
+  tps: 584.8915295716887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheBladefist-29348"
  value: {
-  dps: 653.8753526544334
-  tps: 556.0040483706362
+  dps: 648.3670747368395
+  tps: 552.0110283819783
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheDecapitator-28767"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 644.9598901664233
-  tps: 547.1843455910375
+  dps: 644.4439928984675
+  tps: 547.1830400319254
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 672.7418677761846
-  tps: 571.7664582237235
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheNightBlade-31331"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 667.3570558018251
-  tps: 566.6601045228863
+  dps: 674.9454786538898
+  tps: 573.1942893030075
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 674.8711744906868
-  tps: 573.1943110201024
+  dps: 677.9522304194364
+  tps: 575.934736883636
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 812.7256115445015
-  tps: 686.9372583523342
+  dps: 807.1209982722384
+  tps: 682.196318643932
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinStars"
  value: {
-  dps: 676.1954229282428
-  tps: 573.6979292084256
+  dps: 673.5245790256445
+  tps: 571.8598736275633
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 695.926552537254
-  tps: 590.0484593451454
+  dps: 697.4017045512825
+  tps: 591.7913001778221
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 671.8202518002097
-  tps: 570.7094290745742
+  dps: 678.1241190044312
+  tps: 575.5840372241291
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 694.9385665463014
-  tps: 589.7255398739024
+  dps: 695.1175045812691
+  tps: 589.7880480034415
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarbringerArmor"
  value: {
-  dps: 531.3457023035141
-  tps: 451.41390062553046
+  dps: 533.2670310697681
+  tps: 453.1705779280294
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarbringerBattlegear"
  value: {
-  dps: 622.795243112272
-  tps: 530.1124606580742
+  dps: 625.2177404360153
+  tps: 532.4015171081451
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarpSlicer-30311"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WastewalkerArmor"
  value: {
-  dps: 584.8084133925433
-  tps: 496.30344132593325
+  dps: 586.4646263475161
+  tps: 497.68780203819364
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WindhawkArmor"
  value: {
-  dps: 616.6120457582529
-  tps: 524.5120966284633
+  dps: 621.3461719447997
+  tps: 528.4373780168326
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WorldBreaker-30090"
  value: {
-  dps: 790.94900090758
-  tps: 663.6798517369436
+  dps: 792.5346897177695
+  tps: 665.0082797199201
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofSpellfire"
  value: {
-  dps: 614.7056662881113
-  tps: 523.1631235823711
+  dps: 610.1371138738965
+  tps: 519.5457738190682
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 678.0540166996911
-  tps: 575.2251926389582
+  dps: 671.6926459167562
+  tps: 570.2241029534663
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 705.7381222416225
-  tps: 598.8147971343177
+  dps: 705.6722361234466
+  tps: 598.8016052531882
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1163.1064729210418
-  tps: 1096.8867059615247
+  dps: 1153.7508674419873
+  tps: 1088.4493408600865
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 706.8865223665988
-  tps: 600.0397460371817
+  dps: 705.8977317792835
+  tps: 599.9408914272386
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 850.7337710906379
-  tps: 721.5048563874204
+  dps: 846.4904900113283
+  tps: 718.6647361729828
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 884.7346382106774
-  tps: 862.1611510259285
+  dps: 884.6506283882773
+  tps: 861.9957274096336
  }
 }
 dps_results: {
@@ -993,29 +993,29 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1168.243506160362
-  tps: 1099.4923648513861
+  dps: 1168.4031157249635
+  tps: 1100.7084063685986
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 704.1284187089193
-  tps: 597.3418715983107
+  dps: 710.1732632645159
+  tps: 602.6165071594073
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 857.6162596488753
-  tps: 728.0044918689065
+  dps: 845.8411226988385
+  tps: 718.3677040696053
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 885.9159944266338
-  tps: 860.8470555705951
+  dps: 882.172453934798
+  tps: 858.1906864653622
  }
 }
 dps_results: {
@@ -1035,7 +1035,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 602.984485294018
-  tps: 512.8931538817181
+  dps: 600.6129846113913
+  tps: 510.83794148462385
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -48,498 +48,498 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 919.7622475555804
-  tps: 700.5138805608754
+  dps: 922.1467277288087
+  tps: 702.3392065023811
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 899.2417036100071
-  tps: 685.2822006830992
+  dps: 895.00887921614
+  tps: 681.7524413393462
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 898.9261512423706
-  tps: 684.7575260794697
+  dps: 902.2187510219549
+  tps: 687.0996265013256
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 899.2395761681737
-  tps: 684.8434784995786
+  dps: 904.9467870999812
+  tps: 689.3540706322202
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 943.6291989278355
-  tps: 720.1102549741084
+  dps: 944.1096458957497
+  tps: 720.507106527895
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 914.3049086356784
-  tps: 697.7333496759888
+  dps: 916.2768359032015
+  tps: 698.6428666728629
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 914.3049086356784
-  tps: 697.7333496759888
+  dps: 916.2768359032015
+  tps: 698.6428666728629
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 933.3651289330575
-  tps: 710.1024328955199
+  dps: 927.653833130031
+  tps: 706.0867278269989
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 941.2134611877584
-  tps: 717.0010362257857
+  dps: 943.4243447217285
+  tps: 718.6936346445217
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 906.2356307916793
-  tps: 690.5006471460275
+  dps: 909.7971977361302
+  tps: 693.4313490345236
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 918.8003936098486
-  tps: 700.6937395142508
+  dps: 914.6564085879223
+  tps: 697.5321379700406
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Blinkstrike-31332"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BoldArmor"
  value: {
-  dps: 735.0613451394177
-  tps: 557.7015504360816
+  dps: 735.0002969158633
+  tps: 557.6569945490431
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 935.8560947427984
-  tps: 714.1515941193361
+  dps: 943.7815304719219
+  tps: 720.1797383990505
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 918.8934779887717
-  tps: 700.9813954260126
+  dps: 919.0948275583872
+  tps: 701.4272101056418
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 934.1065670703127
-  tps: 712.6543808184564
+  dps: 935.4741138063899
+  tps: 713.9117798432142
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 944.5589578237757
-  tps: 721.0328219159114
+  dps: 945.0992323976117
+  tps: 720.5321435341178
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BurningRage"
  value: {
-  dps: 843.6652111530026
-  tps: 641.1207172565838
+  dps: 848.4060386508665
+  tps: 645.4776389047071
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 932.9370605294143
-  tps: 711.8523379091256
+  dps: 932.8763893361813
+  tps: 711.8098680738625
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 933.7643421409983
-  tps: 712.0759573678141
+  dps: 930.406254742272
+  tps: 709.7219082311337
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 911.5679934253469
-  tps: 694.0429940378164
+  dps: 911.5379893742893
+  tps: 694.0197685864109
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 910.0622190126797
-  tps: 693.2745722560207
+  dps: 910.5833852158698
+  tps: 693.7769434779991
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 924.0603723067884
-  tps: 703.7852693285759
+  dps: 925.4337223161606
+  tps: 704.7553550995154
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 895.7359490546565
-  tps: 681.7077315280098
+  dps: 899.2593636915528
+  tps: 684.3516568485279
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 899.4253789001632
-  tps: 685.732169385826
+  dps: 902.6108513839165
+  tps: 688.2838205090089
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DesolationBattlegear"
  value: {
-  dps: 761.1862304189123
-  tps: 578.2840908765339
+  dps: 762.082729735091
+  tps: 578.9315416084289
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Despair-28573"
  value: {
-  dps: 738.9402515241152
-  tps: 549.7479278549813
+  dps: 738.928743331165
+  tps: 549.7398721199162
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerArmor"
  value: {
-  dps: 741.6670551338206
-  tps: 563.2825915830406
+  dps: 743.1311426712989
+  tps: 564.6699869023008
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerBattlegear"
  value: {
-  dps: 869.0420018012508
-  tps: 662.8910645500592
+  dps: 865.7729145083784
+  tps: 660.2045587021546
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Devastation-30316"
  value: {
-  dps: 972.3300167838248
-  tps: 728.1383255050008
+  dps: 970.0439988427257
+  tps: 726.5782034619555
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DoomplateBattlegear"
  value: {
-  dps: 781.3320280620693
-  tps: 593.1110742565984
+  dps: 785.9584085366206
+  tps: 596.353999594325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Dragonstrike-28439"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 922.4831171009655
-  tps: 702.1604248686344
+  dps: 923.2950495933927
+  tps: 703.2327435299761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 915.0585712998425
-  tps: 698.1271152478521
+  dps: 916.696696729593
+  tps: 699.346659844209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FaithinFelsteel"
  value: {
-  dps: 766.0199293075046
-  tps: 583.4500925050321
+  dps: 761.218832534923
+  tps: 579.3139315077973
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 874.993354833459
-  tps: 667.5534943961435
+  dps: 875.7674973080358
+  tps: 668.1969594119386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 913.1398467684296
-  tps: 695.7018959121533
+  dps: 911.6990970190844
+  tps: 694.6220731820295
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 922.957358329859
-  tps: 702.5600799505862
+  dps: 924.0691501567682
+  tps: 704.2275179514168
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FlameGuard"
  value: {
-  dps: 723.9333712376766
-  tps: 550.1598816104254
+  dps: 721.0125439384149
+  tps: 547.7218977445433
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HandofJustice-11815"
  value: {
-  dps: 913.5582481112982
-  tps: 696.2809401825175
+  dps: 912.7951053942804
+  tps: 695.5867946784368
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Heartrazor-29962"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 916.5511961751416
-  tps: 698.8579388602463
+  dps: 910.5768456482868
+  tps: 693.7266655023022
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 901.881739242515
-  tps: 687.0491757379264
+  dps: 901.2102282783642
+  tps: 686.5134274767645
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 724.6173108027104
-  tps: 539.4332939418086
+  dps: 725.7033808925963
+  tps: 540.4072213750693
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 913.0484955934362
-  tps: 696.434044076529
+  dps: 912.2281494809224
+  tps: 695.7867969975166
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LionheartChampion-28429"
  value: {
-  dps: 753.3718351084359
-  tps: 561.123600626399
+  dps: 753.8199063936802
+  tps: 561.3672623758712
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 775.576872494448
-  tps: 578.5435245347436
+  dps: 775.5653643014979
+  tps: 578.5354687996786
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 931.0080443816204
-  tps: 709.008217066577
+  dps: 923.2625733070123
+  tps: 703.2229297148707
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 652.2755557537341
-  tps: 493.886082539946
+  dps: 651.9236383639936
+  tps: 493.75516607846674
  }
 }
 dps_results: {
@@ -552,43 +552,43 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 921.9887781067504
-  tps: 702.2513473645149
+  dps: 931.4929452669337
+  tps: 709.0963467214293
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 909.982205026421
-  tps: 694.5078629234773
+  dps: 908.1939837085635
+  tps: 692.6757681657282
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 891.0736725299556
-  tps: 679.858349171586
+  dps: 891.0506561440554
+  tps: 679.8422377014559
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
-  dps: 810.8681529388318
-  tps: 618.846855483508
+  dps: 811.2917589081732
+  tps: 618.9785280251332
  }
 }
 dps_results: {
@@ -601,127 +601,127 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 952.1582479013665
-  tps: 724.421461782198
+  dps: 950.4845811467945
+  tps: 723.1473583682138
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 917.4086875150398
-  tps: 700.1404793198432
+  dps: 911.0504061827083
+  tps: 695.0588436151335
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PrimalIntent"
  value: {
-  dps: 910.727980741876
-  tps: 694.4424217252026
+  dps: 912.5382394137
+  tps: 695.5272108330138
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 886.4088339480071
-  tps: 675.0808678750986
+  dps: 888.0655956190553
+  tps: 676.605507709193
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 880.4846769221764
-  tps: 671.0960952734401
+  dps: 880.3658899873371
+  tps: 671.1613099999599
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 913.1206225692445
-  tps: 694.8881272649871
+  dps: 914.4884336434245
+  tps: 695.8672383716602
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 881.6918776294201
-  tps: 671.862801224922
+  dps: 887.5618531382282
+  tps: 676.8418755580979
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 886.1938179586706
-  tps: 674.9908678797099
+  dps: 892.9834489352178
+  tps: 680.2084373268937
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShardofContempt-34472"
  value: {
-  dps: 938.8276822691914
-  tps: 714.7484272262041
+  dps: 934.4785794657241
+  tps: 710.6222997360626
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 909.5226158947619
-  tps: 693.2161709651268
+  dps: 907.1151622742374
+  tps: 691.4704386462138
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 949.9096174013554
-  tps: 724.4832097363195
+  dps: 944.2411730097878
+  tps: 719.7169852173965
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 894.1228109656545
-  tps: 681.533740712493
+  dps: 893.1058798990962
+  tps: 681.0058031832825
  }
 }
 dps_results: {
@@ -734,232 +734,232 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 919.9667421553969
-  tps: 700.4579226051696
+  dps: 919.4851632112628
+  tps: 700.108783499834
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 793.2794420596603
-  tps: 604.0483800244217
+  dps: 791.3578718992328
+  tps: 602.4897363949902
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormGauntlets-12632"
  value: {
-  dps: 891.3374487391176
-  tps: 679.9404774565401
+  dps: 896.2381914351469
+  tps: 684.0185384064347
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 796.6180250441452
-  tps: 606.8588909511287
+  dps: 798.697288597874
+  tps: 608.5535491023461
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 917.4086875150398
-  tps: 700.1404793198432
+  dps: 911.0504061827083
+  tps: 695.0588436151335
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 919.0011897619568
-  tps: 700.8074553910858
+  dps: 918.9666651831062
+  tps: 700.7812742521243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 909.7341410682559
-  tps: 693.8903771633685
+  dps: 911.7724983657304
+  tps: 695.0074665934623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheBladefist-29348"
  value: {
-  dps: 901.1301099368065
-  tps: 687.3359703584945
+  dps: 898.4084786160159
+  tps: 685.61921756324
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheDecapitator-28767"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 923.534004525602
-  tps: 701.5072587656792
+  dps: 922.8011218660274
+  tps: 701.3456384192342
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheNightBlade-31331"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 891.5947402294
-  tps: 679.0214894576975
+  dps: 891.5841307715184
+  tps: 679.012206182051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1024.8869202096305
-  tps: 779.8222967200278
+  dps: 1023.9838853955022
+  tps: 778.9851302690004
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinStars"
  value: {
-  dps: 897.605937596249
-  tps: 684.647879913873
+  dps: 893.1383380917164
+  tps: 680.8516143733085
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 928.8978560116298
-  tps: 708.9403444805382
+  dps: 928.8079139077367
+  tps: 708.4156004819829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 894.6444633283483
-  tps: 681.1562956269612
+  dps: 894.6338538704665
+  tps: 681.1470123513147
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 923.43790581279
-  tps: 703.4270052405327
+  dps: 919.4890893899266
+  tps: 700.8287595858066
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerArmor"
  value: {
-  dps: 718.6180057599948
-  tps: 545.3234054572936
+  dps: 717.8200187703766
+  tps: 544.6850955437899
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerBattlegear"
  value: {
-  dps: 831.362732886164
-  tps: 634.7621675513063
+  dps: 832.181345969806
+  tps: 635.1939130978407
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarpSlicer-30311"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WastewalkerArmor"
  value: {
-  dps: 771.5839170489292
-  tps: 586.7546955444244
+  dps: 768.517530110051
+  tps: 584.265715499274
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 810.8681529388318
-  tps: 618.846855483508
+  dps: 811.2917589081732
+  tps: 618.9785280251332
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WorldBreaker-30090"
  value: {
-  dps: 761.5661734068531
-  tps: 567.0231612102933
+  dps: 765.1256719137797
+  tps: 570.2334208465119
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 803.3305851189127
-  tps: 612.6290074436539
+  dps: 800.783120133501
+  tps: 610.9107014781614
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 886.1938179586706
-  tps: 674.9908678797099
+  dps: 892.9834489352178
+  tps: 680.2084373268937
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 934.7551436858777
-  tps: 712.9395402195032
+  dps: 934.8391771595994
+  tps: 713.0364479847583
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1565.5973249293475
-  tps: 1327.7711731282945
+  dps: 1568.9175183405532
+  tps: 1330.7051725760612
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 932.5886119550834
-  tps: 711.3577561961654
+  dps: 938.053391260226
+  tps: 715.48602812048
  }
 }
 dps_results: {
@@ -972,15 +972,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1148.9374057361163
-  tps: 1002.8386672229334
+  dps: 1142.3697575804263
+  tps: 997.0254363448165
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 657.1526563932744
-  tps: 499.9294166856689
+  dps: 657.1480608347877
+  tps: 499.9253955719929
  }
 }
 dps_results: {
@@ -993,15 +993,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1566.2876742245237
-  tps: 1325.9444133480968
+  dps: 1579.0567237309263
+  tps: 1336.6852532332412
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 935.6041715099019
-  tps: 713.5757849196386
+  dps: 936.5252103789651
+  tps: 714.9419329324209
  }
 }
 dps_results: {
@@ -1014,15 +1014,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1163.552142568367
-  tps: 1012.9757388223301
+  dps: 1155.111652357442
+  tps: 1005.8699941276293
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 659.2047130077792
-  tps: 501.3066482808008
+  dps: 659.1873964274541
+  tps: 501.29336799162496
  }
 }
 dps_results: {
@@ -1035,7 +1035,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 811.4271699432932
-  tps: 620.5119681775706
+  dps: 810.2729383384087
+  tps: 619.5403589587014
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -48,498 +48,498 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 921.97323395021
-  tps: 702.4180395720277
+  dps: 919.7622475555804
+  tps: 700.5138805608754
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 894.9996296039152
-  tps: 681.745347702912
+  dps: 899.2417036100071
+  tps: 685.2822006830992
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 900.1470060016526
-  tps: 685.5453519053664
+  dps: 898.9261512423706
+  tps: 684.7575260794697
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 904.9352789070311
-  tps: 689.3460148971551
+  dps: 899.2395761681737
+  tps: 684.8434784995786
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 944.075650850349
-  tps: 720.4819038374184
+  dps: 943.6291989278355
+  tps: 720.1102549741084
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 916.2648179364472
-  tps: 698.6333507262154
+  dps: 914.3049086356784
+  tps: 697.7333496759888
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 916.2648179364472
-  tps: 698.6333507262154
+  dps: 914.3049086356784
+  tps: 697.7333496759888
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 931.7880524551808
-  tps: 709.6510841505706
+  dps: 933.3651289330575
+  tps: 710.1024328955199
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 943.4133648879229
-  tps: 718.6850270642042
+  dps: 941.2134611877584
+  tps: 717.0010362257857
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 906.6959439397017
-  tps: 691.2532782852779
+  dps: 906.2356307916793
+  tps: 690.5006471460275
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 914.6506955921365
-  tps: 697.5281388729904
+  dps: 918.8003936098486
+  tps: 700.6937395142508
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Blinkstrike-31332"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BoldArmor"
  value: {
-  dps: 735.0002969158633
-  tps: 557.6569945490431
+  dps: 735.0613451394177
+  tps: 557.7015504360816
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 943.7571245539243
-  tps: 720.1616544821899
+  dps: 935.8560947427984
+  tps: 714.1515941193361
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 919.0829662909458
-  tps: 701.4178312708932
+  dps: 918.8934779887717
+  tps: 700.9813954260126
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 932.9755171566463
-  tps: 712.0581497599233
+  dps: 934.1065670703127
+  tps: 712.6543808184564
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 937.6714610868817
-  tps: 715.5165462080721
+  dps: 944.5589578237757
+  tps: 721.0328219159114
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BurningRage"
  value: {
-  dps: 848.3998903792111
-  tps: 645.4722591670087
+  dps: 843.6652111530026
+  tps: 641.1207172565838
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 932.8763893361813
-  tps: 711.8098680738625
+  dps: 932.9370605294143
+  tps: 711.8523379091256
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 930.3875618200605
-  tps: 709.7088231855856
+  dps: 933.7643421409983
+  tps: 712.0759573678141
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 919.5818957155726
-  tps: 701.1352284263637
+  dps: 911.5679934253469
+  tps: 694.0429940378164
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 912.8084662468297
-  tps: 695.0899789840992
+  dps: 910.0622190126797
+  tps: 693.2745722560207
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 888.5317126177944
-  tps: 676.2525637253214
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 925.4301856997216
-  tps: 704.7522605601313
+  dps: 924.0603723067884
+  tps: 703.7852693285759
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 899.2540968535333
-  tps: 684.3470483652605
+  dps: 895.7359490546565
+  tps: 681.7077315280098
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 902.5978714574907
-  tps: 688.2747345605109
+  dps: 899.4253789001632
+  tps: 685.732169385826
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DesolationBattlegear"
  value: {
-  dps: 762.082729735091
-  tps: 578.9315416084289
+  dps: 761.1862304189123
+  tps: 578.2840908765339
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Despair-28573"
  value: {
-  dps: 738.928743331165
-  tps: 549.7398721199162
+  dps: 738.9402515241152
+  tps: 549.7479278549813
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerArmor"
  value: {
-  dps: 743.1311426712989
-  tps: 564.6699869023008
+  dps: 741.6670551338206
+  tps: 563.2825915830406
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerBattlegear"
  value: {
-  dps: 865.7610532409371
-  tps: 660.195179867406
+  dps: 869.0420018012508
+  tps: 662.8910645500592
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Devastation-30316"
  value: {
-  dps: 970.0439988427257
-  tps: 726.5782034619555
+  dps: 972.3300167838248
+  tps: 728.1383255050008
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DoomplateBattlegear"
  value: {
-  dps: 785.9526955408345
-  tps: 596.3500004972748
+  dps: 781.3320280620693
+  tps: 593.1110742565984
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Dragonstrike-28439"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 919.8585682224289
-  tps: 700.2929494737815
+  dps: 922.4831171009655
+  tps: 702.1604248686344
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 916.6909837338071
-  tps: 699.3426607471588
+  dps: 915.0585712998425
+  tps: 698.1271152478521
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FaithinFelsteel"
  value: {
-  dps: 761.2062639441938
-  tps: 579.3051334942869
+  dps: 766.0199293075046
+  tps: 583.4500925050321
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 875.7617843122498
-  tps: 668.1929603148883
+  dps: 874.993354833459
+  tps: 667.5534943961435
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 888.5317126177944
-  tps: 676.2525637253214
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 911.1535704387898
-  tps: 693.9799948005242
+  dps: 913.1398467684296
+  tps: 695.7018959121533
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 923.3694184664578
-  tps: 702.9517405037213
+  dps: 922.957358329859
+  tps: 702.5600799505862
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FlameGuard"
  value: {
-  dps: 720.9999753476858
-  tps: 547.7130997310329
+  dps: 723.9333712376766
+  tps: 550.1598816104254
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HandofJustice-11815"
  value: {
-  dps: 912.7951053942804
-  tps: 695.5867946784368
+  dps: 913.5582481112982
+  tps: 696.2809401825175
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Heartrazor-29962"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 888.5317126177944
-  tps: 676.2525637253214
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 910.5581527260751
-  tps: 693.7135804567541
+  dps: 916.5511961751416
+  tps: 698.8579388602463
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 903.4320440018867
-  tps: 688.4355875987612
+  dps: 901.881739242515
+  tps: 687.0491757379264
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 888.5317126177944
-  tps: 676.2525637253214
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 725.7033808925963
-  tps: 540.4072213750693
+  dps: 724.6173108027104
+  tps: 539.4332939418086
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 913.6724231538846
-  tps: 696.5819920073138
+  dps: 913.0484955934362
+  tps: 696.434044076529
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LionheartChampion-28429"
  value: {
-  dps: 753.8199063936802
-  tps: 561.3672623758712
+  dps: 753.3718351084359
+  tps: 561.123600626399
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 775.5653643014979
-  tps: 578.5354687996786
+  dps: 775.576872494448
+  tps: 578.5435245347436
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 923.2625733070123
-  tps: 703.2229297148707
+  dps: 931.0080443816204
+  tps: 709.008217066577
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 651.9201017475547
-  tps: 493.7520715390827
+  dps: 652.2755557537341
+  tps: 493.886082539946
  }
 }
 dps_results: {
@@ -552,43 +552,43 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 931.4929452669337
-  tps: 709.0963467214293
+  dps: 921.9887781067504
+  tps: 702.2513473645149
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 908.1825577169916
-  tps: 692.667769971628
+  dps: 909.982205026421
+  tps: 694.5078629234773
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 891.0506561440554
-  tps: 679.8422377014559
+  dps: 891.0736725299556
+  tps: 679.858349171586
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
-  dps: 811.2707437891983
-  tps: 618.9624112831546
+  dps: 810.8681529388318
+  tps: 618.846855483508
  }
 }
 dps_results: {
@@ -601,127 +601,127 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 950.464641335779
-  tps: 723.133400500503
+  dps: 952.1582479013665
+  tps: 724.421461782198
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 911.0321245961933
-  tps: 695.046046504573
+  dps: 917.4086875150398
+  tps: 700.1404793198432
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PrimalIntent"
  value: {
-  dps: 912.532526417914
-  tps: 695.5232117359635
+  dps: 910.727980741876
+  tps: 694.4424217252026
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 888.0655956190553
-  tps: 676.605507709193
+  dps: 886.4088339480071
+  tps: 675.0808678750986
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 880.3566403751122
-  tps: 671.1542163635257
+  dps: 880.4846769221764
+  tps: 671.0960952734401
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 914.4561688196046
-  tps: 695.8435496250668
+  dps: 913.1206225692445
+  tps: 694.8881272649871
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 887.5618531382282
-  tps: 676.8418755580979
+  dps: 881.6918776294201
+  tps: 671.862801224922
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 893.1633490366937
-  tps: 680.6880988663708
+  dps: 886.1938179586706
+  tps: 674.9908678797099
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShardofContempt-34472"
  value: {
-  dps: 934.4728664699383
-  tps: 710.6183006390124
+  dps: 938.8276822691914
+  tps: 714.7484272262041
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 907.1021823478118
-  tps: 691.4613526977156
+  dps: 909.5226158947619
+  tps: 693.2161709651268
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 944.2411730097878
-  tps: 719.7169852173965
+  dps: 949.9096174013554
+  tps: 724.4832097363195
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 894.1393406950041
-  tps: 681.7441415561573
+  dps: 894.1228109656545
+  tps: 681.533740712493
  }
 }
 dps_results: {
@@ -734,232 +734,232 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 923.9372961193911
-  tps: 703.1297670163644
+  dps: 919.9667421553969
+  tps: 700.4579226051696
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 791.3201661270455
-  tps: 602.4633423544592
+  dps: 793.2794420596603
+  tps: 604.0483800244217
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormGauntlets-12632"
  value: {
-  dps: 896.219498512935
-  tps: 684.0054533608865
+  dps: 891.3374487391176
+  tps: 679.9404774565401
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 798.697288597874
-  tps: 608.5535491023461
+  dps: 796.6180250441452
+  tps: 606.8588909511287
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 911.0321245961933
-  tps: 695.046046504573
+  dps: 917.4086875150398
+  tps: 700.1404793198432
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 918.9666651831062
-  tps: 700.7812742521243
+  dps: 919.0011897619568
+  tps: 700.8074553910858
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 911.7724983657304
-  tps: 695.0074665934623
+  dps: 909.7341410682559
+  tps: 693.8903771633685
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheBladefist-29348"
  value: {
-  dps: 898.3954986895903
-  tps: 685.6101316147419
+  dps: 901.1301099368065
+  tps: 687.3359703584945
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheDecapitator-28767"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 922.8011218660274
-  tps: 701.3456384192342
+  dps: 923.534004525602
+  tps: 701.5072587656792
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 891.5841307715184
-  tps: 679.012206182051
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheNightBlade-31331"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 888.5317126177944
-  tps: 676.2525637253214
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 888.5317126177944
-  tps: 676.2525637253214
+  dps: 891.5947402294
+  tps: 679.0214894576975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1023.9803487790632
-  tps: 778.9820357296163
+  dps: 1024.8869202096305
+  tps: 779.8222967200278
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinStars"
  value: {
-  dps: 893.13339335784
-  tps: 680.8472877311667
+  dps: 897.605937596249
+  tps: 684.647879913873
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 928.7887073599994
-  tps: 708.4007943012375
+  dps: 928.8978560116298
+  tps: 708.9403444805382
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 894.6338538704665
-  tps: 681.1470123513147
+  dps: 894.6444633283483
+  tps: 681.1562956269612
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 919.4719504025687
-  tps: 700.8167622946561
+  dps: 923.43790581279
+  tps: 703.4270052405327
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerArmor"
  value: {
-  dps: 717.8200187703766
-  tps: 544.6850955437899
+  dps: 718.6180057599948
+  tps: 545.3234054572936
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerBattlegear"
  value: {
-  dps: 832.1687773790769
-  tps: 635.1851150843303
+  dps: 831.362732886164
+  tps: 634.7621675513063
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarpSlicer-30311"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WastewalkerArmor"
  value: {
-  dps: 768.517530110051
-  tps: 584.265715499274
+  dps: 771.5839170489292
+  tps: 586.7546955444244
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 811.2707437891983
-  tps: 618.9624112831546
+  dps: 810.8681529388318
+  tps: 618.846855483508
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WorldBreaker-30090"
  value: {
-  dps: 765.1256719137797
-  tps: 570.2334208465119
+  dps: 761.5661734068531
+  tps: 567.0231612102933
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 800.783120133501
-  tps: 610.9107014781614
+  dps: 803.3305851189127
+  tps: 612.6290074436539
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 893.1633490366937
-  tps: 680.6880988663708
+  dps: 886.1938179586706
+  tps: 674.9908678797099
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 934.827623325561
-  tps: 713.0280579151706
+  dps: 934.7551436858777
+  tps: 712.9395402195032
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1571.8833911311397
-  tps: 1332.6474502248084
+  dps: 1565.5973249293475
+  tps: 1327.7711731282945
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 938.0404113338004
-  tps: 715.4769421719819
+  dps: 932.5886119550834
+  tps: 711.3577561961654
  }
 }
 dps_results: {
@@ -972,15 +972,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1152.2921648079453
-  tps: 1005.6007444152178
+  dps: 1148.9374057361163
+  tps: 1002.8386672229334
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 657.1480608347877
-  tps: 499.9253955719929
+  dps: 657.1526563932744
+  tps: 499.9294166856689
  }
 }
 dps_results: {
@@ -993,15 +993,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1568.2804327550245
-  tps: 1328.3684026779383
+  dps: 1566.2876742245237
+  tps: 1325.9444133480968
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 936.5252103789651
-  tps: 714.9419329324209
+  dps: 935.6041715099019
+  tps: 713.5757849196386
  }
 }
 dps_results: {
@@ -1014,15 +1014,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1155.111652357442
-  tps: 1005.8699941276293
+  dps: 1163.552142568367
+  tps: 1012.9757388223301
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 659.1767008925474
-  tps: 501.28588111719034
+  dps: 659.2047130077792
+  tps: 501.3066482808008
  }
 }
 dps_results: {
@@ -1035,7 +1035,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 810.2465802081368
-  tps: 619.5205668561007
+  dps: 811.4271699432932
+  tps: 620.5119681775706
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -48,7 +48,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.26459995003330394
+  weights: 0.26456870811068145
   weights: 0
   weights: 0
   weights: 0
@@ -66,7 +66,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10173900528684726
+  weights: 0.10181030095643223
   weights: 0
   weights: 0
   weights: 0
@@ -75,12 +75,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.008354662997055583
+  weights: -0.008329562648960974
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13383063535252063
-  weights: -0.043305009720526186
+  weights: 0.13385279842583372
+  weights: -0.043290056321662856
   weights: 0
   weights: 0
   weights: 0
@@ -95,43 +95,43 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 491.1259727349893
-  tps: 861.6732975720166
+  dps: 491.1233024851922
+  tps: 861.6692257081008
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 480.7859427805883
-  tps: 843.6791400580079
+  dps: 480.78327253079107
+  tps: 843.675068194092
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 480.6347071681016
-  tps: 844.712300928166
+  dps: 480.6288326185479
+  tps: 844.7033428275515
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 483.38423405911203
-  tps: 847.827298859936
+  dps: 483.36242366390815
+  tps: 847.5908414938328
  }
 }
 dps_results: {
@@ -144,148 +144,148 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 488.37701469253943
-  tps: 854.4472928620114
+  dps: 488.3684698931886
+  tps: 854.4342628974814
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 484.4831404221866
-  tps: 848.5505530241168
+  dps: 484.4745956228357
+  tps: 848.5375230595869
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 498.7590342044895
-  tps: 873.6339334534845
+  dps: 498.7576990795909
+  tps: 873.6318975215268
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 508.6047583275733
-  tps: 891.7261997366732
+  dps: 508.6007529528776
+  tps: 891.7200919407996
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 483.7164671960441
-  tps: 848.5098769790486
+  dps: 483.71352992126725
+  tps: 848.5053979287413
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 483.59649940297066
-  tps: 847.1137705322465
+  dps: 483.5951642780721
+  tps: 847.1117346002885
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 494.7765180520818
-  tps: 867.5596563677407
+  dps: 494.7722456524064
+  tps: 867.5531413854756
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 460.68681541715176
-  tps: 794.3134792206666
+  dps: 460.68387814237497
+  tps: 794.3090879948752
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 491.02029725330095
-  tps: 859.625212170166
+  dps: 491.0133546038282
+  tps: 859.6146253239853
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 488.3537752794707
-  tps: 855.2139282718647
+  dps: 488.3481677548968
+  tps: 855.2053773576417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 494.1961427738547
-  tps: 865.8226421539116
+  dps: 494.1877809867981
+  tps: 865.8098912648289
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 496.1929224820758
-  tps: 868.9924724456399
+  dps: 496.18842022125847
+  tps: 868.9856069481197
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 500.1805700634801
-  tps: 859.3763072694112
+  dps: 500.17763278870325
+  tps: 859.3719160436198
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 495.43806185699447
-  tps: 866.7144038255143
+  dps: 495.4323582034278
+  tps: 866.7057063241905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 486.30457957059957
-  tps: 851.6350957298472
+  dps: 486.303244445701
+  tps: 851.6330597978895
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
@@ -305,92 +305,92 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 490.75867476945416
-  tps: 860.2814817261087
+  dps: 490.7546693947585
+  tps: 860.2753739302352
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 489.44427065903966
-  tps: 858.7838478219674
+  dps: 489.44026528434387
+  tps: 858.7777400260939
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DesolationBattlegear"
  value: {
-  dps: 463.2713754120599
-  tps: 798.5034404463431
+  dps: 463.26843813728306
+  tps: 798.4990492205517
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Despair-28573"
  value: {
-  dps: 601.3863178528007
-  tps: 1019.3163627832984
+  dps: 601.3442614184958
+  tps: 1019.2522309266269
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 482.26558338676296
-  tps: 827.5490487906802
+  dps: 482.2613109870875
+  tps: 827.5426615531655
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 522.4837122781112
-  tps: 895.9211571704989
+  dps: 522.4794398784358
+  tps: 895.9147699329842
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 484.4831404221866
-  tps: 848.5505530241168
+  dps: 484.4745956228357
+  tps: 848.5375230595869
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 804.14759738043
-  tps: 1347.374663086571
+  dps: 804.0654871991683
+  tps: 1347.249453271165
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 484.4222926009573
-  tps: 832.8537287723957
+  dps: 484.4166850763833
+  tps: 832.8453455231576
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonmaw-28438"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
@@ -403,92 +403,92 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 494.7765180520818
-  tps: 867.5596563677407
+  dps: 494.7722456524064
+  tps: 867.5531413854756
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 490.63879587487753
-  tps: 859.503470252622
+  dps: 490.63452347520206
+  tps: 859.4969552703571
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FaithinFelsteel"
  value: {
-  dps: 446.5164907528625
-  tps: 769.2697822453468
+  dps: 446.51382050306546
+  tps: 769.2657902219001
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 476.86602812483693
-  tps: 836.1913003536513
+  dps: 476.86335787503987
+  tps: 836.1872284897357
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 489.02970080577524
-  tps: 857.7498509418375
+  dps: 489.0256954310796
+  tps: 857.7437431459641
  }
 }
 dps_results: {
@@ -501,442 +501,442 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FlameGuard"
  value: {
-  dps: 425.9104927132118
-  tps: 736.0827338908417
+  dps: 425.90915758831324
+  tps: 736.0807378791184
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 491.2979219106336
-  tps: 862.4549294613182
+  dps: 491.296586785735
+  tps: 862.4528935293605
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartrazor-29962"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 488.17460559994623
-  tps: 856.1320020776484
+  dps: 488.1732704750477
+  tps: 856.1299661456907
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 596.588195537994
-  tps: 1015.8166211592309
+  dps: 596.5184352620437
+  tps: 1015.710243714434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 488.9594345093326
-  tps: 858.4146427447236
+  dps: 488.9567642595354
+  tps: 858.4105708808079
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 613.3860194744298
-  tps: 1039.1527479327751
+  dps: 613.3392901029798
+  tps: 1039.0814903142516
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 635.394141465118
-  tps: 1073.9995027537245
+  dps: 635.3367310944797
+  tps: 1073.9119576795376
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 489.67170678949054
-  tps: 858.6229764360687
+  dps: 489.6690081961014
+  tps: 858.6188613510097
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 408.05580666213405
-  tps: 707.0048933119019
+  dps: 408.0544715372355
+  tps: 707.0028973001786
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 452.8208062631102
-  tps: 810.0917102895269
+  dps: 452.72501105163775
+  tps: 809.9456321715527
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 494.5446658110526
-  tps: 866.6032179599836
+  dps: 494.5417285362757
+  tps: 866.5987389096765
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 487.0339896954088
-  tps: 853.6820827758746
+  dps: 487.03131944561164
+  tps: 853.678010911959
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 446.1458603513157
-  tps: 784.9220692538233
+  dps: 446.1431901015185
+  tps: 784.9179973899076
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 449.34896757447024
-  tps: 772.6629397878703
+  dps: 449.3433600498963
+  tps: 772.654556538632
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 625.7174611932236
-  tps: 1066.2605436387848
+  dps: 625.7101868732714
+  tps: 1066.2496685304561
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 489.9909674513949
-  tps: 857.4145507482161
+  dps: 489.9869620766993
+  tps: 857.4084429523427
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 499.15301091003573
-  tps: 873.782501837666
+  dps: 499.14900553533994
+  tps: 873.7763940417926
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 497.90982814760537
-  tps: 871.3019658418224
+  dps: 497.90679474383586
+  tps: 871.2973402044142
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 469.0983623115754
-  tps: 823.6281327735998
+  dps: 469.0970271866769
+  tps: 823.626096841642
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 484.2541140898831
-  tps: 848.1969415716194
+  dps: 484.24850656530907
+  tps: 848.1883906573966
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 472.0881580889117
-  tps: 829.0493222779577
+  dps: 472.08255056433774
+  tps: 829.0407713637348
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 477.5513780397043
-  tps: 838.7111921300175
+  dps: 477.5488143760681
+  tps: 838.7072827993386
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 474.42075403994767
-  tps: 833.2477874157356
+  dps: 474.4122092405968
+  tps: 833.2347574512055
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 519.1386982444561
-  tps: 907.6599153693877
+  dps: 519.1344258447807
+  tps: 907.6534003871228
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 479.2689346282878
-  tps: 840.098414467318
+  dps: 479.2630600787341
+  tps: 840.0894563667035
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 498.17370708667085
-  tps: 871.405167101525
+  dps: 498.1723719617723
+  tps: 871.4031311695672
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 474.40622663999244
-  tps: 833.2090199594002
+  dps: 474.3976818406416
+  tps: 833.1959899948702
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 475.63015167674587
-  tps: 835.4625944940541
+  dps: 475.62630618129157
+  tps: 835.4567304980359
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 601.4808673344728
-  tps: 1028.441489237148
+  dps: 601.4054327777036
+  tps: 1028.3264590815304
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 491.8535900978087
-  tps: 862.4807153590988
+  dps: 491.85225497291015
+  tps: 862.4786794271408
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 459.4304566503456
-  tps: 808.140328917114
+  dps: 459.4277864005484
+  tps: 808.1362570531982
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormGauntlets-12632"
  value: {
-  dps: 470.24925724114246
-  tps: 808.410334245063
+  dps: 470.24792211624384
+  tps: 808.4083382333396
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 461.59435989943216
-  tps: 811.0624042048319
+  dps: 461.59035452473654
+  tps: 811.0562964089582
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 489.9909674513949
-  tps: 857.4145507482161
+  dps: 489.9869620766993
+  tps: 857.4084429523427
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 489.76108851360533
-  tps: 857.383615009749
+  dps: 489.7597533887069
+  tps: 857.381579077791
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 494.0750963670024
-  tps: 863.516139229754
+  dps: 494.0710909923067
+  tps: 863.5100314338805
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheDecapitator-28767"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 629.8082546071223
-  tps: 1089.126840179589
+  dps: 629.7599230857941
+  tps: 1089.0531394427157
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheNightBlade-31331"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 474.3717717673707
-  tps: 833.0906979254218
+  dps: 474.3632269680199
+  tps: 833.0776679608915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 479.5172155349038
-  tps: 841.4906124626586
+  dps: 479.5158804100052
+  tps: 841.4885765307009
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 708.8016210910649
-  tps: 1220.8627186972544
+  dps: 708.7185763223736
+  tps: 1220.7360837294775
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinStars"
  value: {
-  dps: 479.2689346282878
-  tps: 840.098414467318
+  dps: 479.2630600787341
+  tps: 840.0894563667035
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 490.7306656425562
-  tps: 859.4030900124537
+  dps: 490.7263932428808
+  tps: 859.3965750301887
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 481.3381673836986
-  tps: 844.3110012726314
+  dps: 481.3325598591246
+  tps: 844.3024503584084
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 491.85865806800985
-  tps: 862.4857915857423
+  dps: 491.8573229431113
+  tps: 862.4837556537844
  }
 }
 dps_results: {
@@ -949,65 +949,65 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 514.9757241710131
-  tps: 890.1814716417923
+  dps: 514.9743890461145
+  tps: 890.1794756300687
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 484.45879720769784
-  tps: 848.4724030193768
+  dps: 484.450252408347
+  tps: 848.4593730548467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 468.05641591182496
-  tps: 807.0138196205099
+  dps: 468.04813813745386
+  tps: 807.0014443478249
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 446.13304865682716
-  tps: 784.8615036639309
+  dps: 446.1303784070299
+  tps: 784.8574318000153
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 620.4106791176072
-  tps: 1049.597091706743
+  dps: 620.3589430277876
+  tps: 1049.518199343377
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 435.08584500899167
-  tps: 750.6160681072851
+  dps: 435.0845098840931
+  tps: 750.6140720955617
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 475.66810941806347
-  tps: 835.5836700402951
+  dps: 475.66426392260934
+  tps: 835.5778060442768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 607.7959485917183
-  tps: 1184.7176279161797
+  dps: 607.7707224103257
+  tps: 1184.6791605121766
   dtps: 506.2130352389552
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SelfDrums-DPS"
  value: {
-  dps: 608.3031883505033
-  tps: 1186.0400494124724
+  dps: 608.2911722264163
+  tps: 1186.021726024852
   dtps: 510.93505061080145
  }
 }
@@ -1056,15 +1056,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 557.6213018595191
-  tps: 1105.6112536962946
+  dps: 557.6159613599248
+  tps: 1105.6031099684633
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 547.9921470431026
-  tps: 954.0643800689352
+  dps: 547.9836022437518
+  tps: 954.0513501044053
  }
 }
 dps_results: {
@@ -1098,8 +1098,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 681.0224052690542
-  tps: 1307.1673814485848
+  dps: 680.9975719459408
+  tps: 1307.1295131141696
   dtps: 460.05300905876976
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -48,7 +48,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.2652171699348014
+  weights: 0.26459995003330394
   weights: 0
   weights: 0
   weights: 0
@@ -66,7 +66,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10131267514878005
+  weights: 0.10173900528684726
   weights: 0
   weights: 0
   weights: 0
@@ -75,12 +75,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.008638558599124053
+  weights: -0.008354662997055583
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13326887228869735
-  weights: -0.0422778597020374
+  weights: 0.13383063535252063
+  weights: -0.043305009720526186
   weights: 0
   weights: 0
   weights: 0
@@ -95,934 +95,934 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 493.576183033641
-  tps: 866.0143816210098
+  dps: 491.1259727349893
+  tps: 861.6732975720166
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 480.78007868044233
-  tps: 843.6701978916951
+  dps: 480.7859427805883
+  tps: 843.6791400580079
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 483.3727213062464
-  tps: 848.5069430577212
+  dps: 480.6347071681016
+  tps: 844.712300928166
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 483.35690869293995
-  tps: 847.5818677997224
+  dps: 483.38423405911203
+  tps: 847.827298859936
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 502.7257878625994
-  tps: 879.4633607416127
+  dps: 502.77863931585523
+  tps: 879.5439539226824
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 488.3373745077494
-  tps: 854.386845544225
+  dps: 488.37701469253943
+  tps: 854.4472928620114
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 484.44369425948605
-  tps: 848.4904015706151
+  dps: 484.4831404221866
+  tps: 848.5505530241168
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 499.37403669952585
-  tps: 874.3654983044885
+  dps: 498.7590342044895
+  tps: 873.6339334534845
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 508.5974088922634
-  tps: 891.7144286678879
+  dps: 508.6047583275733
+  tps: 891.7261997366732
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 486.83942732641697
-  tps: 854.2068818554213
+  dps: 483.7164671960441
+  tps: 848.5098769790486
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 483.5817367923712
-  tps: 847.0912590273431
+  dps: 483.59649940297066
+  tps: 847.1137705322465
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 495.90697528804395
-  tps: 868.6786417301232
+  dps: 494.7765180520818
+  tps: 867.5596563677407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 460.657099622005
-  tps: 794.2690541069221
+  dps: 460.68681541715176
+  tps: 794.3134792206666
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 490.96786045923255
-  tps: 859.5446873880102
+  dps: 491.02029725330095
+  tps: 859.625212170166
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 488.3318004031518
-  tps: 855.1804187829658
+  dps: 488.3537752794707
+  tps: 855.2139282718647
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 494.16671669276525
-  tps: 865.7777703228584
+  dps: 494.1961427738547
+  tps: 865.8226421539116
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 496.15291065349754
-  tps: 868.9314584082412
+  dps: 496.1929224820758
+  tps: 868.9924724456399
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 500.14843546687734
-  tps: 859.32826604749
+  dps: 500.1805700634801
+  tps: 859.3763072694112
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 495.415983616859
-  tps: 866.6807367171318
+  dps: 495.43806185699447
+  tps: 866.7144038255143
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 486.2620312435312
-  tps: 851.5702137859004
+  dps: 486.30457957059957
+  tps: 851.6350957298472
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 489.00918547317616
-  tps: 857.4760589076317
+  dps: 489.3732068489473
+  tps: 858.3516839443236
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 489.0972272419794
-  tps: 857.7339928168922
+  dps: 489.2541774177356
+  tps: 857.9221672104362
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 474.2668493282584
-  tps: 832.1717241349374
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 490.7443961746181
-  tps: 860.2597082968432
+  dps: 490.75867476945416
+  tps: 860.2814817261087
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 489.435667047014
-  tps: 858.7701642591082
+  dps: 489.44427065903966
+  tps: 858.7838478219674
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DesolationBattlegear"
  value: {
-  dps: 463.26612037261543
-  tps: 798.495031304647
+  dps: 463.2713754120599
+  tps: 798.5034404463431
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Despair-28573"
  value: {
-  dps: 601.3116196043121
-  tps: 1019.2004048246101
+  dps: 601.3863178528007
+  tps: 1019.3163627832984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 482.1490392148052
-  tps: 827.3748152536034
+  dps: 482.26558338676296
+  tps: 827.5490487906802
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 522.3970136807442
-  tps: 895.791542767435
+  dps: 522.4837122781112
+  tps: 895.9211571704989
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 484.44369425948605
-  tps: 848.4904015706151
+  dps: 484.4831404221866
+  tps: 848.5505530241168
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 803.9904369972627
-  tps: 1347.1280371797488
+  dps: 804.14759738043
+  tps: 1347.374663086571
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 484.400032343452
-  tps: 832.8198968296986
+  dps: 484.4222926009573
+  tps: 832.8537287723957
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonmaw-28438"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 499.1605939896713
-  tps: 876.0271790302899
+  dps: 499.1650703457263
+  tps: 876.0340050256382
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 495.90697528804395
-  tps: 868.6786417301232
+  dps: 494.7765180520818
+  tps: 867.5596563677407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 490.6311722336559
-  tps: 859.4912810472422
+  dps: 490.63879587487753
+  tps: 859.503470252622
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FaithinFelsteel"
  value: {
-  dps: 446.4870884581328
-  tps: 769.2258258147258
+  dps: 446.5164907528625
+  tps: 769.2697822453468
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 476.8360756532736
-  tps: 836.145061914883
+  dps: 476.86602812483693
+  tps: 836.1913003536513
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 474.2668493282584
-  tps: 832.1717241349374
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 488.36074010493684
-  tps: 856.3000352776845
+  dps: 489.02970080577524
+  tps: 857.7498509418375
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 494.83499855326977
-  tps: 866.5917902748707
+  dps: 494.1646845736706
+  tps: 865.5552953345389
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FlameGuard"
  value: {
-  dps: 425.89591028046664
-  tps: 736.0609331538877
+  dps: 425.9104927132118
+  tps: 736.0827338908417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 491.2862139910192
-  tps: 862.4365121398172
+  dps: 491.2979219106336
+  tps: 862.4549294613182
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartrazor-29962"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 474.2668493282584
-  tps: 832.1717241349374
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 488.1723945372076
-  tps: 856.1286304280785
+  dps: 488.17460559994623
+  tps: 856.1320020776484
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 474.2668493282584
-  tps: 832.1717241349374
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 596.4615407414203
-  tps: 1015.6165132214045
+  dps: 596.588195537994
+  tps: 1015.8166211592309
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 485.8940311238452
-  tps: 853.0665836657089
+  dps: 488.9594345093326
+  tps: 858.4146427447236
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 613.2990405328054
-  tps: 1039.0136543560538
+  dps: 613.3860194744298
+  tps: 1039.1527479327751
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 635.2880979034927
-  tps: 1073.8326704276824
+  dps: 635.394141465118
+  tps: 1073.9995027537245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 489.6671405631885
-  tps: 858.6160133975807
+  dps: 489.67170678949054
+  tps: 858.6229764360687
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 408.0407779227639
-  tps: 706.9818724888169
+  dps: 408.05580666213405
+  tps: 707.0048933119019
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 452.667276665297
-  tps: 809.849083017615
+  dps: 452.8208062631102
+  tps: 810.0917102895269
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 494.5333515489026
-  tps: 866.5854009267499
+  dps: 494.5446658110526
+  tps: 866.6032179599836
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 487.0295319991166
-  tps: 853.6752852347985
+  dps: 487.0339896954088
+  tps: 853.6820827758746
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 446.11404972413555
-  tps: 784.8735612284363
+  dps: 446.1458603513157
+  tps: 784.9220692538233
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 449.32600399907176
-  tps: 772.6286092426494
+  dps: 449.34896757447024
+  tps: 772.6629397878703
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 625.6497086444713
-  tps: 1066.1592535784002
+  dps: 625.7174611932236
+  tps: 1066.2605436387848
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 489.9591800760516
-  tps: 857.3660781795551
+  dps: 489.9909674513949
+  tps: 857.4145507482161
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 499.146193240221
-  tps: 873.7721055729656
+  dps: 499.15301091003573
+  tps: 873.782501837666
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 497.8636672964444
-  tps: 871.231575159887
+  dps: 497.90982814760537
+  tps: 871.3019658418224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 469.0712141019849
-  tps: 823.5867344687952
+  dps: 469.0983623115754
+  tps: 823.6281327735998
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 484.2409344206133
-  tps: 848.1757160641878
+  dps: 484.2541140898831
+  tps: 848.1969415716194
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 472.0821352884457
-  tps: 829.040138109527
+  dps: 472.0881580889117
+  tps: 829.0493222779577
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 480.23418827248815
-  tps: 843.7860970957842
+  dps: 477.5513780397043
+  tps: 838.7111921300175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 474.403662308692
-  tps: 833.221724234744
+  dps: 474.42075403994767
+  tps: 833.2477874157356
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 519.1296848651253
-  tps: 907.645606952365
+  dps: 519.1386982444561
+  tps: 907.6599153693877
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 479.2591608164545
-  tps: 840.0835103816534
+  dps: 479.2689346282878
+  tps: 840.098414467318
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 498.1584242240426
-  tps: 871.381298349422
+  dps: 498.17370708667085
+  tps: 871.405167101525
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 474.3891349087368
-  tps: 833.1829567784085
+  dps: 474.40622663999244
+  tps: 833.2090199594002
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 474.45286738343856
-  tps: 832.7679813176986
+  dps: 475.63015167674587
+  tps: 835.4625944940541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 601.3474147435501
-  tps: 1028.2313229326546
+  dps: 601.4808673344728
+  tps: 1028.441489237148
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 493.0903634027113
-  tps: 864.8646914482939
+  dps: 491.8535900978087
+  tps: 862.4807153590988
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 459.4130637940205
-  tps: 808.1132426356224
+  dps: 459.4304566503456
+  tps: 808.140328917114
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormGauntlets-12632"
  value: {
-  dps: 470.15142558567373
-  tps: 808.2640759201371
+  dps: 470.24925724114246
+  tps: 808.410334245063
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 461.57533581124795
-  tps: 811.0333943727595
+  dps: 461.59435989943216
+  tps: 811.0624042048319
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 489.9591800760516
-  tps: 857.3660781795551
+  dps: 489.9909674513949
+  tps: 857.4145507482161
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 489.7462986044487
-  tps: 857.3610618772758
+  dps: 489.76108851360533
+  tps: 857.383615009749
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 494.02999496829534
-  tps: 863.4468001919846
+  dps: 494.0750963670024
+  tps: 863.516139229754
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheDecapitator-28767"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 629.7165699168968
-  tps: 1088.9799248679615
+  dps: 629.8082546071223
+  tps: 1089.126840179589
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 474.35468003611516
-  tps: 833.0646347444301
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheNightBlade-31331"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 474.2668493282584
-  tps: 832.1717241349374
+  dps: 474.3717717673707
+  tps: 833.0906979254218
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 479.0638269952349
-  tps: 841.0565065467624
+  dps: 479.5172155349038
+  tps: 841.4906124626586
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 708.6455395529348
-  tps: 1220.6192963769004
+  dps: 708.8016210910649
+  tps: 1220.8627186972544
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinStars"
  value: {
-  dps: 479.2591608164545
-  tps: 840.0835103816534
+  dps: 479.2689346282878
+  tps: 840.098414467318
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 490.6852685390321
-  tps: 859.3333000544086
+  dps: 490.7306656425562
+  tps: 859.4030900124537
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 481.32751035394205
-  tps: 844.2947503679555
+  dps: 481.3381673836986
+  tps: 844.3110012726314
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 491.85187084089733
-  tps: 862.4754417431186
+  dps: 491.85865806800985
+  tps: 862.4857915857423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 459.9204760165571
-  tps: 791.2353667490041
+  dps: 459.93307414211534
+  tps: 791.2542009467139
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 514.9184007458667
-  tps: 890.0952202634719
+  dps: 514.9757241710131
+  tps: 890.1814716417923
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 484.41935104499737
-  tps: 848.412251565875
+  dps: 484.45879720769784
+  tps: 848.4724030193768
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 467.99317500218933
-  tps: 806.9192744606047
+  dps: 468.05641591182496
+  tps: 807.0138196205099
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 446.101238029647
-  tps: 784.8129956385441
+  dps: 446.13304865682716
+  tps: 784.8615036639309
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 620.3135257267811
-  tps: 1049.4421755224985
+  dps: 620.4106791176072
+  tps: 1049.597091706743
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 435.0457096582843
-  tps: 750.555512900251
+  dps: 435.08584500899167
+  tps: 750.6160681072851
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 474.4923649988341
-  tps: 832.8931661334065
+  dps: 475.66810941806347
+  tps: 835.5836700402951
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 607.1654059689163
-  tps: 1183.7555423661809
+  dps: 607.7959485917183
+  tps: 1184.7176279161797
   dtps: 506.2130352389552
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SelfDrums-DPS"
  value: {
-  dps: 607.3905583536135
-  tps: 1184.6483799302148
+  dps: 608.3031883505033
+  tps: 1186.0400494124724
   dtps: 510.93505061080145
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 557.1229923422565
-  tps: 1104.669118203434
+  dps: 557.1689720654566
+  tps: 1104.7392326833422
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 544.6363230486979
-  tps: 948.1832725317013
+  dps: 544.6507249786056
+  tps: 948.2052340346174
  }
 }
 dps_results: {
@@ -1035,15 +1035,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 233.35380782720674
-  tps: 557.2083820791986
+  dps: 233.48194144607535
+  tps: 557.4069659831462
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 223.08132751399108
-  tps: 407.8253927547844
+  dps: 223.1780105087144
+  tps: 407.9738245485827
  }
 }
 dps_results: {
@@ -1056,15 +1056,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 557.5587702640701
-  tps: 1105.5149698426153
+  dps: 557.6213018595191
+  tps: 1105.6112536962946
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 547.9098628999213
-  tps: 953.9389049789984
+  dps: 547.9921470431026
+  tps: 954.0643800689352
  }
 }
 dps_results: {
@@ -1077,15 +1077,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 233.68993466409134
-  tps: 557.6512078379083
+  dps: 233.72133156924684
+  tps: 557.7027778746872
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 223.60687403328
-  tps: 408.19057424210206
+  dps: 223.6457740590577
+  tps: 408.25089278655526
  }
 }
 dps_results: {
@@ -1098,8 +1098,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 680.2068811087275
-  tps: 1305.9237886565031
+  dps: 681.0224052690542
+  tps: 1307.1673814485848
   dtps: 460.05300905876976
  }
 }

--- a/sim/web/main.go
+++ b/sim/web/main.go
@@ -128,7 +128,6 @@ func handleAsyncAPI(w http.ResponseWriter, r *http.Request, addNewSim simProgRep
 				}
 				report(progMetric)
 				if progMetric.FinalRaidResult != nil || progMetric.FinalWeightResult != nil {
-					close(reporter)
 					return
 				}
 			}


### PR DESCRIPTION
Once a major cooldown is used that has a shared cooldown timer (trinkets/pots), the other goes on cooldown, as it should. However the loop in `TryUseCooldowns` then stops because of it, even if there are still other cooldowns ready that we want to use.

This simply iterates through all of them even if a cooldown is found that is not ready.

On use trinkets test results change, this can simply be due to the order they are added to the cooldown manager, for example.
Some dps variance for classes that are tested with double on use trinkets. Leaning slightly towards an overall dps increase.