### PR TITLE
feature: WCL groups importer, spec mapping fixes

### DIFF
--- a/ui/raid/import_export.ts
+++ b/ui/raid/import_export.ts
@@ -760,7 +760,7 @@ class WCLSimPlayer implements wclSimPlayer {
 				
 				// Diff the distance to the preset.
 				
-				const newDistance = presetTalents.reduce((acc, v, i) => acc += Math.abs(this.talents[i].guid - presetTalents[i]), 0);
+				const newDistance = presetTalents.reduce((acc, v, i) => acc += Math.abs(this.talents[i]?.guid - presetTalents[i]), 0);
 				
 				// If this is the best distance, assign this preset.
 				if (newDistance < distance) {

--- a/ui/raid/import_export.ts
+++ b/ui/raid/import_export.ts
@@ -1,41 +1,32 @@
-import { Exporter } from '/tbc/core/components/exporters.js';
-import { Importer } from '/tbc/core/components/importers.js';
-import { BuffBot, RaidSimSettings } from '/tbc/core/proto/ui.js';
-import { Party, Player, Raid, TargetedActionMetrics } from '../core/proto/api.js';
-import { EventID, TypedEvent } from '/tbc/core/typed_event.js';
+import { Exporter } from "/tbc/core/components/exporters.js";
+import { Importer } from "/tbc/core/components/importers.js";
+import { MAX_PARTY_SIZE } from "/tbc/core/party.js";
+import { BuffBot, RaidSimSettings } from "/tbc/core/proto/ui.js";
+import { TypedEvent } from "/tbc/core/typed_event.js";
+import { Party, Player, Raid } from "../core/proto/api.js";
+import { Encounter, EquipmentSpec, ItemSpec, MobType, Spec, Target } from "../core/proto/common.js";
+import { nameToClass } from "../core/proto_utils/names.js";
+import { Faction, makeDefaultBlessings, specTypeFunctions, withSpecProto } from "../core/proto_utils/utils.js";
+import { MAX_NUM_PARTIES } from "../core/raid.js";
+import { playerPresets, PresetSpecSettings } from "./presets.js";
 
-import { RaidSimUI } from './raid_sim_ui.js';
-import { Class, Encounter, EquipmentSpec, Gem, ItemSpec, MobType, RaidTarget, Spec, Target } from '../core/proto/common.js';
-import { nameToClass } from '../core/proto_utils/names.js';
-import { Faction, makeDefaultBlessings, raceToFaction, specToClass, specToEligibleRaces, specTypeFunctions, withSpecProto } from '../core/proto_utils/utils.js';
-import { BalanceDruid, BalanceDruid_Rotation_PrimarySpell, FeralDruid } from '../core/proto/druid.js';
-import { ElementalShaman, EnhancementShaman } from '../core/proto/shaman.js';
-import { Hunter } from '../core/proto/hunter.js';
-import { Mage } from '../core/proto/mage.js';
-import { Rogue } from '../core/proto/rogue.js';
-import { RetributionPaladin } from '../core/proto/paladin.js';
-import { ShadowPriest, SmitePriest } from '../core/proto/priest.js';
-import { Warlock } from '../core/proto/warlock.js';
-import { ProtectionWarrior, Warrior } from '../core/proto/warrior.js';
-import { gemMatchesSocket } from '../core/proto_utils/gems.js';
-import { buffBotPresets, playerPresets, BuffBotSettings } from './presets.js';
-import { talentStringToProto } from '../core/talents/factory.js';
+import { RaidSimUI } from "./raid_sim_ui.js";
 
 declare var $: any;
 declare var tippy: any;
 
 export function newRaidImporters(simUI: RaidSimUI): HTMLElement {
-	const importSettings = document.createElement('div');
-	importSettings.classList.add('import-settings', 'sim-dropdown-menu');
+	const importSettings = document.createElement("div");
+	importSettings.classList.add("import-settings", "sim-dropdown-menu");
 	importSettings.innerHTML = `
 		<span id="importMenuLink" class="dropdown-toggle fas fa-file-import" role="button" data-toggle="dropdown" aria-haspopup="true" arai-expanded="false"></span>
 		<div class="dropdown-menu dropdown-menu-right" aria-labelledby="importMenuLink">
 		</div>
 	`;
-	const linkElem = importSettings.getElementsByClassName('dropdown-toggle')[0] as HTMLElement;
+	const linkElem = importSettings.getElementsByClassName("dropdown-toggle")[0] as HTMLElement;
 	tippy(linkElem, {
-		'content': 'Import',
-		'allowHTML': true,
+		"content": "Import",
+		"allowHTML": true,
 	});
 
 	const menuElem = importSettings.getElementsByClassName('dropdown-menu')[0] as HTMLElement;
@@ -122,6 +113,9 @@ class RaidJsonExporter extends Exporter {
 }
 
 class RaidWCLImporter extends Importer {
+	
+	private queryCounter: number = 0;
+	
 	private readonly simUI: RaidSimUI;
 	constructor(parent: HTMLElement, simUI: RaidSimUI) {
 		super(parent, 'WCL Import');
@@ -142,301 +136,799 @@ class RaidWCLImporter extends Importer {
 			</p>
 		`;
 	}
-
-	onImport(importLink: string) {
-		// TODO: validate link so we dont get a crash
-		const url = new URL(importLink);
-		var reportID = url.pathname.split("reports/")[1];
-		var hashVals = url.hash.replace("#", "").split("&");
-		var fightID = "0";
-		hashVals.forEach(val => {
-			var parts = val.split("=");
-			if (parts.length < 2 || parts[0] != "fight") {
-				return;
-			}
-			fightID = parts[1];
-		});
+	
+	private getWCLBearerToken(): Promise<string> {
 		
-		var settings = RaidSimSettings.create();
-		var raid = Raid.create();
-		raid.parties = new Array<Party>();
-		settings.raid = raid;
-		var encounter = Encounter.create();
-		encounter.targets = new Array<Target>();
-		var target = Target.create();
-
-		// TODO: look up target in WCL data.
-		target.armor = 7700;
-		target.level = 73;
-		target.mobType = MobType.MobTypeDemon;
-
-		var buffBots = new Array<BuffBot>();
-
-		encounter.targets.push(target)
-		settings.encounter = encounter;
-
-		var numPaladins = 0;
-		var numPlayers = 0;
-
-		// Raid index of players that recieved innervates
-		var wclIDtoRaidIndex = new Map<number, number>();
-
-		fetch("https://classic.warcraftlogs.com/oauth/token", {
+		return fetch("https://classic.warcraftlogs.com/oauth/token", {
 			"method": "POST",
 			"headers": {
 				"Authorization": "Basic " + btoa("963d31c8-7efa-4dde-87cf-1b254a8a2f8c:lRJVhujEEnF96xfUoxVHSpnqKN9v8bTqGEjutsO3"),
 			},
 			body: new URLSearchParams({
-				'grant_type': 'client_credentials'
-			})
-		}).then(response => response.json()).then(data => {
-			fetch("https://classic.warcraftlogs.com/api/v2/client?=", {
-				"method": "POST",
-				"headers": {
-					"Content-Type": "application/json",
-					"Authorization": "Bearer " + data.access_token,
-				},
-				"body": `{"query":"{reportData { report(code: \\"${reportID}\\") { guild { name faction {id} } playerDetails(fightIDs: [${fightID}], endTime: 99999999)  events(fightIDs: [${fightID}], dataType:CombatantInfo, endTime: 99999999) {data}  fights(fightIDs: [${fightID}]) { startTime endTime } buffs: events(fightIDs: [${fightID}], dataType:Buffs, endTime: 99999999, abilityID: 29166){ data }}}}"}`
-			}).then(response => {
-				console.log(response);
-				return response.json()
-			}).then(data => {
-
-				var playerDetails = new Map<Number, any>();
-
-				encounter.duration = (data.data.reportData.report.fights[0].endTime - data.data.reportData.report.fights[0].startTime) / 1000;
-
-				(data.data.reportData.report.playerDetails.data.playerDetails.tanks as Array<any>).forEach(player => playerDetails.set(player.id, player) );
-				(data.data.reportData.report.playerDetails.data.playerDetails.dps as Array<any>).forEach(player => playerDetails.set(player.id, player) );
-				(data.data.reportData.report.playerDetails.data.playerDetails.healers as Array<any>).forEach(player => playerDetails.set(player.id, player) );
-
-				var currentParty = 0;
-				raid.parties.push(Party.create());
-				(data.data.reportData.report.events.data as Array<any>).forEach(info => {
-					if (currentParty == 5) {
-						return;
-					}
-
-					var player = Player.create();
-					var details = playerDetails.get(info.sourceID);
-					var spec = specNames[details.specs[0].spec];
-
-					if (details.type == "Paladin") {
-						numPaladins++;
-					}
-
-					// If we couldn't find the type, check buff bots.
-					if (spec == null || spec == undefined) {
-						var botID = buffBotNames[details.specs[0].spec+details.type];
-						if (botID == null || botID == undefined) {
-							console.log("Spec Not Implemented: ", details.specs[0].spec+details.type);
-							return;
-						}
-
-						// Insert bot!
-						var bot = BuffBot.create();
-						bot.id = botID;
-						bot.raidIndex = numPlayers;
-						buffBots.push(bot);
-						wclIDtoRaidIndex.set(info.sourceID, numPlayers);
-
-						numPlayers++;
-						// For now, insert a placeholder for the bot. It will get overwritten later I think.
-						raid.parties[currentParty].players.push(player);
-						if (raid.parties[currentParty].players.length == 5) {
-							currentParty++;
-						}
-						if (raid.parties.length <= currentParty) {
-							if (currentParty == 5) {
-								return;
+				                          "grant_type": "client_credentials",
+			                          }),
+		}).then((response) => response.json())
+		  .then((res) => res.access_token)
+		  .catch((err) => { // TODO: handle error
+			  console.error(err);
+		  });
+	}
+	
+	private queryWCL(query: string, token: string): Promise<any> {
+		const headers = {
+			"Content-Type": "application/json",
+			"Authorization": `Bearer ${token}`,
+			"Accept": "application/json",
+		};
+		
+		const queryURL = `https://classic.warcraftlogs.com/api/v2/client?query=${query}`;
+		
+		this.queryCounter++;
+		
+		// Query WCL
+		return fetch(encodeURI(queryURL), {
+			"method": "GET",
+			"headers": headers,
+		}).then((res) => res.json());
+	}
+	
+	private getURLInfo(url: string): { reportID: string; fightID: string } {
+		
+		let urlInfo = { reportID: "", fightID: "0" };
+		
+		if (!url.includes("warcraftlogs.com")) {
+			console.error("Invalid WCL URL", url, "must be from warcraftlogs.com");
+			return urlInfo;
+		}
+		
+		let fightIDIndex = url.indexOf("fight=");
+		let reportIDIndex = url.indexOf("/reports/");
+		
+		if (reportIDIndex === -1) {
+			console.error("Could not find report ID in URL", url);
+			return urlInfo;
+		}
+		
+		reportIDIndex += 9; // 9 = length of "/reports/"
+		const reportIDLength = 16;
+		
+		if (fightIDIndex !== -1) {
+			fightIDIndex += 6; // 6 = length of "fight="
+			
+			let fightID = parseInt(url.substring(fightIDIndex), 10);
+			
+			if (isNaN(fightID)) {
+				fightID = 0;
+			}
+			
+			urlInfo.fightID = fightID.toString();
+		} else {
+			console.warn("Could not find fight ID in URL", url, "defaulting to fight 0");
+		}
+		
+		urlInfo.reportID = url.substring(reportIDIndex, reportIDIndex + reportIDLength) ?? "";
+		
+		return urlInfo
+	}
+	
+	private getRateLimit(token: string): Promise<wclRateLimitData> {
+		const query = `
+	  {
+	    rateLimitData {
+	      limitPerHour, pointsSpentThisHour, pointsResetIn
+	    }
+	  }`;
+		return this.queryWCL(query, token)
+		           .then((res) => res['data']['rateLimitData'] as wclRateLimitData);
+	}
+	
+	async onImport(importLink: string) {
+		
+		if (!importLink.length) {
+			console.error("No import link provided!");
+			return;
+		}
+		
+		let urlInfo = this.getURLInfo(importLink);
+		
+		const reportID = urlInfo.reportID;
+		const fightID = urlInfo.fightID;
+		
+		if (!reportID.length) {
+			console.error("Could not find report ID in URL", importLink);
+			return;
+		}
+		
+		// Clear the raid out to avoid any taint issues.
+		this.simUI.clearRaid(TypedEvent.nextEventID());
+		
+		const token = await this.getWCLBearerToken();
+		
+		const rateLimitBuffer = 30; // WCL Query point buffer
+		const rateLimitStart: wclRateLimitData = await this.getRateLimit(token);
+		
+		// Slower but more accurate way to generate the raid sim.
+		// Generates players into the groups that they were in during the fight.
+		// If the rate limit is close to max, then it will create the raid parties "randomly".
+		let experimentalGenerateParties: boolean = rateLimitStart.pointsSpentThisHour + rateLimitBuffer < rateLimitStart.limitPerHour;
+		
+		console.info("Importing WCL report", reportID, "fight", fightID, "Generate Parties:", experimentalGenerateParties);
+		
+		const reportDataQuery = `
+				{
+					reportData {
+						report(code: "${reportID}") {
+							guild {
+								name faction {id}
 							}
-							raid.parties.push(Party.create());
-						}
-						return;
-					}
-
-					const matchingPresets = playerPresets.filter(preset => preset.spec == spec);
-					var presetIdx = 0;
-					if (matchingPresets.length == 0) {
-						return;
-					} else if (matchingPresets.length > 1) {
-						var distance = 100;
-						// Search talents and find the preset that the players talents most closely match.
-						matchingPresets.forEach((preset, i) => {
-							var presetTalents = [0,0,0];
-							var talentIdx = 0;
-							// First sum up the number of talents per tree for preset.
-							Array.from(preset.talents).forEach((v) => {
-								if (v == '-') {
-									talentIdx+=1;
-									return;
-								}
-								presetTalents[talentIdx] += parseInt(v)
-							});
-							// Diff the distance to the preset.
-							var newDistance = Math.abs(info.talents[0].id - presetTalents[0]) + Math.abs(info.talents[1].id - presetTalents[1]) + Math.abs(info.talents[2].id - presetTalents[2]);
-							// If this is the best distance, assign this preset.
-							if (newDistance < distance) {
-								presetIdx = i;
-								distance = newDistance;
+							table(fightIDs: [${fightID}], endTime: 99999999, dataType: Casts, killType: All, viewBy: Default)
+							fights(fightIDs: [${fightID}]) {
+								startTime, endTime, id, name
 							}
-						})
-					}
-					const matchingPreset = matchingPresets[presetIdx];
-
-					var specFuncs = specTypeFunctions[spec];
-					player = withSpecProto(spec, player, matchingPreset.rotation, specFuncs.talentsCreate(), matchingPreset.specOptions);
-					player.talentsString = matchingPreset.talents;
-					player.consumes = matchingPreset.consumes;
-
-					player.name = details.name;
-					player.class = nameToClass(details.type);
-					player.equipment = EquipmentSpec.create();
-					player.equipment.items = new Array<ItemSpec>();
-
-					// Default to UI setting
-					var faction = this.simUI.raidPicker?.getCurrentFaction();
-
-					// If defined in log, use that faction.
-					if (data.data.reportData.report.guild != null && data.data.reportData.report.guild != undefined) {
-						faction = data.data.reportData.report.guild.faction.id as Faction;
-					}
-
-					// Fallback if UI is broken and log has no faction.
-					if (faction == undefined) {
-						faction = Faction.Horde;
-					}
-					player.race = matchingPreset.defaultFactionRaces[faction];
-
-					(info.gear as Array<any>).forEach(gear => {
-						var item = ItemSpec.create();
-						item.id = gear.id;
-						const dbEnchant = this.simUI.sim.getEnchantFlexible(gear.permanentEnchant);
-						if (dbEnchant) {
-							item.enchant = dbEnchant.id;
-						} else {
-							item.enchant = 0;
 						}
-						if (gear.gems) {
-							item.gems = new Array<number>();
-							(gear.gems as Array<any>).forEach(gemInfo => item.gems.push(gemInfo.id));	
+					}
+				}
+				`;
+		
+		/*
+			INNERVATE BUFFS ARE UNUSED RIGHT NOW.
+			buffs: events(fightIDs: [${fightID}], dataType:Buffs, endTime: 99999999, abilityID: 29166) { data }
+		 */
+		
+		const reportData = await this.queryWCL(reportDataQuery, token);
+		
+		// Process the report data.
+		const wclData = reportData.data.reportData.report; // TODO: Typings?
+		
+		const guildData = wclData.guild;
+		const playerData: wclPlayer[] = wclData.table.data.entries;
+		
+		// Set up the general variables we need for import to be successful.
+		const fight: { startTime: number, endTime: number, id: number, name: string } = wclData.fights[0];
+		const startTime: number = fight.startTime;
+		const endTime: number = fight.endTime;
+		
+		// Default to UI setting
+		let faction = this.simUI.raidPicker?.getCurrentFaction();
+		
+		// If defined in log, use that faction.
+		if (guildData != null) {
+			faction = guildData.faction.id as Faction;
+		}
+		
+		// Fallback if UI is broken and log has no faction.
+		if (faction == undefined) {
+			faction = Faction.Horde;
+		}
+		
+		const encounter = Encounter.create();
+		encounter.duration = (endTime - startTime) / 1000;
+		
+		encounter.targets = new Array<Target>();
+		
+		let closestEncounterPreset = this.simUI.sim.getAllPresetEncounters().find((enc) => enc.path.includes(fight.name));
+		
+		// Use the preset encounter if it exists.
+		if (closestEncounterPreset && closestEncounterPreset.targets.length) {
+			closestEncounterPreset.targets
+			                      .map((mob) => mob.target as Target)
+			                      .filter((target) => target !== undefined)
+			                      .forEach((target) => encounter.targets.push(target));
+		}
+		
+		// Build a manual target list if no preset encounter exists.
+		if (encounter.targets.length === 0) {
+			let target = Target.create();
+			target.armor = 7700;
+			target.level = 73;
+			target.mobType = MobType.MobTypeDemon;
+			encounter.targets.push(target);
+		}
+		
+		const settings = RaidSimSettings.create();
+		settings.encounter = encounter;
+		
+		const raid = Raid.create();
+		raid.parties = new Array<Party>();
+		settings.raid = raid;
+		
+		const buffBots = new Array<BuffBot>();
+		
+		// Raid index of players that received innervates
+		const wclIDtoRaidIndex = new Map<number, number>();
+		
+		const numPaladins = playerData.filter((player) => player.type === "Paladin").length;
+		
+		// Generate an empty set of 3 dimensional arrays for each party. [ party ][ player or buffBot ][ player ]
+		let tempParties: WCLSimPlayer[][] = Array.from({ length: MAX_NUM_PARTIES }).map(() => []);
+		
+		// Generate the default 5 raid parties & temp parties.
+		tempParties.forEach(() => raid.parties.push(Party.create()));
+		
+		// Sorts an objectArray by a property. Returns a new array.
+		// Can be called recursively.
+		const sortByProperty = (objArray: any[], prop: string) => {
+			if (!Array.isArray(objArray)) throw new Error("FIRST ARGUMENT NOT AN ARRAY");
+			const clone = objArray.slice(0);
+			const direct = arguments.length > 2 ? arguments[2] : 1; //Default to ascending
+			const propPath = (prop.constructor === Array) ? prop : prop.split(".");
+			clone.sort(function (a, b) {
+				for (let p in propPath) {
+					if (a[propPath[p]] && b[propPath[p]]) {
+						a = a[propPath[p]];
+						b = b[propPath[p]];
+					}
+				}
+				// convert numeric strings to integers
+				a = a.toString().match(/^\d+$/) ? +a : a;
+				b = b.toString().match(/^\d+$/) ? +b : b;
+				return ((a < b) ? -1 * direct : ((a > b) ? 1 * direct : 0));
+			});
+			return clone;
+		}
+		
+		const mappedPlayers = playerData
+			.map((wclPlayer) => new WCLSimPlayer(wclPlayer, this.simUI, faction));
+		
+		const wclPlayers: WCLSimPlayer[] = sortByProperty(sortByProperty(mappedPlayers, "type"), "sortPriority");
+		
+		let raidIndex = 0;
+		
+		// Sorts buff bots to the end of the array to prevent overwriting them later on.
+		const sortBuffBotsLast = (a: WCLSimPlayer, b: WCLSimPlayer) => a.isBuffBot ? 1 : b.isBuffBot ? 1 : 0;
+		
+		// Reusable function to add a player to the raid.parties[raidIndex] array.
+		const assignPlayerToParty = (player: WCLSimPlayer, raidParty: Party, missing = false) => {
+			
+			if (!player) {
+				console.error("Cannot assign player to party because player is undefined!");
+				return;
+			}
+			
+			if (!raidParty) {
+				console.error("Cannot assign player to party because party is undefined!");
+				return;
+			}
+			
+			if (raidParty.players.length === MAX_PARTY_SIZE) {
+				console.error("Cannot assign player to party because party is full!", player, raidParty.players);
+				return;
+			}
+			
+			if (missing) {
+				console.warn(`Could not locate a group for ${player.name}, assigning them to an open group.`);
+			}
+			
+			let buffBot = player.getBuffBot();
+			let simPlayer = player.getPlayer();
+			
+			if (!buffBot && !simPlayer) {
+				console.error("Cannot assign player to party because player data is undefined!", player);
+				return;
+			}
+			
+			wclIDtoRaidIndex.set(player.id, raidIndex);
+			
+			if (buffBot) {
+				buffBot.raidIndex = raidIndex;
+				buffBots.push(buffBot);
+				raidParty.players.push(Player.create());
+			} else if (simPlayer) {
+				raidParty.players.push(simPlayer);
+			}
+			
+			// Just in case this did not get set previously.
+			player.partyAssigned = true;
+			
+			raidIndex++;
+		}
+		
+		// if experimental_generate_parties is true, we will generate parties based on the party buffers
+		if (experimentalGenerateParties) {
+			
+			// We only care about the players who can provide party buffs on logs.
+			const partyBuffPlayers = wclPlayers.filter((player) => player.isPartyBuffer);
+			
+			// Can't be a forEach because we need to wait for the query to finish on each iteration later on.
+			for (const player of partyBuffPlayers) {
+				
+				const partyFull = player.partyMembers.length >= MAX_PARTY_SIZE;
+				
+				// Skip players that have already been assigned to a party.
+				// player.partyAssigned || player.partyFound || player.partyMembers.length > 0
+				if (partyFull) {
+					continue;
+				}
+				
+				const auraIDs: number[] = player.getPartyAuraIds();
+				
+				if (!auraIDs.length) {
+					console.warn("No party aura ids found for partyBuff player " + player.name);
+					continue;
+				}
+				
+				let auraBuffQueries = auraIDs.map((auraID) => `
+				{
+					reportData {
+						report(code: "${reportID}") {
+					table(startTime: ${startTime}, endTime: ${endTime}, sourceID: ${player.id}, abilityID: ${auraID}, fightIDs: [${fightID}],dataType:Buffs,viewBy:Target,hostilityType:Friendlies)
 						}
-						player.equipment!.items.push(item);
-					});
+					}
+				}`);
+				
+				let auraTargets: wclAura[] = [];
+				
+				// Can't be a forEach because we need to await each query.
+				for (let i = 0; i < auraBuffQueries.length; i++) {
 					
-					wclIDtoRaidIndex.set(info.sourceID, numPlayers);
-					numPlayers++;
-					raid.parties[currentParty].players.push(player);
-					if (raid.parties[currentParty].players.length == 5) {
-						currentParty++;
+					if (auraTargets.length >= MAX_PARTY_SIZE || partyFull) {
+						break;
 					}
-					if (raid.parties.length <= currentParty) {
-						if (currentParty == 5) {
-							return;
+					
+					let auraQueryRes = await this.queryWCL(auraBuffQueries[i], token);
+					if (auraQueryRes) {
+						let playerAuras: wclAura[] = auraQueryRes.data?.reportData?.report?.table?.data?.auras ?? [];
+						if (playerAuras.length) {
+							
+							playerAuras = playerAuras.filter((auraTarget) => auraTarget.type !== "Pet")
+							                         .sort((a, b) => a.bands[0].startTime - b.bands[0].startTime)
+							                         .filter((auraTarget, index) => index < 5);
+							
+							const uniqueAuraTargets = playerAuras.filter((auraTarget) => !auraTargets.some((target) => target.name === auraTarget.name));
+							auraTargets.push(...uniqueAuraTargets);
 						}
-						raid.parties.push(Party.create());
 					}
-				});
-
-				(data.data.reportData.report.buffs.data as Array<any>).forEach(buff => {
-					if (buff.type == "removebuff") {
+				}
+				
+				if (auraTargets.length === 0) {
+					continue;
+				}
+				
+				player.partyFound = true;
+				
+				// Only need the member names at this point.
+				player.partyMembers = auraTargets.map((auraTarget) => auraTarget.name);
+				
+				let partyMembers = wclPlayers
+					.filter((raidMember) => player.partyMembers.includes(raidMember.name))
+					.filter((raidMember) => !raidMember.partyAssigned);
+				
+				const totalPartyMembers = partyMembers.length;
+				
+				// Find an empty temp party to assign the members to.
+				let partyIndex: number = tempParties.findIndex((party) => party.length < MAX_PARTY_SIZE && party.length < totalPartyMembers);
+				
+				// Try and see if any of the parties have your party members in it without you.
+				if (partyIndex === -1) {
+					console.warn("No empty temp party found for player " + player.name);
+					partyIndex = tempParties
+						.filter((party) => party.length < MAX_PARTY_SIZE)
+						.findIndex((party) => party.some((member) => player.partyMembers.includes(member.name)));
+					console.info("Found party with members in it: " + partyIndex);
+				}
+				
+				let party: WCLSimPlayer[] = tempParties[partyIndex];
+				
+				partyMembers.forEach((partyMember) => {
+					
+					const isUndefined = party === undefined;
+					const isFull = party.length === MAX_PARTY_SIZE;
+					
+					if (isUndefined || isFull) {
 						return;
 					}
-
-					// Innervate!
-					if (buff.abilityGameID == 29166) {
-						// Find if target is a player.
-						// If so, find source, could be a player or a buffbot.
-						// Apply innervate.
-						var sourceID = wclIDtoRaidIndex.get(buff.sourceID)!;
-						var targetID = wclIDtoRaidIndex.get(buff.targetID)!;
-						var source = settings.raid!.parties[Math.floor(sourceID/5)].players[sourceID%5];
-						var target = settings.raid!.parties[Math.floor(targetID/5)].players[targetID%5];
-						if (target.class == undefined) {
-							// Target is not a player
-							return;
-						}
-						if (source.class != Class.ClassDruid) {
-							// its a buffbot
-							buffBots.forEach(bot => {
-								if (bot.raidIndex == sourceID) {
-									// Found our buffer
-									bot.innervateAssignment = RaidTarget.create();
-									bot.innervateAssignment.targetIndex = targetID;
-									return;
-								}
-							});
-						} else {
-							// Assign player sources
-							if (source.spec.oneofKind == "balanceDruid") {
-								source.spec.balanceDruid.options!.innervateTarget = RaidTarget.create();
-								source.spec.balanceDruid.options!.innervateTarget.targetIndex = targetID;
-							} else if (source.spec.oneofKind == "feralDruid") {
-								source.spec.feralDruid.options!.innervateTarget = RaidTarget.create();
-								source.spec.feralDruid.options!.innervateTarget.targetIndex = targetID;
-							} else if (source.spec.oneofKind == "feralTankDruid") {
-								source.spec.feralTankDruid.options!.innervateTarget = RaidTarget.create();
-								source.spec.feralTankDruid.options!.innervateTarget.targetIndex = targetID;
-							}
-						}
-					}
+					
+					partyMember.partyAssigned = true;
+					partyMember.partyMembers = player.partyMembers;
+					
+					party.push(partyMember);
 				});
-				settings.blessings = makeDefaultBlessings(numPaladins);
-
-				this.simUI.clearRaid(TypedEvent.nextEventID());
-				this.simUI.fromProto(TypedEvent.nextEventID(), settings);
-				this.simUI.setBuffBots(TypedEvent.nextEventID(), buffBots);
-				this.close();
-			}).catch(err => {
-				console.error(err);
-			});	
+			}
+			
+			// Process the temp groups into the sim raid groups.
+			tempParties.forEach((party, partyIndex) => {
+				
+				let raidParty = raid.parties[partyIndex];
+				
+				party
+					.sort(sortBuffBotsLast)
+					.forEach((player) => assignPlayerToParty(player, raidParty));
+			});
+		}
+		
+		// Process the players who didn't get assigned a group yet.
+		wclPlayers
+			.filter((player) => !player.partyAssigned)
+			.sort(sortBuffBotsLast)
+      .map((player) => {
+        let raidParty = raid.parties.filter((party) => party.players.length < MAX_PARTY_SIZE)[0];
+				assignPlayerToParty(player, raidParty, true);
+      });
+		
+		wclPlayers
+			.filter((player) => !player.partyAssigned)
+			.forEach((player) => {
+			console.error(`${player.name} is not in a party!`, player);
 		});
+		
+		settings.blessings = makeDefaultBlessings(numPaladins);
+		
+		this.simUI.clearRaid(TypedEvent.nextEventID());
+		this.simUI.fromProto(TypedEvent.nextEventID(), settings);
+		this.simUI.setBuffBots(TypedEvent.nextEventID(), buffBots);
+		
+		if (!experimentalGenerateParties) {
+			const rateLimitEnd: wclRateLimitData = await this.getRateLimit(token);
+			console.debug(`Rate Limit resets in ${rateLimitEnd.pointsResetIn} seconds.`);
+		}
+		this.close();
 	}
 }
 
+class WCLSimPlayer implements wclSimPlayer {
+	public gear: wclGear[];
+	public icon: string;
+	public id: number;
+	public name: string;
+	public type: string;
+	public talents: wclTalents[];
+	public wclSpec: string;
+	
+	public partyAssigned: boolean = false;
+	public partyFound: boolean = false;
+	public partyMembers: string[] = [];
+	
+	public isPartyBuffer: boolean = false;
+	public isBuffBot: boolean = false;
+	public sortPriority: number = 99;
+	
+	private simUI: RaidSimUI;
+	private spec: Spec;
+	private specType: string;
+	private faction: Faction;
+	
+	constructor(data: wclPlayer, simUI: RaidSimUI, faction: Faction = Faction.Unknown) {
+		this.simUI = simUI;
+		
+		this.name = data.name;
+		this.gear = data.gear;
+		this.icon = data.icon;
+		this.id = data.id;
+		this.type = data.type;
+		this.talents = data.talents;
+		this.wclSpec = data.icon.split("-")[1];
+		this.faction = faction;
+		
+		// Prot Paladin's occasionally have a specType of "Protection" instead of "Justicar"?
+		if (this.type === "Paladin" && this.wclSpec === "Protection") {
+			this.wclSpec = "Justicar";
+		}
+		
+		this.spec = specNames[this.wclSpec];
+		this.specType = this.wclSpec + this.type;
+		
+		this.isBuffBot = this.spec === undefined;
+		
+		this.isPartyBuffer = this.getPartyAuraIds().length > 1;
+		
+		this.sortPriority = specSortPriority[this.wclSpec] ?? 99;
+	}
+	
+	public getPlayer(): Player | undefined {
+		
+		if (this.isBuffBot) {
+			return;
+		}
+		
+		let player = Player.create();
+		
+		const specFuncs = specTypeFunctions[this.spec];
+		
+		const matchingPreset = this.getMatchingPreset();
+		
+		if (matchingPreset === undefined) {
+			console.error("Could not find matching preset for non buff bot", {
+				"name": this.name,
+				"spec": this.spec,
+				"type": this.type,
+				"talents": this.talents,
+			});
+			return;
+		}
+		
+		player = withSpecProto(this.spec, player, matchingPreset.rotation, specFuncs.talentsCreate(), matchingPreset.specOptions);
+		
+		player.talentsString = matchingPreset.talents;
+		player.consumes = matchingPreset.consumes;
+		
+		player.name = this.name;
+		player.class = nameToClass(this.type);
+		player.equipment = this.getEquipment();
+		player.race = matchingPreset.defaultFactionRaces[this.faction];
+		
+		return player;
+	}
+	
+	public getBuffBot(): BuffBot | undefined {
+		
+		if (!this.isBuffBot) {
+			return;
+		}
+		
+		const botID = buffBotNames[this.specType];
+		
+		if (botID == null) {
+			console.error("Buff Bot Spec not implemented: ", this.specType);
+			return;
+		}
+		
+		const bot = BuffBot.create();
+		bot.id = botID;
+		bot.raidIndex = -1; // Default it for now. // numPlayers
+		
+		return bot;
+	}
+	
+	public getPartyAuraIds() {
+		
+		const allSpecClassAuras: any = {
+			"Paladin": [
+				19746, // Concentration Aura
+				27149, // Devotion Aura,
+				27150, // Retribution Aura
+			],
+			"Warrior": [
+				2048,  // Battle Shout
+				469, // Commanding Shout
+			],
+			"Warlock": [
+				27268, // Pet Imp: Blood Pact
+				18696, // Improved Imp: Blood Pact
+			],
+		};
+		
+		// Reused for the plethora of Feral specs.
+		const feralDruidSpecAuras = [
+			24932, // Improved Leader of the Pack // at least 0,32,0
+			// 17007, // Leader of the Pack // at least 0,31,0
+		];
+		
+		// TODO: Could additionally filter out buff IDs based on minimum req talent strings?
+		const specSpecificAuras: any = {
+			"RetributionPaladin": [
+				20092, // Improved Retribution Aura // at least 0,0,16
+				20218, // Sanctity Aura // at least 0,0,21
+				31870, // Improved Sanctity Aura // at least 0,0,22
+			],
+			"GuardianDruid": [...feralDruidSpecAuras],
+			"WardenDruid": [...feralDruidSpecAuras],
+			"FeralDruid": [...feralDruidSpecAuras],
+			"BalanceDruid": [
+				24907, // Moonkin Aura // at least 31,0,0
+			],
+			"RestorationDruid": [
+				34123, // Tree of Life // at least 0,0,41
+			],
+			"MarksmanHunter": [
+				27066, // Trueshot Aura // at least 0,32,0
+			],
+			"EnhancementShaman": [
+				30811, // Unleashed Rage // at least 0,36,0
+			],
+			// "ElementalShaman": [] // Totem buffs do not show up in logs. Leaving for future reference.
+		};
+		
+		const consumableAuras = [
+			351355, // Greater Drums of Battle
+		];
+		
+		const classAuras = allSpecClassAuras[this.type] ?? [];
+		const specAuras = specSpecificAuras[this.specType] ?? [];
+		
+		const reliableAuras = [
+			...specAuras, ...classAuras, ...consumableAuras,
+		];
+		
+		if (this.type === "Shaman") {
+			// Shamans get moved around a lot, so Heroism isn't a good reference for what group they are in.
+			return [
+				...reliableAuras,
+				32182, // Heroism
+			];
+		}
+		return reliableAuras;
+	}
+	
+	private getMatchingPreset(): PresetSpecSettings<Spec> {
+		const matchingPresets = playerPresets.filter((preset) => preset.spec === this.spec);
+		let presetIdx = 0;
+		
+		if (matchingPresets && matchingPresets.length > 1) {
+			let distance = 100;
+			// Search talents and find the preset that the players talents most closely match.
+			matchingPresets.forEach((preset, i) => {
+				let presetTalents = [0, 0, 0];
+				let talentIdx = 0;
+				// First sum up the number of talents per tree for preset.
+				Array.from(preset.talents).forEach((v) => {
+					if (v == "-") {
+						talentIdx++;
+						return;
+					}
+					presetTalents[talentIdx] += parseInt(v);
+				});
+				
+				// Diff the distance to the preset.
+				
+				const newDistance = presetTalents.reduce((acc, v, i) => acc += Math.abs(this.talents[i].guid - presetTalents[i]), 0);
+				
+				// If this is the best distance, assign this preset.
+				if (newDistance < distance) {
+					presetIdx = i;
+					distance = newDistance;
+				}
+			});
+		}
+		return matchingPresets[presetIdx];
+	}
+	
+	private getEquipment(): EquipmentSpec {
+		let equipment = EquipmentSpec.create();
+		equipment.items = new Array<ItemSpec>();
+		
+		this.gear.forEach((gear) => {
+			const item = ItemSpec.create();
+			item.id = gear.id;
+			const dbEnchant = this.simUI.sim.getEnchantFlexible(gear.permanentEnchant);
+			item.enchant = dbEnchant
+			               ? dbEnchant.id
+			               : 0;
+			if (gear.gems) {
+				item.gems = new Array<number>();
+				gear.gems.forEach((gemInfo) => item.gems.push(gemInfo.id));
+			}
+			equipment!.items.push(item);
+		});
+		return equipment;
+	}
+	
+}
+
+
+// Maps WCL spec to sorting priority for party makeup checks. Lower the number, the more likely the query will be successful.
+const specSortPriority: Record<string, number> = {
+	"Warden": 0,
+	"Guardian": 1,
+	"Feral": 2,
+	"Balance": 3,
+	"Justicar": 4,
+	"Retribution": 5,
+	"Fury": 6,
+	"Arms": 7,
+	"Protection": 8,
+	"Enhancement": 9,
+	"Destruction": 10,
+	"Affliction": 11,
+	"Demonology": 12,
+	"Marksman": 13,
+};
 
 // Maps WCL spec names to internal Spec enum.
 const specNames: Record<string, Spec> = {
-	'Balance': Spec.SpecBalanceDruid,
-	'Elemental': Spec.SpecElementalShaman,
-	'Enhancement': Spec.SpecEnhancementShaman,
-  	// 'Feral': Spec.SpecFeralDruid,
-	// 'Warden': Spec.SpecFeralTankDruid,
-	// 'Guardian': Spec.SpecFeralTankDruid,
-	'Survival': Spec.SpecHunter,
-	'BeastMastery': Spec.SpecHunter,
-	'Arcane': Spec.SpecMage,
-	'Fire': Spec.SpecMage,
-	'Frost': Spec.SpecMage,
-	'Assassination': Spec.SpecRogue,
-	'Combat': Spec.SpecRogue,
-	'Retribution': Spec.SpecRetributionPaladin,
-	// 'Justicar': Spec.SpecProtectionPaladin,
-	'Shadow': Spec.SpecShadowPriest,
-	'Smite': Spec.SpecSmitePriest,
-	'Destruction': Spec.SpecWarlock,
-	'Affliction': Spec.SpecWarlock,
-	'Demonology': Spec.SpecWarlock,
-	'Arms': Spec.SpecWarrior,
-	'Fury': Spec.SpecWarrior,
-	// 'Protection': Spec.SpecProtectionWarrior,
+	"Balance": Spec.SpecBalanceDruid,
+	"Elemental": Spec.SpecElementalShaman,
+	"Enhancement": Spec.SpecEnhancementShaman,
+	// 'Feral': Spec.SpecFeralDruid,
+	"Warden": Spec.SpecFeralTankDruid,
+	"Guardian": Spec.SpecFeralTankDruid,
+	"Survival": Spec.SpecHunter,
+	"BeastMastery": Spec.SpecHunter,
+	"Arcane": Spec.SpecMage,
+	"Fire": Spec.SpecMage,
+	"Frost": Spec.SpecMage,
+	"Assassination": Spec.SpecRogue,
+	"Combat": Spec.SpecRogue,
+	"Retribution": Spec.SpecRetributionPaladin,
+	"Justicar": Spec.SpecProtectionPaladin,
+	"Shadow": Spec.SpecShadowPriest,
+	"Smite": Spec.SpecSmitePriest,
+	"Destruction": Spec.SpecWarlock,
+	"Affliction": Spec.SpecWarlock,
+	"Demonology": Spec.SpecWarlock,
+	"Arms": Spec.SpecWarrior,
+	"Fury": Spec.SpecWarrior,
+	"Champion": Spec.SpecWarrior,
+	"Warrior": Spec.SpecWarrior,
+	"Gladiator": Spec.SpecWarrior,
+	"Protection": Spec.SpecProtectionWarrior,
 };
 
 // Maps WCL spec+type to internal buff bot IDs.
 const buffBotNames: Record<string, string> = {
 	// DPS
-	'FeralDruid': 'Bear',
-
-	// Tank
-	'JusticarPaladin': 'JoW Paladin',
-	'ProtectionWarrior': 'Prot Warrior',
-	'WardenDruid': 'Bear',
-	'GuardianDruid': 'Bear',
-
+	"FeralDruid": "Bear",
+	
 	// Healers
-	'HolyPaladin': 'Paladin',
-	'HolyPriest': 'Holy Priest',
-	'DisciplinePriest': 'Divine Spirit Priest',
-	'RestorationDruid': 'Resto Druid',
-	'RestorationShaman': 'Resto Shaman',
+	"HolyPaladin": "Paladin",
+	"HolyPriest": "Holy Priest",
+	"DisciplinePriest": "Divine Spirit Priest",
+	"RestorationDruid": "Resto Druid",
+	"DreamstateDruid": "Resto Druid",
+	"RestorationShaman": "Resto Shaman",
 };
+
+interface wclRateLimitData {
+	limitPerHour: number,
+	pointsSpentThisHour: number,
+	pointsResetIn: number
+}
+
+// Typed interface for WCL talents
+interface wclTalents {
+	name: string;
+	guid: number;
+	type: number;
+	abilityIcon: string;
+}
+
+// Typed interface for WCL Gems
+interface wclGems {
+	id: number;
+	itemLevel: number;
+	icon: string;
+}
+
+// Typed interface for WCL Gear
+interface wclGear {
+	id: number;
+	slot: number;
+	quality: number;
+	icon: string;
+	name: string;
+	itemLevel: number;
+	permanentEnchant: number;
+	permanentEnchantName: string;
+	temporaryEnchant: number;
+	gems?: wclGems[];
+}
+
+// Typed interface for WCL Player Data
+interface wclPlayer {
+	name: string;
+	id: number;
+	guid?: number;
+	type: string; // Paladin, Mage, etc.
+	icon: string; // Paladin-Justicar, Mage-Fire, etc.
+	itemLevel?: number;
+	total?: number;
+	activeTime?: number;
+	activeTimeReduced?: number;
+	abilities?: unknown[]; // Don't care about abilities.
+	damageAbilities?: unknown[];
+	targets?: unknown[];
+	talents: wclTalents[];
+	gear: wclGear[];
+}
+
+// Typed interface for WoWSimPlayer class
+interface wclSimPlayer extends wclPlayer {
+	wclSpec: string;
+	partyAssigned: boolean;
+	isPartyBuffer: boolean;
+	partyMembers: string[];
+	isBuffBot: boolean;
+}
+
+interface wclAura {
+	name: string;
+	id: number;
+	guid: number;
+	type: string;
+	icon: string;
+	totalUptime: number;
+	totalUses: number;
+	bands: {
+		startTime: number,
+		endTime: number,
+	}[];
+}

--- a/ui/raid/raid_sim_ui.ts
+++ b/ui/raid/raid_sim_ui.ts
@@ -1,42 +1,31 @@
-import { Encounter } from '/tbc/core/encounter.js';
-import { Player } from '/tbc/core/player.js';
-import { Raid } from '/tbc/core/raid.js';
-import { Sim } from '/tbc/core/sim.js';
-import { SimUI } from '/tbc/core/sim_ui.js';
-import { Stat } from '/tbc/core/proto/common.js';
-import { EventID, TypedEvent } from '/tbc/core/typed_event.js';
-import { Raid as RaidProto } from '/tbc/core/proto/api.js';
-import { Blessings } from '/tbc/core/proto/paladin.js';
-import { BlessingsAssignments } from '/tbc/core/proto/ui.js';
-import { BuffBot as BuffBotProto } from '/tbc/core/proto/ui.js';
-import { RaidSimSettings } from '/tbc/core/proto/ui.js';
-import { SavedEncounter } from '/tbc/core/proto/ui.js';
-import { SavedRaid } from '/tbc/core/proto/ui.js';
-import { SimSettings as SimSettingsProto } from '/tbc/core/proto/ui.js';
-import { Class } from '/tbc/core/proto/common.js';
-import { Encounter as EncounterProto } from '/tbc/core/proto/common.js';
-import { Spec } from '/tbc/core/proto/common.js';
-import { TristateEffect } from '/tbc/core/proto/common.js';
-import { playerToSpec } from '/tbc/core/proto_utils/utils.js';
-import { BooleanPicker } from '/tbc/core/components/boolean_picker.js';
-import { DetailedResults } from '/tbc/core/components/detailed_results.js';
-import { EncounterPicker, EncounterPickerConfig } from '/tbc/core/components/encounter_picker.js';
-import { LogRunner } from '/tbc/core/components/log_runner.js';
-import { SavedDataConfig } from '/tbc/core/components/saved_data_manager.js';
-import { SavedDataManager } from '/tbc/core/components/saved_data_manager.js';
-import { SettingsMenu } from '/tbc/core/components/settings_menu.js';
-import { addRaidSimAction, RaidSimResultsManager, ReferenceData } from '/tbc/core/components/raid_sim_action.js';
-import { downloadJson } from '/tbc/core/utils.js';
+import { BooleanPicker } from "/tbc/core/components/boolean_picker.js";
+import { DetailedResults } from "/tbc/core/components/detailed_results.js";
+import { EncounterPicker } from "/tbc/core/components/encounter_picker.js";
+import { LogRunner } from "/tbc/core/components/log_runner.js";
+import { addRaidSimAction, RaidSimResultsManager, ReferenceData } from "/tbc/core/components/raid_sim_action.js";
+import { SavedDataManager } from "/tbc/core/components/saved_data_manager.js";
+import { SettingsMenu } from "/tbc/core/components/settings_menu.js";
 
-import { AssignmentsPicker } from './assignments_picker.js';
-import { BlessingsPicker } from './blessings_picker.js';
-import { BuffBot } from './buff_bot.js';
-import { RaidPicker } from './raid_picker.js';
-import { TanksPicker } from './tanks_picker.js';
-import { implementedSpecs } from './presets.js';
-import { newRaidExporters, newRaidImporters } from './import_export.js';
+import * as Tooltips from "/tbc/core/constants/tooltips.js";
+import { Encounter } from "/tbc/core/encounter.js";
+import { Player } from "/tbc/core/player.js";
+import { Raid as RaidProto } from "/tbc/core/proto/api.js";
+import { Class, Encounter as EncounterProto, Stat, TristateEffect } from "/tbc/core/proto/common.js";
+import { Blessings } from "/tbc/core/proto/paladin.js";
+import { BlessingsAssignments, BuffBot as BuffBotProto, RaidSimSettings, SavedEncounter, SavedRaid } from "/tbc/core/proto/ui.js";
+import { playerToSpec } from "/tbc/core/proto_utils/utils.js";
+import { Raid } from "/tbc/core/raid.js";
+import { Sim } from "/tbc/core/sim.js";
+import { SimUI } from "/tbc/core/sim_ui.js";
+import { EventID, TypedEvent } from "/tbc/core/typed_event.js";
 
-import * as Tooltips from '/tbc/core/constants/tooltips.js';
+import { AssignmentsPicker } from "./assignments_picker.js";
+import { BlessingsPicker } from "./blessings_picker.js";
+import { BuffBot } from "./buff_bot.js";
+import { newRaidExporters, newRaidImporters } from "./import_export.js";
+import { implementedSpecs } from "./presets.js";
+import { RaidPicker } from "./raid_picker.js";
+import { TanksPicker } from "./tanks_picker.js";
 
 declare var Muuri: any;
 declare var tippy: any;
@@ -361,6 +350,10 @@ export class RaidSimUI extends SimUI {
 	setBuffBots(eventID: EventID, buffBotProtos: BuffBotProto[]): void {
 		this.raidPicker!.setBuffBots(eventID, buffBotProtos);
 	}
+	
+	clearBuffBots(eventID: EventID): void {
+		this.raidPicker!.setBuffBots(eventID, []);
+	}
 
 	getPlayersAndBuffBots(): Array<Player<any> | BuffBot | null> {
 		const players = this.sim.raid.getPlayers();
@@ -406,6 +399,7 @@ export class RaidSimUI extends SimUI {
 
 	clearRaid(eventID: EventID) {
 		this.sim.raid.clear(eventID);
+		this.clearBuffBots(eventID);
 	}
 
 	// Returns the actual key to use for local storage, based on the given key part and the site context.


### PR DESCRIPTION
## PR Goals
### Import players into parties as closely resembling the ones that they were in during the encounter.

When importing a log the importer will attempt to utilize party buffs (such as the Feral Druid buff: Leader of the Pack) to determine who was originally in the party during the encounter start to build the parties. If a party cannot be found for a particular player, they will be randomly inserted into an open group at the end of the cycle.

### Add additional typing to the WCL section of the importer.

Added some typing interfaces to the WCL data stream. Not 100% foolproof as a lot of the endpoints aren't frozen, but should help alleviate some of the errors that can come up.

### Reduce query requests when importing without group makeup.

There is a guard in place that checks to see if the application is nearing it's `pointLimitPerHour` mark, and if it is, then it will not import groups as they were, but will insert people into random raid groups instead. Standard `limitPerHour` is 3600 points.

### Loosening of URL formatting requirements

The requirements for the URL is a lot less strict now, previously it was necessary that the URL you were importing was in a very specific format (e.g: `https://classic.warcraftlogs.com/reports/reportID#fight=fightID`). Now the player can drop pretty much any valid warcraftlogs.com report link into the importer, and it will import it, as long as `/reports/` and `fight=` exist within that path.

### URL validation

The URLs are validated at the start and will prevent you from importing if the checks fail. Pretty simple stuff, just checks to see if you have a reportID, fightID & have the words `warcraftlogs.com` in the name.

- [x] Reduce code required for WCL V2 Queries
Added some helper functions to make repeated queries need less duplicated code.

- [x] Reusability
- [x] Cleanup logic for WCL imports