### PR TITLE
Hunter arrow defaults, Hunter melee-weave default should be none

### DIFF
--- a/ui/hunter/presets.ts
+++ b/ui/hunter/presets.ts
@@ -1,15 +1,21 @@
-import * as Tooltips from "/tbc/core/constants/tooltips.js";
-import { Player } from "/tbc/core/player.js";
-import { Consumes, EquipmentSpec, Flask, Food, Potions, WeaponImbue } from "/tbc/core/proto/common.js";
+import { Consumes } from '/tbc/core/proto/common.js';
+import { EquipmentSpec } from '/tbc/core/proto/common.js';
+import { Flask } from '/tbc/core/proto/common.js';
+import { Food } from '/tbc/core/proto/common.js';
+import { Potions } from '/tbc/core/proto/common.js';
+import { WeaponImbue } from '/tbc/core/proto/common.js';
+import { Player } from '/tbc/core/player.js';
+
 import {
-	Hunter,
 	Hunter_Rotation as HunterRotation,
 	Hunter_Rotation_WeaveType as WeaveType,
 	Hunter_Options as HunterOptions,
 	Hunter_Options_Ammo as Ammo,
 	Hunter_Options_QuiverBonus as QuiverBonus,
 	Hunter_Options_PetType as PetType,
-} from "/tbc/core/proto/hunter.js";
+} from '/tbc/core/proto/hunter.js';
+
+import * as Tooltips from '/tbc/core/constants/tooltips.js';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to

--- a/ui/hunter/presets.ts
+++ b/ui/hunter/presets.ts
@@ -1,8 +1,15 @@
 import * as Tooltips from "/tbc/core/constants/tooltips.js";
 import { Player } from "/tbc/core/player.js";
 import { Consumes, EquipmentSpec, Flask, Food, Potions, WeaponImbue } from "/tbc/core/proto/common.js";
-
-import { Hunter_Options as HunterOptions, Hunter_Options_Ammo as Ammo, Hunter_Options_PetType as PetType, Hunter_Options_QuiverBonus as QuiverBonus, Hunter_Rotation as HunterRotation, Hunter_Rotation_WeaveType as WeaveType } from "/tbc/core/proto/hunter.js";
+import {
+	Hunter,
+	Hunter_Rotation as HunterRotation,
+	Hunter_Rotation_WeaveType as WeaveType,
+	Hunter_Options as HunterOptions,
+	Hunter_Options_Ammo as Ammo,
+	Hunter_Options_QuiverBonus as QuiverBonus,
+	Hunter_Options_PetType as PetType,
+} from "/tbc/core/proto/hunter.js";
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to

--- a/ui/hunter/presets.ts
+++ b/ui/hunter/presets.ts
@@ -1,27 +1,8 @@
-import { Consumes } from '/tbc/core/proto/common.js';
-import { Drums } from '/tbc/core/proto/common.js';
-import { EquipmentSpec } from '/tbc/core/proto/common.js';
-import { Flask } from '/tbc/core/proto/common.js';
-import { Food } from '/tbc/core/proto/common.js';
-import { ItemSpec } from '/tbc/core/proto/common.js';
-import { Potions } from '/tbc/core/proto/common.js';
-import { WeaponImbue } from '/tbc/core/proto/common.js';
-import { Faction } from '/tbc/core/proto_utils/utils.js';
-import { Player } from '/tbc/core/player.js';
+import * as Tooltips from "/tbc/core/constants/tooltips.js";
+import { Player } from "/tbc/core/player.js";
+import { Consumes, EquipmentSpec, Flask, Food, Potions, WeaponImbue } from "/tbc/core/proto/common.js";
 
-import {
-	Hunter,
-	Hunter_Rotation as HunterRotation,
-	Hunter_Rotation_WeaveType as WeaveType,
-	Hunter_Options as HunterOptions,
-	Hunter_Options_Ammo as Ammo,
-	Hunter_Options_QuiverBonus as QuiverBonus,
-	Hunter_Options_PetType as PetType,
-} from '/tbc/core/proto/hunter.js';
-
-import * as Enchants from '/tbc/core/constants/enchants.js';
-import * as Gems from '/tbc/core/proto_utils/gems.js';
-import * as Tooltips from '/tbc/core/constants/tooltips.js';
+import { Hunter_Options as HunterOptions, Hunter_Options_Ammo as Ammo, Hunter_Options_PetType as PetType, Hunter_Options_QuiverBonus as QuiverBonus, Hunter_Rotation as HunterRotation, Hunter_Rotation_WeaveType as WeaveType } from "/tbc/core/proto/hunter.js";
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
@@ -50,14 +31,14 @@ export const DefaultRotation = HunterRotation.create({
 	viperStartManaPercent: 0.1,
 	viperStopManaPercent: 0.3,
 
-	weave: WeaveType.WeaveFull,
+	weave: WeaveType.WeaveNone,
 	timeToWeaveMs: 500,
 	percentWeaved: 0.8,
 });
 
 export const DefaultOptions = HunterOptions.create({
 	quiverBonus: QuiverBonus.Speed15,
-	ammo: Ammo.AdamantiteStinger,
+	ammo: Ammo.TimelessArrow,
 	petType: PetType.Ravager,
 	petUptime: 1,
 	latencyMs: 30,


### PR DESCRIPTION
The hunter arrow preset should default to use TimelessArrow instead of AdamantiteStinger and the default weave type be none (since the vast majority of people do not melee-weave).